### PR TITLE
ENH: Added LaplacianRecursiveGaussianImageFilter Python script

### DIFF
--- a/src/Filtering/ImageFeature/LaplacianRecursiveGaussianImageFilter/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/LaplacianRecursiveGaussianImageFilter/CMakeLists.txt
@@ -19,8 +19,21 @@ install( FILES Code.cxx CMakeLists.txt
 )
 
 enable_testing()
+
+set( input_image ${CMAKE_CURRENT_BINARY_DIR}/cthead1.png )
+set( output_image Output.mha )
+
 add_test( NAME LaplacianRecursiveGaussianImageFilterTest
   COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/LaplacianRecursiveGaussianImageFilter
-  ${CMAKE_CURRENT_BINARY_DIR}/cthead1.png
-  Output.mha
+    ${input_image}
+    ${output_image}
   )
+
+if( ITK_WRAP_PYTHON )
+  string( REPLACE . "Python." output_image "${output_image}" )
+  add_test( NAME LaplacianRecursiveGaussianImageFilterTestPython
+    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/Code.py
+      ${input_image}
+      ${output_image}
+    )
+endif()

--- a/src/Filtering/ImageFeature/LaplacianRecursiveGaussianImageFilter/Code.py
+++ b/src/Filtering/ImageFeature/LaplacianRecursiveGaussianImageFilter/Code.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+# Copyright NumFOCUS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import itk
+
+if len(sys.argv) != 3:
+    print("Usage: " + sys.argv[0] + " <InputFileName> <OutputFileName>")
+    sys.exit(1)
+
+image = itk.imread(sys.argv[1], pixel_type=itk.F)
+
+image = itk.laplacian_recursive_gaussian_image_filter(image)
+
+itk.imwrite(image, sys.argv[2])

--- a/src/Filtering/ImageFeature/LaplacianRecursiveGaussianImageFilter/Documentation.rst
+++ b/src/Filtering/ImageFeature/LaplacianRecursiveGaussianImageFilter/Documentation.rst
@@ -28,6 +28,13 @@ Results
 Code
 ----
 
+Python
+......
+
+.. literalinclude:: Code.py
+   :language: python
+   :lines: 1, 16-
+
 C++
 ...
 


### PR DESCRIPTION
Created a Python LaplacianRecursiveGaussianImageFilter example based off of the existing C++ example.