### PR TITLE
remove recursive header includes

### DIFF
--- a/src/Core/Common/DistanceBetweenPoints/Code.cxx
+++ b/src/Core/Common/DistanceBetweenPoints/Code.cxx
@@ -57,7 +57,7 @@ main(int, char *[])
   PointType::RealType dist2 = p0.SquaredEuclideanDistanceTo(p1);
   std::cout << "Dist2: " << dist2 << std::endl;
 
-  if (std::abs(dist2 - dist * dist) < itk::Math::eps)
+  if (itk::Math::abs(dist2 - dist * dist) < itk::Math::eps)
   {
     std::cerr << "dist2 != dist * dist" << std::endl;
     return EXIT_FAILURE;

--- a/src/Developer/ImageFilter.hxx
+++ b/src/Developer/ImageFilter.hxx
@@ -1,7 +1,6 @@
 #ifndef __itkImageFilter_hxx
 #define __itkImageFilter_hxx
 
-#include "ImageFilter.h"
 #include "itkObjectFactory.h"
 #include "itkImageRegionIterator.h"
 #include "itkImageRegionConstIterator.h"

--- a/src/Developer/ImageFilterMultipleInputsDifferentType.hxx
+++ b/src/Developer/ImageFilterMultipleInputsDifferentType.hxx
@@ -1,7 +1,6 @@
 #ifndef __itkImageFilterMultipleInputs_hxx
 #define __itkImageFilterMultipleInputs_hxx
 
-#include "ImageFilterMultipleInputsDifferentType.h"
 
 #include "itkObjectFactory.h"
 #include "itkImageRegionIterator.h"

--- a/src/Developer/ImageFilterMultipleOutputs.hxx
+++ b/src/Developer/ImageFilterMultipleOutputs.hxx
@@ -1,7 +1,6 @@
 #ifndef __itkImageFilterMultipleOutputs_hxx
 #define __itkImageFilterMultipleOutputs_hxx
 
-#include "ImageFilterMultipleOutputs.h"
 
 #include "itkObjectFactory.h"
 #include "itkImageRegionIterator.h"

--- a/src/Developer/ImageFilterMultipleOutputsDifferentType.hxx
+++ b/src/Developer/ImageFilterMultipleOutputsDifferentType.hxx
@@ -1,7 +1,6 @@
 #ifndef __itkImageFilterMultipleOutputsDifferentType_hxx
 #define __itkImageFilterMultipleOutputsDifferentType_hxx
 
-#include "ImageFilterMultipleOutputsDifferentType.h"
 
 #include "itkObjectFactory.h"
 #include "itkImageRegionIterator.h"

--- a/src/Developer/ImageFilterX.hxx
+++ b/src/Developer/ImageFilterX.hxx
@@ -1,7 +1,6 @@
 #ifndef __itkImageFilter_hxx
 #define __itkImageFilter_hxx
 
-#include "ImageFilterX.h"
 #include "itkObjectFactory.h"
 #include "itkImageRegionIterator.h"
 #include "itkImageRegionConstIterator.h"

--- a/src/Developer/ImageFilterY.hxx
+++ b/src/Developer/ImageFilterY.hxx
@@ -1,7 +1,6 @@
 #ifndef __ImageFilterY_hxx
 #define __ImageFilterY_hxx
 
-#include "ImageFilterY.h"
 #include "itkObjectFactory.h"
 #include "itkImageRegionIterator.h"
 

--- a/src/Developer/ImageSource.hxx
+++ b/src/Developer/ImageSource.hxx
@@ -1,7 +1,6 @@
 #ifndef __itkImageSource_hxx
 #define __itkImageSource_hxx
 
-#include "ImageSource.h"
 #include "itkObjectFactory.h"
 #include "itkImageRegionIterator.h"
 #include "itkImageRegionConstIterator.h"

--- a/src/Developer/MultiThreadedImageFilter.hxx
+++ b/src/Developer/MultiThreadedImageFilter.hxx
@@ -1,7 +1,6 @@
 #ifndef __itkMultiThreadedImageFilter_hxx
 #define __itkMultiThreadedImageFilter_hxx
 
-#include "MultiThreadedImageFilter.h"
 
 #include "itkObjectFactory.h"
 #include "itkImageRegionIterator.h"

--- a/src/Developer/MyInPlaceImageFilter.hxx
+++ b/src/Developer/MyInPlaceImageFilter.hxx
@@ -1,7 +1,6 @@
 #ifndef __itkMyInPlaceImageFilter_hxx
 #define __itkMyInPlaceImageFilter_hxx
 
-#include "MyInPlaceImageFilter.h"
 
 #include "itkObjectFactory.h"
 #include "itkImageRegionIterator.h"

--- a/src/Developer/itkImageFilterMultipleInputs.hxx
+++ b/src/Developer/itkImageFilterMultipleInputs.hxx
@@ -1,7 +1,6 @@
 #ifndef itkImageFilterMultipleInputs_hxx
 #define itkImageFilterMultipleInputs_hxx
 
-#include "itkImageFilterMultipleInputs.h"
 
 #include "itkObjectFactory.h"
 #include "itkImageRegionIterator.h"

--- a/src/Developer/itkOilPaintingImageFilter.hxx
+++ b/src/Developer/itkOilPaintingImageFilter.hxx
@@ -1,7 +1,6 @@
 #ifndef __itkOilPaintingImageFilter_hxx
 #define __itkOilPaintingImageFilter_hxx
 
-#include "itkOilPaintingImageFilter.h"
 #include "itkObjectFactory.h"
 #include "itkImageRegionIterator.h"
 #include "itkImageRegionConstIterator.h"

--- a/src/Filtering/MathematicalMorphology/GenerateStructureElementsWithAccurateArea/Code.cxx
+++ b/src/Filtering/MathematicalMorphology/GenerateStructureElementsWithAccurateArea/Code.cxx
@@ -177,7 +177,7 @@ ComputeAreaError(SEType k, unsigned int thickness)
   std::cout << "Expected foreground area: " << expectedForegroundArea << std::endl;
   std::cout << "Computed foreground area: " << computedForegroundArea << std::endl;
   std::cout << "Foreground area error: "
-            << 100 * std::abs(expectedForegroundArea - computedForegroundArea) / expectedForegroundArea << "%"
+            << 100 * itk::Math::abs(expectedForegroundArea - computedForegroundArea) / expectedForegroundArea << "%"
             << "\n\n";
 
   return EXIT_FAILURE;


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

