### PR TITLE
ENH: Translating Mesh3 C++ example into Python

### DIFF
--- a/src/Core/Mesh/AccessDataInCells/CMakeLists.txt
+++ b/src/Core/Mesh/AccessDataInCells/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.10.2)
+
+project(AccessDataInCells)
+
+find_package(ITK REQUIRED)
+include(${ITK_USE_FILE})
+
+add_executable(AccessDataInCells Code.cxx)
+target_link_libraries(AccessDataInCells ${ITK_LIBRARIES})
+
+install(TARGETS AccessDataInCells
+  DESTINATION bin/ITKSphinxExamples/Core/Mesh
+  COMPONENT Runtime
+  )
+
+install(FILES Code.cxx CMakeLists.txt Code.py
+  DESTINATION share/ITKSphinxExamples/Code/Core/Mesh/AccessDataInCells/
+  COMPONENT Code
+  )
+
+enable_testing()
+
+add_test(NAME AccessDataInCellsTest
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/AccessDataInCells)
+
+if(ITK_WRAP_PYTHON)
+  add_test(NAME AccessDataInCellsTestPython
+    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/Code.py)
+endif()

--- a/src/Core/Mesh/AccessDataInCells/Code.cxx
+++ b/src/Core/Mesh/AccessDataInCells/Code.cxx
@@ -1,0 +1,82 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkMesh.h"
+#include "itkLineCell.h"
+
+int main(int, char *[])
+{
+  typedef float                     PixelType;
+  typedef itk::Mesh< PixelType, 2 > MeshType;
+
+  typedef MeshType::CellType        CellType;
+  typedef itk::LineCell< CellType > LineType;
+
+  MeshType::Pointer  mesh = MeshType::New();
+
+  typedef MeshType::PointType PointType;
+  PointType point;
+
+  const unsigned int numberOfPoints = 10;
+  for(unsigned int id=0; id<numberOfPoints; id++)
+    {
+    point[0] = static_cast<PointType::ValueType>( id ); // x
+    point[1] = std::log( static_cast<double>( id ) + itk::Math::eps ); // y
+    mesh->SetPoint( id, point );
+    }
+
+  CellType::CellAutoPointer line;
+  const unsigned int numberOfCells = numberOfPoints-1;
+  for(unsigned int cellId=0; cellId<numberOfCells; cellId++)
+    {
+    line.TakeOwnership(  new LineType  );
+    line->SetPointId( 0, cellId   ); // first point
+    line->SetPointId( 1, cellId+1 ); // second point
+    mesh->SetCell( cellId, line );   // insert the cell
+    }
+
+  std::cout << "Points = " << mesh->GetNumberOfPoints() << std::endl;
+  std::cout << "Cells  = " << mesh->GetNumberOfCells()  << std::endl << std::endl;
+
+  // assign data to cells
+  for(unsigned int cellId=0; cellId<numberOfCells; cellId++)
+    {
+    mesh->SetCellData( cellId, static_cast<PixelType>( cellId * cellId ) );
+    }
+
+  // retrieve data from cells
+  for(unsigned int cellId=0; cellId<numberOfCells; ++cellId)
+    {
+    PixelType value = static_cast<PixelType>(0.0);
+    mesh->GetCellData( cellId, &value );
+    std::cout << "Cell " << cellId << " = " << value << std::endl;
+    }
+
+  // access via an iterator
+  typedef MeshType::CellDataContainer::ConstIterator CellDataIterator;
+  CellDataIterator cellDataIterator  = mesh->GetCellData()->Begin();
+  CellDataIterator end               = mesh->GetCellData()->End();
+  while( cellDataIterator != end )
+    {
+    PixelType cellValue = cellDataIterator.Value();
+    //std::cout << cellValue << std::endl; //same values as before
+    ++cellDataIterator;
+    }
+
+  return EXIT_SUCCESS;
+}

--- a/src/Core/Mesh/AccessDataInCells/Code.cxx
+++ b/src/Core/Mesh/AccessDataInCells/Code.cxx
@@ -19,64 +19,66 @@
 #include "itkMesh.h"
 #include "itkLineCell.h"
 
-int main(int, char *[])
+int
+main(int, char *[])
 {
-  typedef float                     PixelType;
-  typedef itk::Mesh< PixelType, 2 > MeshType;
+  using PixelType = float;
+  using MeshType = itk::Mesh<PixelType, 2>;
 
-  typedef MeshType::CellType        CellType;
-  typedef itk::LineCell< CellType > LineType;
+  using CellType = MeshType::CellType;
+  using LineType = itk::LineCell<CellType>;
 
-  MeshType::Pointer  mesh = MeshType::New();
+  auto mesh = MeshType::New();
 
-  typedef MeshType::PointType PointType;
+  using PointType = MeshType::PointType;
   PointType point;
 
   const unsigned int numberOfPoints = 10;
-  for(unsigned int id=0; id<numberOfPoints; id++)
-    {
-    point[0] = static_cast<PointType::ValueType>( id ); // x
-    point[1] = std::log( static_cast<double>( id ) + itk::Math::eps ); // y
-    mesh->SetPoint( id, point );
-    }
+  for (unsigned int id = 0; id < numberOfPoints; id++)
+  {
+    point[0] = static_cast<PointType::ValueType>(id);              // x
+    point[1] = std::log(static_cast<double>(id) + itk::Math::eps); // y
+    mesh->SetPoint(id, point);
+  }
 
   CellType::CellAutoPointer line;
-  const unsigned int numberOfCells = numberOfPoints-1;
-  for(unsigned int cellId=0; cellId<numberOfCells; cellId++)
-    {
-    line.TakeOwnership(  new LineType  );
-    line->SetPointId( 0, cellId   ); // first point
-    line->SetPointId( 1, cellId+1 ); // second point
-    mesh->SetCell( cellId, line );   // insert the cell
-    }
+  const unsigned int        numberOfCells = numberOfPoints - 1;
+  for (unsigned int cellId = 0; cellId < numberOfCells; cellId++)
+  {
+    line.TakeOwnership(new LineType);
+    line->SetPointId(0, cellId);     // first point
+    line->SetPointId(1, cellId + 1); // second point
+    mesh->SetCell(cellId, line);     // insert the cell
+  }
 
   std::cout << "Points = " << mesh->GetNumberOfPoints() << std::endl;
-  std::cout << "Cells  = " << mesh->GetNumberOfCells()  << std::endl << std::endl;
+  std::cout << "Cells  = " << mesh->GetNumberOfCells() << std::endl << std::endl;
 
   // assign data to cells
-  for(unsigned int cellId=0; cellId<numberOfCells; cellId++)
-    {
-    mesh->SetCellData( cellId, static_cast<PixelType>( cellId * cellId ) );
-    }
+  for (unsigned int cellId = 0; cellId < numberOfCells; cellId++)
+  {
+    mesh->SetCellData(cellId, static_cast<PixelType>(cellId * cellId));
+  }
 
   // retrieve data from cells
-  for(unsigned int cellId=0; cellId<numberOfCells; ++cellId)
-    {
+  for (unsigned int cellId = 0; cellId < numberOfCells; ++cellId)
+  {
     PixelType value = static_cast<PixelType>(0.0);
-    mesh->GetCellData( cellId, &value );
+    mesh->GetCellData(cellId, &value);
     std::cout << "Cell " << cellId << " = " << value << std::endl;
-    }
+  }
 
   // access via an iterator
-  typedef MeshType::CellDataContainer::ConstIterator CellDataIterator;
-  CellDataIterator cellDataIterator  = mesh->GetCellData()->Begin();
-  CellDataIterator end               = mesh->GetCellData()->End();
-  while( cellDataIterator != end )
-    {
+  using CellDataIterator = MeshType::CellDataContainer::ConstIterator;
+  CellDataIterator cellDataIterator = mesh->GetCellData()->Begin();
+  CellDataIterator end = mesh->GetCellData()->End();
+
+  while (cellDataIterator != end)
+  {
     PixelType cellValue = cellDataIterator.Value();
-    //std::cout << cellValue << std::endl; //same values as before
+    // std::cout << cellValue << std::endl; //same values as before
     ++cellDataIterator;
-    }
+  }
 
   return EXIT_SUCCESS;
 }

--- a/src/Core/Mesh/AccessDataInCells/Code.py
+++ b/src/Core/Mesh/AccessDataInCells/Code.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+
+# ==========================================================================
+#
+#   Copyright Insight Software Consortium
+#
+#   Licensed under the Apache License, Version 2.0 (the "License")
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#          http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ==========================================================================*/
+
+import sys
+import itk
+import numpy as np
+
+Dimension = 2
+PixelType = itk.F  # float or double
+
+MeshType = itk.Mesh[PixelType, Dimension]
+PointType = itk.Point[itk.D, Dimension]
+# CellTraits = itk.itkCellTraitsInfo._2FFULLULLULLPF2MCULLPF2
+# CellType = itk.CellInterface[PixelType, CellTraits]()
+# LineType = itk.LineCell()
+
+
+mesh = MeshType.New()
+
+point = PointType()
+
+number_of_points = 10
+for point_id in range(number_of_points):
+    point[0] = float(point_id)
+    point[1] = np.log(float(point_id) + np.finfo(float).eps)
+    mesh.SetPoint(point_id, point)
+
+number_of_cells = number_of_points - 1
+# for cell_id in range(number_of_cells):
+#
+# CellType::CellAutoPointer line;
+# const unsigned int numberOfCells = numberOfPoints-1;
+# for(unsigned int cellId=0; cellId<numberOfCells; cellId++)
+#   {
+#   line.TakeOwnership(  new LineType  );
+#   line->SetPointId( 0, cellId   ); // first point
+#   line->SetPointId( 1, cellId+1 ); // second point
+#   mesh->SetCell( cellId, line );   // insert the cell
+#   }
+#
+# std::cout << "Points = " << mesh->GetNumberOfPoints() << std::endl;
+# std::cout << "Cells  = " << mesh->GetNumberOfCells()  << std::endl << std::endl;
+#
+# # assign data to cells
+# for(unsigned int cellId=0; cellId<numberOfCells; cellId++)
+#   {
+#   mesh->SetCellData( cellId, static_cast<PixelType>( cellId * cellId ) );
+#   }
+#
+# # retrieve data from cells
+# for(unsigned int cellId=0; cellId<numberOfCells; ++cellId)
+#   {
+#   PixelType value = static_cast<PixelType>(0.0);
+#   mesh->GetCellData( cellId, &value );
+#   std::cout << "Cell " << cellId << " = " << value << std::endl;
+#   }

--- a/src/Core/Mesh/AccessDataInCells/Documentation.rst
+++ b/src/Core/Mesh/AccessDataInCells/Documentation.rst
@@ -1,0 +1,58 @@
+Access data in cells
+====================
+
+.. index::
+   single: Mesh
+
+Synopsis
+--------
+
+Just as custom data can be associated with points in the mesh,
+it is also possible to associate custom data with cells. The type of the
+data associated with the cells can be different from the data type
+associated with points. By default, however, these two types are the same.
+The following example illustrates how to access data associated with cells.
+The approach is analogous to the one used to access point data.
+
+
+Results
+-------
+
+::
+
+  Points = 10
+  Cells  = 9
+
+  Cell 0 = 0
+  Cell 1 = 1
+  Cell 2 = 4
+  Cell 3 = 9
+  Cell 4 = 16
+  Cell 5 = 25
+  Cell 6 = 36
+  Cell 7 = 49
+  Cell 8 = 64
+
+
+Code
+----
+
+C++
+...
+
+.. literalinclude:: Code.cxx
+   :language: c++
+   :lines: 18-
+
+Python
+......
+
+.. literalinclude:: Code.py
+   :language: python
+   :lines: 1, 20-
+
+
+Classes demonstrated
+--------------------
+
+.. breathelink:: itk::Mesh

--- a/src/Core/Mesh/CMakeLists.txt
+++ b/src/Core/Mesh/CMakeLists.txt
@@ -9,6 +9,8 @@ add_example( ExtractIsoSurface )
 add_example( TranslateOneMesh )
 #compare_to_baseline( TranslateOneMesh Output )
 
+add_example(AccessDataInCells)
+
 add_example(AddPointsAndEdges)
 add_example(CalculateAreaAndVolumeOfSimplexMesh)
 

--- a/src/Core/Mesh/index.rst
+++ b/src/Core/Mesh/index.rst
@@ -4,6 +4,7 @@ Mesh
 .. toctree::
   :maxdepth: 1
 
+  AccessDataInCells/Documentation.rst
   AddPointsAndEdges/Documentation.rst
   CalculateAreaAndVolumeOfSimplexMesh/Documentation.rst
   ConvertMeshToUnstructeredGrid/Documentation.rst


### PR DESCRIPTION
blocker: identifiers beginning with a digit are not supported
```
  File "./Code.py", line 29
    CellTraits = itk.itkCellTraitsInfo.2FFULLULLULLPF2MCULLPF2
                                       ^
SyntaxError: invalid syntax
```