### PR TITLE
Switch to the new code order: Python before C++

### DIFF
--- a/src/Registration/Metricsv4/RegisterTwoPointSets/Documentation.rst
+++ b/src/Registration/Metricsv4/RegisterTwoPointSets/Documentation.rst
@@ -57,18 +57,18 @@ Jupyter Notebook
 Code
 --------
 
-C++
-...
-
-.. literalinclude:: Code.cxx
-   :lines: 20-
-
 Python
 ......
 
 .. literalinclude:: Code.py
    :language: python
    :lines: 1, 23-
+
+C++
+...
+
+.. literalinclude:: Code.cxx
+   :lines: 20-
 
 Classes demonstrated
 --------------------


### PR DESCRIPTION
I think the PR which introduced this example was concurrent to the one which swapped the order.