### PR TITLE
ENH: Added missing Python licensing files

### DIFF
--- a/src/Filtering/BinaryMathematicalMorphology/ThinImage/Code.py
+++ b/src/Filtering/BinaryMathematicalMorphology/ThinImage/Code.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright NumFOCUS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import sys
 import itk
 

--- a/src/Filtering/ImageIntensity/RescaleIntensity/Code.py
+++ b/src/Filtering/ImageIntensity/RescaleIntensity/Code.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright NumFOCUS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import sys
 import itk
 

--- a/src/IO/ImageBase/WriteAnImage/Code.py
+++ b/src/IO/ImageBase/WriteAnImage/Code.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+# Copyright NumFOCUS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import sys
 import itk
 


### PR DESCRIPTION
Note that the  corresponding .rst files has already accounted for the licensing block. 