### PR TITLE
DOC: Put remaining example headers into proper format

### DIFF
--- a/src/Core/Common/ApplyAFilterOnlyToASpecifiedRegionOfAnImage/Documentation.rst
+++ b/src/Core/Common/ApplyAFilterOnlyToASpecifiedRegionOfAnImage/Documentation.rst
@@ -1,4 +1,4 @@
-Apply A Filter Only To A Specified Region Of An Image
+Apply a Filter Only to a Specified Region of an Image
 =====================================================
 
 .. index::

--- a/src/Core/Common/ApplyCustomOperationToEachPixelInImage/Documentation.rst
+++ b/src/Core/Common/ApplyCustomOperationToEachPixelInImage/Documentation.rst
@@ -1,4 +1,4 @@
-Apply Custom Operation To Each Pixel In Image
+Apply Custom Operation to Each Pixel in Image
 =============================================
 
 .. index::

--- a/src/Core/Common/BoundingBoxOfAPointSet/Documentation.rst
+++ b/src/Core/Common/BoundingBoxOfAPointSet/Documentation.rst
@@ -1,4 +1,4 @@
-Bounding Box Of A Point Set
+Bounding Box of a Point Set
 ===========================
 
 .. index::

--- a/src/Core/Common/BuildAHelloWorldProgram/Documentation.rst
+++ b/src/Core/Common/BuildAHelloWorldProgram/Documentation.rst
@@ -1,4 +1,4 @@
-Build A Hello World Program
+Build a Hello World Program
 ===========================
 
 .. index::

--- a/src/Core/Common/CheckIfModuleIsPresent/Documentation.rst
+++ b/src/Core/Common/CheckIfModuleIsPresent/Documentation.rst
@@ -1,4 +1,4 @@
-Check If Module Is Present
+Check if Module Is Present
 ==========================
 
 .. index::

--- a/src/Core/Common/ConvertArrayToImage/Documentation.rst
+++ b/src/Core/Common/ConvertArrayToImage/Documentation.rst
@@ -1,4 +1,4 @@
-Convert Array To Image
+Convert Array to Image
 ======================
 
 .. index::

--- a/src/Core/Common/CreateAIndex/Documentation.rst
+++ b/src/Core/Common/CreateAIndex/Documentation.rst
@@ -1,4 +1,4 @@
-Create A Index
+Create a Index
 ==============
 
 .. index::

--- a/src/Core/Common/CreateAnImageOfVectors/Documentation.rst
+++ b/src/Core/Common/CreateAnImageOfVectors/Documentation.rst
@@ -1,4 +1,4 @@
-Create An Image Of Vectors
+Create an Image of Vectors
 ==========================
 
 .. index::

--- a/src/Core/Common/CreateAnImageRegion/Documentation.rst
+++ b/src/Core/Common/CreateAnImageRegion/Documentation.rst
@@ -1,4 +1,4 @@
-Create An Image Region
+Create an Image Region
 ======================
 
 .. index::

--- a/src/Core/Common/CreateAnRGBImage/Documentation.rst
+++ b/src/Core/Common/CreateAnRGBImage/Documentation.rst
@@ -1,4 +1,4 @@
-Create An RGB Image
+Create an RGB Image
 ===================
 
 .. index::

--- a/src/Core/Common/DirectWarningToFile/Documentation.rst
+++ b/src/Core/Common/DirectWarningToFile/Documentation.rst
@@ -1,4 +1,4 @@
-Direct Warning To File
+Direct Warning to File
 ======================
 
 .. index::

--- a/src/Core/Common/DuplicateAnImage/Documentation.rst
+++ b/src/Core/Common/DuplicateAnImage/Documentation.rst
@@ -1,4 +1,4 @@
-Duplicate An Image
+Duplicate an Image
 ==================
 
 .. index::

--- a/src/Core/Common/FindMaxAndMinInImage/Documentation.rst
+++ b/src/Core/Common/FindMaxAndMinInImage/Documentation.rst
@@ -1,4 +1,4 @@
-Find Max And Min In Image
+Find Max and Min in Image
 =========================
 
 .. index::

--- a/src/Core/Common/GetNameOfClass/Documentation.rst
+++ b/src/Core/Common/GetNameOfClass/Documentation.rst
@@ -1,4 +1,4 @@
-Get Name Of Class
+Get Name of Class
 =================
 
 .. index::

--- a/src/Core/Common/InPlaceFilterOfImage/Documentation.rst
+++ b/src/Core/Common/InPlaceFilterOfImage/Documentation.rst
@@ -1,4 +1,4 @@
-In Place Filter Of Image
+In Place Filter of Image
 ========================
 .. index::
    single: InPlaceImageFilter

--- a/src/Core/Common/IterateImageStartingAtSeed/Documentation.rst
+++ b/src/Core/Common/IterateImageStartingAtSeed/Documentation.rst
@@ -1,4 +1,4 @@
-Iterate Image Starting At Seed
+Iterate Image Starting at Seed
 ==============================
 .. warning::
    **Fix Problem**

--- a/src/Core/Common/IterateOverARegionWithAShapedNeighborhoodIterator/Documentation.rst
+++ b/src/Core/Common/IterateOverARegionWithAShapedNeighborhoodIterator/Documentation.rst
@@ -1,4 +1,4 @@
-Iterate Over A Region With A Shaped Neighborhood Iterator
+Iterate Over a Region With a Shaped Neighborhood Iterator
 =========================================================
 
 .. index::

--- a/src/Core/Common/IterateOverARegionWithAShapedNeighborhoodIteratorManual/Documentation.rst
+++ b/src/Core/Common/IterateOverARegionWithAShapedNeighborhoodIteratorManual/Documentation.rst
@@ -1,4 +1,4 @@
-Iterate Over A Region With A Shaped Neighborhood Iterator Manually
+Iterate Over a Region With a Shaped Neighborhood Iterator Manually
 ===================================================================
 
 .. index::

--- a/src/Core/Common/IterateRegionWithAccessToIndexWithWriteAccess/Documentation.rst
+++ b/src/Core/Common/IterateRegionWithAccessToIndexWithWriteAccess/Documentation.rst
@@ -1,4 +1,4 @@
-Iterate Region In Image With Access To Current Index With Write Access
+Iterate Region in Image With Access to Current Index With Write Access
 ======================================================================
 
 .. index::

--- a/src/Core/Common/IterateRegionWithAccessToIndexWithoutWriteAccess/Documentation.rst
+++ b/src/Core/Common/IterateRegionWithAccessToIndexWithoutWriteAccess/Documentation.rst
@@ -1,4 +1,4 @@
-Iterate Region In Image With Access To Index Without Write Access
+Iterate Region in Image With Access to Index Without Write Access
 =================================================================
 
 .. index::

--- a/src/Core/Common/IterateRegionWithNeighborhood/Documentation.rst
+++ b/src/Core/Common/IterateRegionWithNeighborhood/Documentation.rst
@@ -1,4 +1,4 @@
-Iterate Region In Image With Neighborhood
+Iterate Region in Image With Neighborhood
 =========================================
 
 .. index::

--- a/src/Core/Common/IterateRegionWithWriteAccess/Documentation.rst
+++ b/src/Core/Common/IterateRegionWithWriteAccess/Documentation.rst
@@ -1,4 +1,4 @@
-Iterate Region In Image With Write Access
+Iterate Region in Image With Write Access
 =========================================
 
 .. index::

--- a/src/Core/Common/MakeOutOfBoundsPixelsReturnConstValue/Documentation.rst
+++ b/src/Core/Common/MakeOutOfBoundsPixelsReturnConstValue/Documentation.rst
@@ -1,4 +1,4 @@
-Make Out Of Bounds Pixels Return Constant Value
+Make Out of Bounds Pixels Return Constant Value
 ===============================================
 
 .. index::

--- a/src/Core/Common/MakePartOfImageTransparent/Documentation.rst
+++ b/src/Core/Common/MakePartOfImageTransparent/Documentation.rst
@@ -1,4 +1,4 @@
-Make Part Of An Image Transparent
+Make Part of an Image Transparent
 =================================
 
 .. index::

--- a/src/Core/Common/MultipleOutputsOfSameType/Documentation.rst
+++ b/src/Core/Common/MultipleOutputsOfSameType/Documentation.rst
@@ -1,4 +1,4 @@
-Multiple Outputs Of Same Type
+Multiple Outputs of Same Type
 =============================
 
 .. index::

--- a/src/Core/Common/ObserveAnEvent/Documentation.rst
+++ b/src/Core/Common/ObserveAnEvent/Documentation.rst
@@ -1,4 +1,4 @@
-Observe An Event
+Observe an Event
 ================
 
 .. index::

--- a/src/Core/Common/PassImageToFunction/Documentation.rst
+++ b/src/Core/Common/PassImageToFunction/Documentation.rst
@@ -1,4 +1,4 @@
-Pass Image To Function
+Pass Image to Function
 ======================
 
 .. index::

--- a/src/Core/Common/RandomSelectOfPixelsFromRegion/Documentation.rst
+++ b/src/Core/Common/RandomSelectOfPixelsFromRegion/Documentation.rst
@@ -1,4 +1,4 @@
-Random Selection Of Pixels From Region
+Random Selection of Pixels From Region
 ======================================
 
 .. index::

--- a/src/Core/Common/index.rst
+++ b/src/Core/Common/index.rst
@@ -27,10 +27,10 @@ Common
   CreateAPointSet/Documentation.rst
   CreateASize/Documentation.rst
   CreateAVector/Documentation.rst
-  CreateAnRGBImage/Documentation.rst
   CreateAnImage/Documentation.rst
   CreateAnImageRegion/Documentation.rst
   CreateAnImageOfVectors/Documentation.rst
+  CreateAnRGBImage/Documentation.rst
   CreateAnother/Documentation.rst
   CreateAnotherInstanceOfAnImage/Documentation.rst
   CreateDerivativeKernel/Documentation.rst

--- a/src/Filtering/ImageCompare/SquaredDifferenceOfTwoImages/Documentation.rst
+++ b/src/Filtering/ImageCompare/SquaredDifferenceOfTwoImages/Documentation.rst
@@ -1,4 +1,4 @@
-Squared Difference Of Two Images
+Squared Difference of Two Images
 ================================
 
 .. index::

--- a/src/Filtering/ImageGradient/ApplyGradientRecursiveGaussianWithVectorInput/Documentation.rst
+++ b/src/Filtering/ImageGradient/ApplyGradientRecursiveGaussianWithVectorInput/Documentation.rst
@@ -1,4 +1,4 @@
-Apply GradientRecursiveGaussianImageFilter on Image with Vector type
+Apply GradientRecursiveGaussianImageFilter on Image With Vector type
 ====================================================================
 
 .. index::

--- a/src/Filtering/Smoothing/MedianFilteringOfAnRGBImage/Documentation.rst
+++ b/src/Filtering/Smoothing/MedianFilteringOfAnRGBImage/Documentation.rst
@@ -1,4 +1,4 @@
-Median Filtering Of An RGB Image
+Median Filtering of an RGB Image
 ================================
 
 .. index::


### PR DESCRIPTION
Several of the examples needed their headers put into proper MLA/APA format. In addition, it ensures `CreateAnRGBImage/Documentation.rst` is in proper alphabetical order when being displayed in Sphinx.