### PR TITLE
COMP: Remove "vtk" prefix from VTK COMPONENTS

### DIFF
--- a/src/Bridge/VtkGlue/VTKImageToITKImage/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/VTKImageToITKImage/CMakeLists.txt
@@ -5,12 +5,17 @@ project(VTKImageToITKImage)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
+find_package(VTK REQUIRED)
+set(_vtk_prefix "")
+if(VTK_VERSION VERSION_LESS "8.90.0")
+  set(_vtk_prefix "vtk")
+endif()
 find_package(VTK REQUIRED
   COMPONENTS
-    vtkImagingColor
-    vtkIOImage
-    vtkRenderingCore
-    vtkRenderingGL2PSOpenGL2
+    ${_vtk_prefix}ImagingColor
+    ${_vtk_prefix}IOImage
+    ${_vtk_prefix}RenderingCore
+    ${_vtk_prefix}RenderingGL2PSOpenGL2
   )
 if(VTK_VERSION VERSION_LESS "8.90.0")
   include(${VTK_USE_FILE})

--- a/src/Bridge/VtkGlue/VisualizeStaticDense2DLevelSetAsElevationMap/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/VisualizeStaticDense2DLevelSetAsElevationMap/CMakeLists.txt
@@ -5,11 +5,16 @@ project( VisualizeStaticDense2DLevelSetAsElevationMap )
 find_package( ITK REQUIRED )
 include( ${ITK_USE_FILE} )
 
+find_package(VTK REQUIRED)
+set(_vtk_prefix "")
+if(VTK_VERSION VERSION_LESS "8.90.0")
+  set(_vtk_prefix "vtk")
+endif()
 find_package( VTK REQUIRED
   COMPONENTS
-    vtkInteractionImage
-    vtkRenderingCore
-    vtkRenderingGL2PSOpenGL2
+    ${_vtk_prefix}InteractionImage
+    ${_vtk_prefix}RenderingCore
+    ${_vtk_prefix}RenderingGL2PSOpenGL2
   )
 if( VTK_VERSION VERSION_LESS "8.90.0" )
   include( ${VTK_USE_FILE} )

--- a/src/Bridge/VtkGlue/VisualizeStaticDense2DLevelSetZeroSet/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/VisualizeStaticDense2DLevelSetZeroSet/CMakeLists.txt
@@ -5,10 +5,15 @@ project( VisualizeStaticDense2DLevelSetZeroSet )
 find_package( ITK REQUIRED )
 include( ${ITK_USE_FILE} )
 
+find_package(VTK REQUIRED)
+set(_vtk_prefix "")
+if(VTK_VERSION VERSION_LESS "8.90.0")
+  set(_vtk_prefix "vtk")
+endif()
 find_package( VTK REQUIRED
   COMPONENTS
-    vtkRenderingCore
-    vtkRenderingGL2PSOpenGL2
+    ${_vtk_prefix}RenderingCore
+    ${_vtk_prefix}RenderingGL2PSOpenGL2
   )
 if( VTK_VERSION VERSION_LESS "8.90.0" )
   include( ${VTK_USE_FILE} )

--- a/src/Bridge/VtkGlue/VisualizeStaticMalcolm2DLevelSetLayers/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/VisualizeStaticMalcolm2DLevelSetLayers/CMakeLists.txt
@@ -5,10 +5,15 @@ project( VisualizeStaticMalcolm2DLevelSetLayers )
 find_package( ITK REQUIRED )
 include( ${ITK_USE_FILE} )
 
+find_package(VTK REQUIRED)
+set(_vtk_prefix "")
+if(VTK_VERSION VERSION_LESS "8.90.0")
+  set(_vtk_prefix "vtk")
+endif()
 find_package( VTK REQUIRED
   COMPONENTS
-    vtkRenderingCore
-    vtkRenderingGL2PSOpenGL2
+    ${_vtk_prefix}RenderingCore
+    ${_vtk_prefix}RenderingGL2PSOpenGL2
   )
 if( VTK_VERSION VERSION_LESS "8.90.0" )
   include( ${VTK_USE_FILE} )

--- a/src/Bridge/VtkGlue/VisualizeStaticShi2DLevelSetLayers/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/VisualizeStaticShi2DLevelSetLayers/CMakeLists.txt
@@ -5,10 +5,15 @@ project( VisualizeStaticShi2DLevelSetLayers )
 find_package( ITK REQUIRED )
 include( ${ITK_USE_FILE} )
 
+find_package(VTK REQUIRED)
+set(_vtk_prefix "")
+if(VTK_VERSION VERSION_LESS "8.90.0")
+  set(_vtk_prefix "vtk")
+endif()
 find_package( VTK REQUIRED
   COMPONENTS
-    vtkRenderingCore
-    vtkRenderingGL2PSOpenGL2
+    ${_vtk_prefix}RenderingCore
+    ${_vtk_prefix}RenderingGL2PSOpenGL2
   )
 if( VTK_VERSION VERSION_LESS "8.90.0" )
   include( ${VTK_USE_FILE} )

--- a/src/Bridge/VtkGlue/VisualizeStaticWhitaker2DLevelSetLayers/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/VisualizeStaticWhitaker2DLevelSetLayers/CMakeLists.txt
@@ -5,10 +5,15 @@ project( VisualizeStaticWhitaker2DLevelSetLayers )
 find_package( ITK REQUIRED )
 include( ${ITK_USE_FILE} )
 
+find_package(VTK REQUIRED)
+set(_vtk_prefix "")
+if(VTK_VERSION VERSION_LESS "8.90.0")
+  set(_vtk_prefix "vtk")
+endif()
 find_package( VTK REQUIRED
   COMPONENTS
-    vtkRenderingCore
-    vtkRenderingGL2PSOpenGL2
+    ${_vtk_prefix}RenderingCore
+    ${_vtk_prefix}RenderingGL2PSOpenGL2
   )
 if( VTK_VERSION VERSION_LESS "8.90.0" )
   include( ${VTK_USE_FILE} )

--- a/src/Core/Common/DisplayImage/CMakeLists.txt
+++ b/src/Core/Common/DisplayImage/CMakeLists.txt
@@ -8,8 +8,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package( VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
   if(VTK_VERSION VERSION_LESS "8.90.0")
     include(${VTK_USE_FILE})

--- a/src/Core/Common/FindMaxAndMinInImage/CMakeLists.txt
+++ b/src/Core/Common/FindMaxAndMinInImage/CMakeLists.txt
@@ -5,11 +5,16 @@ project(FindMaxAndMinInImage)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
+find_package(VTK REQUIRED)
+set(_vtk_prefix "")
+if(VTK_VERSION VERSION_LESS "8.90.0")
+  set(_vtk_prefix "vtk")
+endif()
 find_package(VTK REQUIRED
   COMPONENTS
-    vtkInteractionImage
-    vtkRenderingCore
-    vtkRenderingGL2PSOpenGL2
+    ${_vtk_prefix}InteractionImage
+    ${_vtk_prefix}RenderingCore
+    ${_vtk_prefix}RenderingGL2PSOpenGL2
   )
 if(VTK_VERSION VERSION_LESS "8.90.0")
   include(${VTK_USE_FILE})

--- a/src/Core/Common/InPlaceFilterOfImage/CMakeLists.txt
+++ b/src/Core/Common/InPlaceFilterOfImage/CMakeLists.txt
@@ -5,11 +5,16 @@ project(InPlaceFilterOfImage)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
+find_package(VTK REQUIRED)
+set(_vtk_prefix "")
+if(VTK_VERSION VERSION_LESS "8.90.0")
+  set(_vtk_prefix "vtk")
+endif()
 find_package(VTK REQUIRED
   COMPONENTS
-    vtkInteractionImage
-    vtkRenderingCore
-    vtkRenderingGL2PSOpenGL2
+    ${_vtk_prefix}InteractionImage
+    ${_vtk_prefix}RenderingCore
+    ${_vtk_prefix}RenderingGL2PSOpenGL2
   )
 if(VTK_VERSION VERSION_LESS "8.90.0")
   include(${VTK_USE_FILE})

--- a/src/Core/Common/IterateLineThroughImage/CMakeLists.txt
+++ b/src/Core/Common/IterateLineThroughImage/CMakeLists.txt
@@ -8,8 +8,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package( VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
   if(VTK_VERSION VERSION_LESS "8.90.0")
     include(${VTK_USE_FILE})

--- a/src/Core/Common/IterateRegionWithAccessToIndexWithWriteAccess/CMakeLists.txt
+++ b/src/Core/Common/IterateRegionWithAccessToIndexWithWriteAccess/CMakeLists.txt
@@ -8,8 +8,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
 
   if(VTK_VERSION VERSION_LESS "8.90.0")

--- a/src/Core/Common/IterateRegionWithAccessToIndexWithoutWriteAccess/CMakeLists.txt
+++ b/src/Core/Common/IterateRegionWithAccessToIndexWithoutWriteAccess/CMakeLists.txt
@@ -8,8 +8,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
   if(VTK_VERSION VERSION_LESS "8.90.0")
     include(${VTK_USE_FILE})

--- a/src/Core/Common/IterateRegionWithNeighborhood/CMakeLists.txt
+++ b/src/Core/Common/IterateRegionWithNeighborhood/CMakeLists.txt
@@ -5,11 +5,16 @@ project(IterateRegionWithNeighborhood)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
+find_package(VTK REQUIRED)
+set(_vtk_prefix "")
+if(VTK_VERSION VERSION_LESS "8.90.0")
+  set(_vtk_prefix "vtk")
+endif()
 find_package(VTK REQUIRED
   COMPONENTS
-    vtkInteractionImage
-    vtkRenderingCore
-    vtkRenderingGL2PSOpenGL2
+    ${_vtk_prefix}InteractionImage
+    ${_vtk_prefix}RenderingCore
+    ${_vtk_prefix}RenderingGL2PSOpenGL2
   )
 if(VTK_VERSION VERSION_LESS "8.90.0")
   include(${VTK_USE_FILE})

--- a/src/Core/Common/IterateRegionWithWriteAccess/CMakeLists.txt
+++ b/src/Core/Common/IterateRegionWithWriteAccess/CMakeLists.txt
@@ -5,11 +5,16 @@ project(IterateRegionWithWriteAccess)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
+find_package(VTK REQUIRED)
+set(_vtk_prefix "")
+if(VTK_VERSION VERSION_LESS "8.90.0")
+  set(_vtk_prefix "vtk")
+endif()
 find_package(VTK REQUIRED
   COMPONENTS
-    vtkInteractionImage
-    vtkRenderingCore
-    vtkRenderingGL2PSOpenGL2
+    ${_vtk_prefix}InteractionImage
+    ${_vtk_prefix}RenderingCore
+    ${_vtk_prefix}RenderingGL2PSOpenGL2
   )
 
 if(VTK_VERSION VERSION_LESS "8.90.0")

--- a/src/Core/Common/MakeOutOfBoundsPixelsReturnConstValue/CMakeLists.txt
+++ b/src/Core/Common/MakeOutOfBoundsPixelsReturnConstValue/CMakeLists.txt
@@ -5,12 +5,17 @@ project(MakeOutOfBoundsPixelsReturnConstValue)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
+find_package(VTK REQUIRED)
+set(_vtk_prefix "")
+if(VTK_VERSION VERSION_LESS "8.90.0")
+  set(_vtk_prefix "vtk")
+endif()
 find_package(VTK REQUIRED
   COMPONENTS
-    vtkInteractionImage
-    vtkInteractionStyle
-    vtkRenderingCore
-    vtkRenderingGL2PSOpenGL2
+    ${_vtk_prefix}InteractionImage
+    ${_vtk_prefix}InteractionStyle
+    ${_vtk_prefix}RenderingCore
+    ${_vtk_prefix}RenderingGL2PSOpenGL2
   )
 
 if(VTK_VERSION VERSION_LESS "8.90.0")

--- a/src/Core/Common/MultiThreadOilPainting/CMakeLists.txt
+++ b/src/Core/Common/MultiThreadOilPainting/CMakeLists.txt
@@ -8,8 +8,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
   if(VTK_VERSION VERSION_LESS "8.90.0")
     include(${VTK_USE_FILE})

--- a/src/Core/Mesh/ConvertMeshToUnstructeredGrid/CMakeLists.txt
+++ b/src/Core/Mesh/ConvertMeshToUnstructeredGrid/CMakeLists.txt
@@ -5,11 +5,16 @@ project(ConvertMeshToUnstructeredGrid)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
+find_package(VTK REQUIRED)
+set(_vtk_prefix "")
+if(VTK_VERSION VERSION_LESS "8.90.0")
+  set(_vtk_prefix "vtk")
+endif()
 find_package(VTK REQUIRED
   COMPONENTS
-    vtkIOXML
-    vtkCommonDataModel
-    vtkInteractionImage
+    ${_vtk_prefix}IOXML
+    ${_vtk_prefix}CommonDataModel
+    ${_vtk_prefix}InteractionImage
   )
 if(VTK_VERSION VERSION_LESS "8.90.0")
   include(${VTK_USE_FILE})

--- a/src/Core/SpatialObjects/ContourSpatialObject/CMakeLists.txt
+++ b/src/Core/SpatialObjects/ContourSpatialObject/CMakeLists.txt
@@ -8,8 +8,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
   if(VTK_VERSION VERSION_LESS "8.90.0")
     include(${VTK_USE_FILE})

--- a/src/Core/Transform/GlobalRegistrationTwoImagesBSpline/CMakeLists.txt
+++ b/src/Core/Transform/GlobalRegistrationTwoImagesBSpline/CMakeLists.txt
@@ -8,8 +8,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
   if(VTK_VERSION VERSION_LESS "8.90.0")
     include(${VTK_USE_FILE})

--- a/src/Filtering/AnisotropicSmoothing/SmoothImageWhilePreservingEdges/CMakeLists.txt
+++ b/src/Filtering/AnisotropicSmoothing/SmoothImageWhilePreservingEdges/CMakeLists.txt
@@ -8,8 +8,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
   if(VTK_VERSION VERSION_LESS "8.90.0")
     include(${VTK_USE_FILE})

--- a/src/Filtering/AnisotropicSmoothing/SmoothImageWhilePreservingEdges2/CMakeLists.txt
+++ b/src/Filtering/AnisotropicSmoothing/SmoothImageWhilePreservingEdges2/CMakeLists.txt
@@ -8,8 +8,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
   if(VTK_VERSION VERSION_LESS "8.90.0")
     include(${VTK_USE_FILE})

--- a/src/Filtering/BinaryMathematicalMorphology/ClosingBinaryImage/CMakeLists.txt
+++ b/src/Filtering/BinaryMathematicalMorphology/ClosingBinaryImage/CMakeLists.txt
@@ -8,8 +8,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
   if(VTK_VERSION VERSION_LESS "8.90.0")
     include(${VTK_USE_FILE})

--- a/src/Filtering/BinaryMathematicalMorphology/OpeningBinaryImage/CMakeLists.txt
+++ b/src/Filtering/BinaryMathematicalMorphology/OpeningBinaryImage/CMakeLists.txt
@@ -9,8 +9,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
   if(VTK_VERSION VERSION_LESS "8.90.0")
     include(${VTK_USE_FILE})

--- a/src/Filtering/BinaryMathematicalMorphology/PruneBinaryImage/CMakeLists.txt
+++ b/src/Filtering/BinaryMathematicalMorphology/PruneBinaryImage/CMakeLists.txt
@@ -8,8 +8,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
   if(VTK_VERSION VERSION_LESS "8.90.0")
     include(${VTK_USE_FILE})

--- a/src/Filtering/Convolution/ConvolveImageWithKernel/CMakeLists.txt
+++ b/src/Filtering/Convolution/ConvolveImageWithKernel/CMakeLists.txt
@@ -8,8 +8,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
 
   if(VTK_VERSION VERSION_LESS "8.90.0")

--- a/src/Filtering/CurvatureFlow/BinaryMinMaxCurvatureFlow/CMakeLists.txt
+++ b/src/Filtering/CurvatureFlow/BinaryMinMaxCurvatureFlow/CMakeLists.txt
@@ -8,8 +8,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
   if(VTK_VERSION VERSION_LESS "8.90.0")
     include(${VTK_USE_FILE})

--- a/src/Filtering/CurvatureFlow/SmoothImageUsingCurvatureFlow/CMakeLists.txt
+++ b/src/Filtering/CurvatureFlow/SmoothImageUsingCurvatureFlow/CMakeLists.txt
@@ -8,8 +8,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
   if(VTK_VERSION VERSION_LESS "8.90.0")
     include(${VTK_USE_FILE})

--- a/src/Filtering/CurvatureFlow/SmoothImageUsingMinMaxCurvatureFlow/CMakeLists.txt
+++ b/src/Filtering/CurvatureFlow/SmoothImageUsingMinMaxCurvatureFlow/CMakeLists.txt
@@ -8,8 +8,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
   if(VTK_VERSION VERSION_LESS "8.90.0")
     include(${VTK_USE_FILE})

--- a/src/Filtering/CurvatureFlow/SmoothRGBImageUsingCurvatureFlow/CMakeLists.txt
+++ b/src/Filtering/CurvatureFlow/SmoothRGBImageUsingCurvatureFlow/CMakeLists.txt
@@ -8,8 +8,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
   if(VTK_VERSION VERSION_LESS "8.90.0")
     include(${VTK_USE_FILE})

--- a/src/Filtering/CurvatureFlow/SmoothRGBImageUsingMinMaxCurvatureFlow/CMakeLists.txt
+++ b/src/Filtering/CurvatureFlow/SmoothRGBImageUsingMinMaxCurvatureFlow/CMakeLists.txt
@@ -8,8 +8,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
   if(VTK_VERSION VERSION_LESS "8.90.0")
     include(${VTK_USE_FILE})

--- a/src/Filtering/DistanceMap/ApproxDistanceMapOfBinary/CMakeLists.txt
+++ b/src/Filtering/DistanceMap/ApproxDistanceMapOfBinary/CMakeLists.txt
@@ -8,8 +8,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
   if(VTK_VERSION VERSION_LESS "8.90.0")
     include(${VTK_USE_FILE})

--- a/src/Filtering/DistanceMap/MaurerDistanceMapOfBinary/CMakeLists.txt
+++ b/src/Filtering/DistanceMap/MaurerDistanceMapOfBinary/CMakeLists.txt
@@ -9,8 +9,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
 
   if(VTK_VERSION VERSION_LESS "8.90.0")

--- a/src/Filtering/DistanceMap/MeanDistanceBetweenAllPointsOnTwoCurves/CMakeLists.txt
+++ b/src/Filtering/DistanceMap/MeanDistanceBetweenAllPointsOnTwoCurves/CMakeLists.txt
@@ -8,8 +8,8 @@ include(${ITK_USE_FILE})
 
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED COMPONENTS
-    vtkRenderingCore
-    vtkRenderingGL2PSOpenGL2
+    ${_vtk_prefix}RenderingCore
+    ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
 
   if(VTK_VERSION VERSION_LESS "8.90.0")

--- a/src/Filtering/DistanceMap/SignedDistanceMapOfBinary/CMakeLists.txt
+++ b/src/Filtering/DistanceMap/SignedDistanceMapOfBinary/CMakeLists.txt
@@ -9,8 +9,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
 
   if(VTK_VERSION VERSION_LESS "8.90.0")

--- a/src/Filtering/ImageFeature/ApplyAFilterToASpecifiedRegionOfAnImage/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/ApplyAFilterToASpecifiedRegionOfAnImage/CMakeLists.txt
@@ -9,8 +9,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
 
   if(VTK_VERSION VERSION_LESS "8.90.0")

--- a/src/Filtering/ImageFeature/BilateralFilterAnImage/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/BilateralFilterAnImage/CMakeLists.txt
@@ -9,8 +9,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
 
   if(VTK_VERSION VERSION_LESS "8.90.0")

--- a/src/Filtering/ImageFeature/FindZeroCrossingsInSignedImage/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/FindZeroCrossingsInSignedImage/CMakeLists.txt
@@ -9,8 +9,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package( VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
 
   if(VTK_VERSION VERSION_LESS "8.90.0")

--- a/src/Filtering/ImageFeature/ZeroCrossingBasedEdgeDecor/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/ZeroCrossingBasedEdgeDecor/CMakeLists.txt
@@ -9,8 +9,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
 
   if(VTK_VERSION VERSION_LESS "8.90.0")

--- a/src/Filtering/ImageGrid/CropImageBySpecifyingRegion2/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/CropImageBySpecifyingRegion2/CMakeLists.txt
@@ -9,8 +9,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
 
   if(VTK_VERSION VERSION_LESS "8.90.0")

--- a/src/Filtering/ImageGrid/RunImageFilterOnRegionOfImage/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/RunImageFilterOnRegionOfImage/CMakeLists.txt
@@ -8,8 +8,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package( VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
 
   if(VTK_VERSION VERSION_LESS "8.90.0")

--- a/src/Filtering/ImageIntensity/AbsValueOfImage/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/AbsValueOfImage/CMakeLists.txt
@@ -9,8 +9,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
 
   if(VTK_VERSION VERSION_LESS "8.90.0")

--- a/src/Filtering/ImageIntensity/AddTwoImages/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/AddTwoImages/CMakeLists.txt
@@ -5,11 +5,16 @@ project(AddTwoImages)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
+find_package(VTK REQUIRED)
+set(_vtk_prefix "")
+if(VTK_VERSION VERSION_LESS "8.90.0")
+  set(_vtk_prefix "vtk")
+endif()
 find_package(VTK REQUIRED
   COMPONENTS
-    vtkInteractionImage
-    vtkRenderingCore
-    vtkRenderingGL2PSOpenGL2
+    ${_vtk_prefix}InteractionImage
+    ${_vtk_prefix}RenderingCore
+    ${_vtk_prefix}RenderingGL2PSOpenGL2
   )
 
 if(VTK_VERSION VERSION_LESS "8.90.0")

--- a/src/Filtering/ImageIntensity/InvertImage/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/InvertImage/CMakeLists.txt
@@ -9,8 +9,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
 
   if(VTK_VERSION VERSION_LESS "8.90.0")

--- a/src/Filtering/ImageIntensity/MaskImage/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/MaskImage/CMakeLists.txt
@@ -9,8 +9,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
 
   if(VTK_VERSION VERSION_LESS "8.90.0")

--- a/src/Filtering/ImageIntensity/NormalizeImage/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/NormalizeImage/CMakeLists.txt
@@ -9,8 +9,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
 
   if(VTK_VERSION VERSION_LESS "8.90.0")

--- a/src/Filtering/ImageIntensity/SubtractTwoImages/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/SubtractTwoImages/CMakeLists.txt
@@ -5,11 +5,16 @@ project(SubtractTwoImages)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
+find_package(VTK REQUIRED)
+set(_vtk_prefix "")
+if(VTK_VERSION VERSION_LESS "8.90.0")
+  set(_vtk_prefix "vtk")
+endif()
 find_package(VTK REQUIRED
   COMPONENTS
-    vtkInteractionImage
-    vtkRenderingCore
-    vtkRenderingGL2PSOpenGL2
+    ${_vtk_prefix}InteractionImage
+    ${_vtk_prefix}RenderingCore
+    ${_vtk_prefix}RenderingGL2PSOpenGL2
   )
 if(VTK_VERSION VERSION_LESS "8.90.0")
   include(${VTK_USE_FILE})

--- a/src/Filtering/ImageLabel/ExtractBoundariesOfConnectedRegionsInBinaryImage/CMakeLists.txt
+++ b/src/Filtering/ImageLabel/ExtractBoundariesOfConnectedRegionsInBinaryImage/CMakeLists.txt
@@ -9,8 +9,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
 
   if(VTK_VERSION VERSION_LESS "8.90.0")

--- a/src/Filtering/ImageLabel/ExtractInnerAndOuterBoundariesOfBlobsInBinaryImage/CMakeLists.txt
+++ b/src/Filtering/ImageLabel/ExtractInnerAndOuterBoundariesOfBlobsInBinaryImage/CMakeLists.txt
@@ -9,8 +9,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
 
   if(VTK_VERSION VERSION_LESS "8.90.0")

--- a/src/Filtering/ImageLabel/LabelContoursOfConnectComponent/CMakeLists.txt
+++ b/src/Filtering/ImageLabel/LabelContoursOfConnectComponent/CMakeLists.txt
@@ -9,8 +9,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
 
   if(VTK_VERSION VERSION_LESS "8.90.0")

--- a/src/Filtering/MathematicalMorphology/ErodeBinaryImageUsingFlatStruct/CMakeLists.txt
+++ b/src/Filtering/MathematicalMorphology/ErodeBinaryImageUsingFlatStruct/CMakeLists.txt
@@ -9,8 +9,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
 
   if(VTK_VERSION VERSION_LESS "8.90.0")

--- a/src/Filtering/Smoothing/FindHigherDerivativesOfImage/CMakeLists.txt
+++ b/src/Filtering/Smoothing/FindHigherDerivativesOfImage/CMakeLists.txt
@@ -9,8 +9,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
 
   if(VTK_VERSION VERSION_LESS "8.90.0")

--- a/src/Filtering/Smoothing/SmoothImageWithDiscreteGaussianFilter/CMakeLists.txt
+++ b/src/Filtering/Smoothing/SmoothImageWithDiscreteGaussianFilter/CMakeLists.txt
@@ -9,8 +9,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
 
   if(VTK_VERSION VERSION_LESS "8.90.0")

--- a/src/Filtering/Thresholding/DemonstrateThresholdAlgorithms/CMakeLists.txt
+++ b/src/Filtering/Thresholding/DemonstrateThresholdAlgorithms/CMakeLists.txt
@@ -9,8 +9,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package( VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
 
   if(VTK_VERSION VERSION_LESS "8.90.0")

--- a/src/Filtering/Thresholding/SeparateGroundUsingOtsu/CMakeLists.txt
+++ b/src/Filtering/Thresholding/SeparateGroundUsingOtsu/CMakeLists.txt
@@ -9,8 +9,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
 
   if(VTK_VERSION VERSION_LESS "8.90.0")

--- a/src/Nonunit/Review/GeometricPropertiesOfRegion/CMakeLists.txt
+++ b/src/Nonunit/Review/GeometricPropertiesOfRegion/CMakeLists.txt
@@ -9,8 +9,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
 
   if(VTK_VERSION VERSION_LESS "8.90.0")

--- a/src/Registration/Common/WatchRegistration/CMakeLists.txt
+++ b/src/Registration/Common/WatchRegistration/CMakeLists.txt
@@ -5,10 +5,15 @@ project(WatchRegistration)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
+find_package(VTK REQUIRED)
+set(_vtk_prefix "")
+if(VTK_VERSION VERSION_LESS "8.90.0")
+  set(_vtk_prefix "vtk")
+endif()
 find_package(VTK REQUIRED
   COMPONENTS
-    vtkRenderingCore
-    vtkRenderingGL2PSOpenGL2
+    ${_vtk_prefix}RenderingCore
+    ${_vtk_prefix}RenderingGL2PSOpenGL2
   )
 if(VTK_VERSION VERSION_LESS "8.90.0")
   include(${VTK_USE_FILE})

--- a/src/Segmentation/Classifiers/ClusterPixelsInGrayscaleImage/CMakeLists.txt
+++ b/src/Segmentation/Classifiers/ClusterPixelsInGrayscaleImage/CMakeLists.txt
@@ -5,11 +5,16 @@ project(ClusterPixelsInGrayscaleImage)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
+find_package(VTK REQUIRED)
+set(_vtk_prefix "")
+if(VTK_VERSION VERSION_LESS "8.90.0")
+  set(_vtk_prefix "vtk")
+endif()
 find_package(VTK REQUIRED
   COMPONENTS
-    vtkInteractionImage
-    vtkRenderingCore
-    vtkRenderingGL2PSOpenGL2
+    ${_vtk_prefix}InteractionImage
+    ${_vtk_prefix}RenderingCore
+    ${_vtk_prefix}RenderingGL2PSOpenGL2
   )
 if(VTK_VERSION VERSION_LESS "8.90.0")
   include(${VTK_USE_FILE})

--- a/src/Segmentation/ConnectedComponents/AssignContiguousLabelsToConnectedRegions/CMakeLists.txt
+++ b/src/Segmentation/ConnectedComponents/AssignContiguousLabelsToConnectedRegions/CMakeLists.txt
@@ -9,8 +9,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
 
   if(VTK_VERSION VERSION_LESS "8.90.0")

--- a/src/Segmentation/ConnectedComponents/ExtraLargestConnectComponentFromBinaryImage/CMakeLists.txt
+++ b/src/Segmentation/ConnectedComponents/ExtraLargestConnectComponentFromBinaryImage/CMakeLists.txt
@@ -9,8 +9,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
 
   if(VTK_VERSION VERSION_LESS "8.90.0")

--- a/src/Segmentation/ConnectedComponents/LabelConnectComponentsInGrayscaleImage/CMakeLists.txt
+++ b/src/Segmentation/ConnectedComponents/LabelConnectComponentsInGrayscaleImage/CMakeLists.txt
@@ -9,8 +9,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
 
   if(VTK_VERSION VERSION_LESS "8.90.0")

--- a/src/Segmentation/RegionGrowing/SegmentPixelsWithSimilarStats/CMakeLists.txt
+++ b/src/Segmentation/RegionGrowing/SegmentPixelsWithSimilarStats/CMakeLists.txt
@@ -8,8 +8,8 @@ include(${ITK_USE_FILE})
 if(ENABLE_QUICKVIEW)
   find_package(VTK REQUIRED
     COMPONENTS
-      vtkRenderingCore
-      vtkRenderingGL2PSOpenGL2
+      ${_vtk_prefix}RenderingCore
+      ${_vtk_prefix}RenderingGL2PSOpenGL2
     )
 
   if(VTK_VERSION VERSION_LESS "8.90.0")


### PR DESCRIPTION
In modern VTK (> 8.90) the COMPONENT names don't have the "vtk" prefix.

This fix get the VTK version first, and then look for the `COMPONENTS`
with the right name, prepending ${_vtk_prefix} to the names.

Fix #241