### PR TITLE
Fix another small doc file

### DIFF
--- a/src/IO/Mesh/ReadMesh/CMakeLists.txt
+++ b/src/IO/Mesh/ReadMesh/CMakeLists.txt
@@ -13,7 +13,7 @@ install( TARGETS ReadMesh
   COMPONENT Runtime
   )
 
-install( FILES ReadMesh.cxx CMakeLists.txt
+install( FILES Code.cxx CMakeLists.txt
   DESTINATION share/ITKSphinxExamples/Code/IO/Mesh/ReadMesh
   COMPONENT Code
   )


### PR DESCRIPTION
Another small doc fix.  Allows make install to complete when BUILD_EXAMPLES=ON in ITK.  