### PR TITLE
COMP: Bump min required version for CMake to > 2.8 to avoid warning

### DIFF
--- a/Utilities/SphinxExtensions/RunGitStats.cmake.in
+++ b/Utilities/SphinxExtensions/RunGitStats.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.18.2)
 
 set(Python_ADDITIONAL_VERSIONS 2)
 find_package(PythonInterp QUIET)


### PR DESCRIPTION
Update RunGitStats to require CMake 3.13.2 or greater - the same as
other ITK modules.