### PR TITLE
BUG: Initialize image buffer in Inverse FFT example

### DIFF
--- a/src/Filtering/FFT/ComputeInverseFFTOfImage/Code.py
+++ b/src/Filtering/FFT/ComputeInverseFFTOfImage/Code.py
@@ -37,6 +37,7 @@ if not args.input_image:
 
     image = float_image_type.New(Regions=region)
     image.Allocate()
+    image.FillBuffer(0)
 
     # Make a square
     image[40:100, 40:100] = 100


### PR DESCRIPTION
Previous behavior: FFT and baseline comparison sometimes returns NAN pixel values due to uninitialized buffer

Updated behavior: Pixels are initialized to 0; FFT and baseline comparison succeed