### PR TITLE
DOC: Rename build-test-superbuild to build-test-python

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -125,7 +125,7 @@ jobs:
           ctest -j 2 -VV -S dashboard.cmake
         shell: cmd
 
-  build-test-superbuild:
+  build-test-python-superbuild:
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 3


### PR DESCRIPTION
Contrast and identify these builds with build-test-cxx and
build-test-notebooks: these builds use the superbuild, but in the
process they test the Python examples in addition to the C++ examples.
