### PR TITLE
ENH: Miscellaneous fixes to developer files

### DIFF
--- a/src/Developer/ImageFilter.h
+++ b/src/Developer/ImageFilter.h
@@ -1,5 +1,5 @@
-#ifndef __ImageFilter_h
-#define __ImageFilter_h
+#ifndef ImageFilter_h
+#define ImageFilter_h
 
 #include "itkImageToImageFilter.h"
 
@@ -37,4 +37,4 @@ protected:
 #endif
 
 
-#endif // __ImageFilter_h
+#endif // ImageFilter_h

--- a/src/Developer/ImageFilter.h
+++ b/src/Developer/ImageFilter.h
@@ -14,6 +14,7 @@ public:
   using Self = ImageFilter;
   using Superclass = ImageToImageFilter<TImage, TImage>;
   using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/src/Developer/ImageFilter.h
+++ b/src/Developer/ImageFilter.h
@@ -1,5 +1,5 @@
-#ifndef __itkImageFilter_h
-#define __itkImageFilter_h
+#ifndef __ImageFilter_h
+#define __ImageFilter_h
 
 #include "itkImageToImageFilter.h"
 
@@ -37,4 +37,4 @@ protected:
 #endif
 
 
-#endif // __itkImageFilter_h
+#endif // __ImageFilter_h

--- a/src/Developer/ImageFilter.h
+++ b/src/Developer/ImageFilter.h
@@ -5,7 +5,7 @@
 
 namespace itk
 {
-template <class TImage>
+template <typename TImage>
 class ImageFilter : public ImageToImageFilter<TImage, TImage>
 {
 public:

--- a/src/Developer/ImageFilter.hxx
+++ b/src/Developer/ImageFilter.hxx
@@ -1,5 +1,5 @@
-#ifndef __itkImageFilter_hxx
-#define __itkImageFilter_hxx
+#ifndef __ImageFilter_hxx
+#define __ImageFilter_hxx
 
 #include "itkObjectFactory.h"
 #include "itkImageRegionIterator.h"

--- a/src/Developer/ImageFilter.hxx
+++ b/src/Developer/ImageFilter.hxx
@@ -1,5 +1,5 @@
-#ifndef __ImageFilter_hxx
-#define __ImageFilter_hxx
+#ifndef ImageFilter_hxx
+#define ImageFilter_hxx
 
 #include "itkObjectFactory.h"
 #include "itkImageRegionIterator.h"

--- a/src/Developer/ImageFilter.hxx
+++ b/src/Developer/ImageFilter.hxx
@@ -9,7 +9,7 @@
 namespace itk
 {
 
-template <class TImage>
+template <typename TImage>
 void
 ImageFilter<TImage>::GenerateData()
 {

--- a/src/Developer/ImageFilterMultipleInputsDifferentType.h
+++ b/src/Developer/ImageFilterMultipleInputsDifferentType.h
@@ -15,6 +15,7 @@ public:
   using Self = ImageFilterMultipleInputsDifferentType;
   using Superclass = ImageToImageFilter<TImage, TImage>;
   using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/src/Developer/ImageFilterMultipleInputsDifferentType.h
+++ b/src/Developer/ImageFilterMultipleInputsDifferentType.h
@@ -1,5 +1,5 @@
-#ifndef __itkImageFilterMultipleInputsDifferentType_h
-#define __itkImageFilterMultipleInputsDifferentType_h
+#ifndef __ImageFilterMultipleInputsDifferentType_h
+#define __ImageFilterMultipleInputsDifferentType_h
 
 #include "itkImageToImageFilter.h"
 
@@ -54,4 +54,4 @@ private:
 #endif
 
 
-#endif // __itkImageFilterMultipleInputsDifferentType_h
+#endif // __ImageFilterMultipleInputsDifferentType_h

--- a/src/Developer/ImageFilterMultipleInputsDifferentType.h
+++ b/src/Developer/ImageFilterMultipleInputsDifferentType.h
@@ -1,5 +1,5 @@
-#ifndef __ImageFilterMultipleInputsDifferentType_h
-#define __ImageFilterMultipleInputsDifferentType_h
+#ifndef ImageFilterMultipleInputsDifferentType_h
+#define ImageFilterMultipleInputsDifferentType_h
 
 #include "itkImageToImageFilter.h"
 
@@ -54,4 +54,4 @@ private:
 #endif
 
 
-#endif // __ImageFilterMultipleInputsDifferentType_h
+#endif // ImageFilterMultipleInputsDifferentType_h

--- a/src/Developer/ImageFilterMultipleInputsDifferentType.h
+++ b/src/Developer/ImageFilterMultipleInputsDifferentType.h
@@ -9,6 +9,8 @@ template <typename TImage, typename TMask>
 class ImageFilterMultipleInputsDifferentType : public ImageToImageFilter<TImage, TImage>
 {
 public:
+  ITK_DISALLOW_COPY_AND_MOVE(ImageFilterMultipleInputsDifferentType);
+
   /** Standard class type alias. */
   using Self = ImageFilterMultipleInputsDifferentType;
   using Superclass = ImageToImageFilter<TImage, TImage>;
@@ -40,11 +42,6 @@ protected:
   /** Does the real work. */
   void
   GenerateData() override;
-
-private:
-  ImageFilterMultipleInputsDifferentType(const Self &) = delete; // purposely not implemented
-  void
-  operator=(const Self &) = delete; // purposely not implemented
 };
 } // namespace itk
 

--- a/src/Developer/ImageFilterMultipleInputsDifferentType.hxx
+++ b/src/Developer/ImageFilterMultipleInputsDifferentType.hxx
@@ -1,5 +1,5 @@
-#ifndef __ImageFilterMultipleInputsDifferentType_hxx
-#define __ImageFilterMultipleInputsDifferentType_hxx
+#ifndef ImageFilterMultipleInputsDifferentType_hxx
+#define ImageFilterMultipleInputsDifferentType_hxx
 
 
 #include "itkObjectFactory.h"

--- a/src/Developer/ImageFilterMultipleInputsDifferentType.hxx
+++ b/src/Developer/ImageFilterMultipleInputsDifferentType.hxx
@@ -1,5 +1,5 @@
-#ifndef __itkImageFilterMultipleInputs_hxx
-#define __itkImageFilterMultipleInputs_hxx
+#ifndef __ImageFilterMultipleInputsDifferentType_hxx
+#define __ImageFilterMultipleInputsDifferentType_hxx
 
 
 #include "itkObjectFactory.h"

--- a/src/Developer/ImageFilterMultipleOutputs.h
+++ b/src/Developer/ImageFilterMultipleOutputs.h
@@ -14,6 +14,7 @@ public:
   using Self = ImageFilterMultipleOutputs;
   using Superclass = ImageToImageFilter<TImage, TImage>;
   using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/src/Developer/ImageFilterMultipleOutputs.h
+++ b/src/Developer/ImageFilterMultipleOutputs.h
@@ -5,7 +5,7 @@
 
 namespace itk
 {
-template <class TImage>
+template <typename TImage>
 class ImageFilterMultipleOutputs : public ImageToImageFilter<TImage, TImage>
 {
 public:

--- a/src/Developer/ImageFilterMultipleOutputs.h
+++ b/src/Developer/ImageFilterMultipleOutputs.h
@@ -1,5 +1,5 @@
-#ifndef __ImageFilterMultipleOutputs_h
-#define __ImageFilterMultipleOutputs_h
+#ifndef ImageFilterMultipleOutputs_h
+#define ImageFilterMultipleOutputs_h
 
 #include "itkImageToImageFilter.h"
 
@@ -46,4 +46,4 @@ protected:
 #endif
 
 
-#endif // __ImageFilterMultipleOutputs_h
+#endif // ImageFilterMultipleOutputs_h

--- a/src/Developer/ImageFilterMultipleOutputs.h
+++ b/src/Developer/ImageFilterMultipleOutputs.h
@@ -1,5 +1,5 @@
-#ifndef __itkImageFilterMultipleOutputs_h
-#define __itkImageFilterMultipleOutputs_h
+#ifndef __ImageFilterMultipleOutputs_h
+#define __ImageFilterMultipleOutputs_h
 
 #include "itkImageToImageFilter.h"
 
@@ -46,4 +46,4 @@ protected:
 #endif
 
 
-#endif // __itkImageFilterMultipleOutputs_h
+#endif // __ImageFilterMultipleOutputs_h

--- a/src/Developer/ImageFilterMultipleOutputs.hxx
+++ b/src/Developer/ImageFilterMultipleOutputs.hxx
@@ -9,7 +9,7 @@
 namespace itk
 {
 
-template <class TImage>
+template <typename TImage>
 ImageFilterMultipleOutputs<TImage>::ImageFilterMultipleOutputs()
 {
   this->SetNumberOfRequiredOutputs(2);
@@ -19,7 +19,7 @@ ImageFilterMultipleOutputs<TImage>::ImageFilterMultipleOutputs()
   this->SetNthOutput(1, this->MakeOutput(1));
 }
 
-template <class TImage>
+template <typename TImage>
 void
 ImageFilterMultipleOutputs<TImage>::GenerateData()
 {
@@ -80,7 +80,7 @@ ImageFilterMultipleOutputs<TImage>::GenerateData()
   }
 }
 
-template <class TImage>
+template <typename TImage>
 DataObject::Pointer
 ImageFilterMultipleOutputs<TImage>::MakeOutput(ProcessObject::DataObjectPointerArraySizeType idx)
 {
@@ -102,14 +102,14 @@ ImageFilterMultipleOutputs<TImage>::MakeOutput(ProcessObject::DataObjectPointerA
   return output.GetPointer();
 }
 
-template <class TImage>
+template <typename TImage>
 TImage *
 ImageFilterMultipleOutputs<TImage>::GetOutput1()
 {
   return dynamic_cast<TImage *>(this->ProcessObject::GetOutput(0));
 }
 
-template <class TImage>
+template <typename TImage>
 TImage *
 ImageFilterMultipleOutputs<TImage>::GetOutput2()
 {

--- a/src/Developer/ImageFilterMultipleOutputs.hxx
+++ b/src/Developer/ImageFilterMultipleOutputs.hxx
@@ -1,5 +1,5 @@
-#ifndef __ImageFilterMultipleOutputs_hxx
-#define __ImageFilterMultipleOutputs_hxx
+#ifndef ImageFilterMultipleOutputs_hxx
+#define ImageFilterMultipleOutputs_hxx
 
 
 #include "itkObjectFactory.h"

--- a/src/Developer/ImageFilterMultipleOutputs.hxx
+++ b/src/Developer/ImageFilterMultipleOutputs.hxx
@@ -1,5 +1,5 @@
-#ifndef __itkImageFilterMultipleOutputs_hxx
-#define __itkImageFilterMultipleOutputs_hxx
+#ifndef __ImageFilterMultipleOutputs_hxx
+#define __ImageFilterMultipleOutputs_hxx
 
 
 #include "itkObjectFactory.h"

--- a/src/Developer/ImageFilterMultipleOutputsDifferentType.h
+++ b/src/Developer/ImageFilterMultipleOutputsDifferentType.h
@@ -17,6 +17,7 @@ public:
   using Self = ImageFilterMultipleOutputsDifferentType;
   using Superclass = ImageToImageFilter<TInputImage, TOutputImage1>;
   using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/src/Developer/ImageFilterMultipleOutputsDifferentType.h
+++ b/src/Developer/ImageFilterMultipleOutputsDifferentType.h
@@ -1,5 +1,5 @@
-#ifndef __itkImageFilterMultipleOutputsDifferentType_h
-#define __itkImageFilterMultipleOutputsDifferentType_h
+#ifndef __ImageFilterMultipleOutputsDifferentType_h
+#define __ImageFilterMultipleOutputsDifferentType_h
 
 #include "itkImageToImageFilter.h"
 
@@ -52,4 +52,4 @@ private:
 #endif
 
 
-#endif // __itkImageFilterMultipleOutputsDifferentType_h
+#endif // __ImageFilterMultipleOutputsDifferentType_h

--- a/src/Developer/ImageFilterMultipleOutputsDifferentType.h
+++ b/src/Developer/ImageFilterMultipleOutputsDifferentType.h
@@ -1,5 +1,5 @@
-#ifndef __ImageFilterMultipleOutputsDifferentType_h
-#define __ImageFilterMultipleOutputsDifferentType_h
+#ifndef ImageFilterMultipleOutputsDifferentType_h
+#define ImageFilterMultipleOutputsDifferentType_h
 
 #include "itkImageToImageFilter.h"
 
@@ -52,4 +52,4 @@ private:
 #endif
 
 
-#endif // __ImageFilterMultipleOutputsDifferentType_h
+#endif // ImageFilterMultipleOutputsDifferentType_h

--- a/src/Developer/ImageFilterMultipleOutputsDifferentType.h
+++ b/src/Developer/ImageFilterMultipleOutputsDifferentType.h
@@ -11,6 +11,8 @@ class ImageFilterMultipleOutputsDifferentType
                                                           // output image type in MakeOutput()
 {
 public:
+  ITK_DISALLOW_COPY_AND_MOVE(ImageFilterMultipleOutputsDifferentType);
+
   /** Standard class type alias. */
   using Self = ImageFilterMultipleOutputsDifferentType;
   using Superclass = ImageToImageFilter<TInputImage, TOutputImage1>;
@@ -38,11 +40,6 @@ protected:
   /**  Create the Output */
   DataObject::Pointer
   MakeOutput(ProcessObject::DataObjectPointerArraySizeType idx) override;
-
-private:
-  ImageFilterMultipleOutputsDifferentType(const Self &) = delete; // purposely not implemented
-  void
-  operator=(const Self &) = delete; // purposely not implemented
 };
 } // namespace itk
 

--- a/src/Developer/ImageFilterMultipleOutputsDifferentType.hxx
+++ b/src/Developer/ImageFilterMultipleOutputsDifferentType.hxx
@@ -1,5 +1,5 @@
-#ifndef __itkImageFilterMultipleOutputsDifferentType_hxx
-#define __itkImageFilterMultipleOutputsDifferentType_hxx
+#ifndef __ImageFilterMultipleOutputsDifferentType_hxx
+#define __ImageFilterMultipleOutputsDifferentType_hxx
 
 
 #include "itkObjectFactory.h"

--- a/src/Developer/ImageFilterMultipleOutputsDifferentType.hxx
+++ b/src/Developer/ImageFilterMultipleOutputsDifferentType.hxx
@@ -1,5 +1,5 @@
-#ifndef __ImageFilterMultipleOutputsDifferentType_hxx
-#define __ImageFilterMultipleOutputsDifferentType_hxx
+#ifndef ImageFilterMultipleOutputsDifferentType_hxx
+#define ImageFilterMultipleOutputsDifferentType_hxx
 
 
 #include "itkObjectFactory.h"

--- a/src/Developer/ImageFilterX.h
+++ b/src/Developer/ImageFilterX.h
@@ -5,7 +5,7 @@
 
 namespace itk
 {
-template <class TImage>
+template <typename TImage>
 class ImageFilter : public ImageToImageFilter<TImage, TImage>
 {
 public:

--- a/src/Developer/ImageFilterX.h
+++ b/src/Developer/ImageFilterX.h
@@ -15,6 +15,7 @@ public:
   using Self = ImageFilter;
   using Superclass = ImageToImageFilter<TImage, TImage>;
   using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/src/Developer/ImageFilterX.h
+++ b/src/Developer/ImageFilterX.h
@@ -1,5 +1,5 @@
-#ifndef __ImageFilterX_h
-#define __ImageFilterX_h
+#ifndef ImageFilterX_h
+#define ImageFilterX_h
 
 #include "itkImageToImageFilter.h"
 

--- a/src/Developer/ImageFilterX.h
+++ b/src/Developer/ImageFilterX.h
@@ -9,6 +9,8 @@ template <class TImage>
 class ImageFilter : public ImageToImageFilter<TImage, TImage>
 {
 public:
+  ITK_DISALLOW_COPY_AND_MOVE(ImageFilter);
+
   /** Standard class type alias. */
   using Self = ImageFilter;
   using Superclass = ImageToImageFilter<TImage, TImage>;
@@ -32,11 +34,6 @@ protected:
   GenerateData() override;
 
   double m_Variable;
-
-private:
-  ImageFilter(const Self &) = delete; // purposely not implemented
-  void
-  operator=(const Self &) = delete; // purposely not implemented
 };
 } // namespace itk
 

--- a/src/Developer/ImageFilterX.h
+++ b/src/Developer/ImageFilterX.h
@@ -1,5 +1,5 @@
-#ifndef __itkImageFilter_h
-#define __itkImageFilter_h
+#ifndef __ImageFilterX_h
+#define __ImageFilterX_h
 
 #include "itkImageToImageFilter.h"
 
@@ -46,4 +46,4 @@ private:
 #endif
 
 
-#endif // __itkImageFilter_h
+#endif // __ImageFilterX_h

--- a/src/Developer/ImageFilterX.hxx
+++ b/src/Developer/ImageFilterX.hxx
@@ -8,7 +8,7 @@
 namespace itk
 {
 
-template <class TImage>
+template <typename TImage>
 void
 ImageFilter<TImage>::GenerateData()
 {}

--- a/src/Developer/ImageFilterX.hxx
+++ b/src/Developer/ImageFilterX.hxx
@@ -1,5 +1,5 @@
-#ifndef __itkImageFilter_hxx
-#define __itkImageFilter_hxx
+#ifndef __ImageFilterX_hxx
+#define __ImageFilterX_hxx
 
 #include "itkObjectFactory.h"
 #include "itkImageRegionIterator.h"

--- a/src/Developer/ImageFilterX.hxx
+++ b/src/Developer/ImageFilterX.hxx
@@ -1,5 +1,5 @@
-#ifndef __ImageFilterX_hxx
-#define __ImageFilterX_hxx
+#ifndef ImageFilterX_hxx
+#define ImageFilterX_hxx
 
 #include "itkObjectFactory.h"
 #include "itkImageRegionIterator.h"

--- a/src/Developer/ImageFilterY.h
+++ b/src/Developer/ImageFilterY.h
@@ -1,5 +1,5 @@
-#ifndef __itkImageFilter_h
-#define __itkImageFilter_h
+#ifndef __ImageFilterY_h
+#define __ImageFilterY_h
 
 #include "itkImageToImageFilter.h"
 
@@ -54,4 +54,4 @@ private:
 #endif
 
 
-#endif // __itkImageFilter_h
+#endif // __ImageFilterY_h

--- a/src/Developer/ImageFilterY.h
+++ b/src/Developer/ImageFilterY.h
@@ -17,6 +17,7 @@ public:
   using Self = ImageFilter;
   using Superclass = ImageToImageFilter<TImage, TImage>;
   using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/src/Developer/ImageFilterY.h
+++ b/src/Developer/ImageFilterY.h
@@ -7,7 +7,7 @@
 
 namespace itk
 {
-template <class TImage>
+template <typename TImage>
 class ImageFilter : public ImageToImageFilter<TImage, TImage>
 {
 public:

--- a/src/Developer/ImageFilterY.h
+++ b/src/Developer/ImageFilterY.h
@@ -1,5 +1,5 @@
-#ifndef __ImageFilterY_h
-#define __ImageFilterY_h
+#ifndef ImageFilterY_h
+#define ImageFilterY_h
 
 #include "itkImageToImageFilter.h"
 
@@ -54,4 +54,4 @@ private:
 #endif
 
 
-#endif // __ImageFilterY_h
+#endif // ImageFilterY_h

--- a/src/Developer/ImageFilterY.h
+++ b/src/Developer/ImageFilterY.h
@@ -36,7 +36,7 @@ public:
   using InternalGaussianFilterPointer = typename InternalGaussianFilterType::Pointer;
 
 protected:
-  ImageFilter();
+  ImageFilter() = default;
   ~ImageFilter() override = default;
 
   /** Does the real work. */

--- a/src/Developer/ImageFilterY.h
+++ b/src/Developer/ImageFilterY.h
@@ -11,6 +11,8 @@ template <class TImage>
 class ImageFilter : public ImageToImageFilter<TImage, TImage>
 {
 public:
+  ITK_DISALLOW_COPY_AND_MOVE(ImageFilter);
+
   /** Standard class type alias. */
   using Self = ImageFilter;
   using Superclass = ImageToImageFilter<TImage, TImage>;
@@ -40,11 +42,6 @@ protected:
   /** Does the real work. */
   void
   GenerateData() override;
-
-private:
-  ImageFilter(const Self &); // purposely not implemented
-  void
-  operator=(const Self &); // purposely not implemented
 };
 } // namespace itk
 

--- a/src/Developer/ImageFilterY.hxx
+++ b/src/Developer/ImageFilterY.hxx
@@ -1,5 +1,5 @@
-#ifndef __ImageFilterY_hxx
-#define __ImageFilterY_hxx
+#ifndef ImageFilterY_hxx
+#define ImageFilterY_hxx
 
 #include "itkObjectFactory.h"
 #include "itkImageRegionIterator.h"

--- a/src/Developer/ImageFilterY.hxx
+++ b/src/Developer/ImageFilterY.hxx
@@ -7,7 +7,7 @@
 namespace itk
 {
 
-template <class TImage>
+template <typename TImage>
 void
 ImageFilter<TImage>::GenerateData()
 {

--- a/src/Developer/ImageFilterY.hxx
+++ b/src/Developer/ImageFilterY.hxx
@@ -8,9 +8,6 @@ namespace itk
 {
 
 template <class TImage>
-ImageFilter<TImage>::ImageFilter() = default;
-
-template <class TImage>
 void
 ImageFilter<TImage>::GenerateData()
 {

--- a/src/Developer/ImageSource.h
+++ b/src/Developer/ImageSource.h
@@ -1,5 +1,5 @@
-#ifndef __itkImageFilter_h
-#define __itkImageFilter_h
+#ifndef __ImageSource_h
+#define __ImageSource_h
 
 #include "itkProcessObject.h"
 
@@ -43,4 +43,4 @@ private:
 #endif
 
 
-#endif // __itkImageFilter_h
+#endif // __ImageSource_h

--- a/src/Developer/ImageSource.h
+++ b/src/Developer/ImageSource.h
@@ -7,7 +7,7 @@
 
 namespace itk
 {
-template <class TImage>
+template <typename TImage>
 class ImageSource : public ProcessObject
 {
 public:

--- a/src/Developer/ImageSource.h
+++ b/src/Developer/ImageSource.h
@@ -8,11 +8,11 @@
 namespace itk
 {
 template <class TImage>
-class ImageFilter : public ImageToImageFilter<TImage, TImage>
+class ImageSource : public ImageToImageFilter<TImage, TImage>
 {
 public:
   /** Standard class type alias. */
-  using Self = ImageFilter;
+  using Self = ImageSource;
   using Superclass = ImageToImageFilter<TImage, TImage>;
   using Pointer = SmartPointer<Self>;
 
@@ -20,18 +20,18 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ImageFilter, ImageToImageFilter);
+  itkTypeMacro(ImageSource, ImageToImageFilter);
 
 protected:
-  ImageFilter() {}
-  ~ImageFilter() {}
+  ImageSource() {}
+  ~ImageSource() {}
 
   /** Does the real work. */
   virtual void
   GenerateData();
 
 private:
-  ImageFilter(const Self &); // purposely not implemented
+  ImageSource(const Self &); // purposely not implemented
   void
   operator=(const Self &); // purposely not implemented
 };

--- a/src/Developer/ImageSource.h
+++ b/src/Developer/ImageSource.h
@@ -11,6 +11,8 @@ template <class TImage>
 class ImageSource : public ProcessObject
 {
 public:
+  ITK_DISALLOW_COPY_AND_MOVE(ImageSource);
+
   /** Standard class type alias. */
   using Self = ImageSource;
   using Superclass = ProcessObject;
@@ -29,11 +31,6 @@ protected:
   /** Does the real work. */
   virtual void
   GenerateData();
-
-private:
-  ImageSource(const Self &); // purposely not implemented
-  void
-  operator=(const Self &); // purposely not implemented
 };
 } // namespace itk
 

--- a/src/Developer/ImageSource.h
+++ b/src/Developer/ImageSource.h
@@ -1,5 +1,5 @@
-#ifndef __ImageSource_h
-#define __ImageSource_h
+#ifndef ImageSource_h
+#define ImageSource_h
 
 #include "itkProcessObject.h"
 
@@ -43,4 +43,4 @@ private:
 #endif
 
 
-#endif // __ImageSource_h
+#endif // ImageSource_h

--- a/src/Developer/ImageSource.h
+++ b/src/Developer/ImageSource.h
@@ -26,7 +26,7 @@ public:
 
 protected:
   ImageSource() = default;
-  ~ImageSource() = default;
+  ~ImageSource() override = default;
 
   /** Does the real work. */
   virtual void

--- a/src/Developer/ImageSource.h
+++ b/src/Developer/ImageSource.h
@@ -39,7 +39,7 @@ private:
 
 
 #ifndef ITK_MANUAL_INSTANTIATION
-#  include "ImageFilter.hxx"
+#  include "ImageSource.hxx"
 #endif
 
 

--- a/src/Developer/ImageSource.h
+++ b/src/Developer/ImageSource.h
@@ -1,26 +1,26 @@
 #ifndef __itkImageFilter_h
 #define __itkImageFilter_h
 
-#include "itkImageToImageFilter.h"
+#include "itkProcessObject.h"
 
 #include <set>
 
 namespace itk
 {
 template <class TImage>
-class ImageSource : public ImageToImageFilter<TImage, TImage>
+class ImageSource : public ProcessObject
 {
 public:
   /** Standard class type alias. */
   using Self = ImageSource;
-  using Superclass = ImageToImageFilter<TImage, TImage>;
+  using Superclass = ProcessObject;
   using Pointer = SmartPointer<Self>;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ImageSource, ImageToImageFilter);
+  itkTypeMacro(ImageSource, ProcessObject);
 
 protected:
   ImageSource() {}

--- a/src/Developer/ImageSource.h
+++ b/src/Developer/ImageSource.h
@@ -25,8 +25,8 @@ public:
   itkTypeMacro(ImageSource, ProcessObject);
 
 protected:
-  ImageSource() {}
-  ~ImageSource() {}
+  ImageSource() = default;
+  ~ImageSource() = default;
 
   /** Does the real work. */
   virtual void

--- a/src/Developer/ImageSource.h
+++ b/src/Developer/ImageSource.h
@@ -17,6 +17,7 @@ public:
   using Self = ImageSource;
   using Superclass = ProcessObject;
   using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/src/Developer/ImageSource.hxx
+++ b/src/Developer/ImageSource.hxx
@@ -10,7 +10,7 @@ namespace itk
 
 template <class TImage>
 void
-ImageFilter<TImage>::GenerateData()
+ImageSource<TImage>::GenerateData()
 {
   double a = 2.1;
   itkExceptionMacro("Here is a variable: " << a << " and then more text.");

--- a/src/Developer/ImageSource.hxx
+++ b/src/Developer/ImageSource.hxx
@@ -1,5 +1,5 @@
-#ifndef __itkImageSource_hxx
-#define __itkImageSource_hxx
+#ifndef __ImageSource_hxx
+#define __ImageSource_hxx
 
 #include "itkObjectFactory.h"
 #include "itkImageRegionIterator.h"

--- a/src/Developer/ImageSource.hxx
+++ b/src/Developer/ImageSource.hxx
@@ -1,5 +1,5 @@
-#ifndef __ImageSource_hxx
-#define __ImageSource_hxx
+#ifndef ImageSource_hxx
+#define ImageSource_hxx
 
 #include "itkObjectFactory.h"
 #include "itkImageRegionIterator.h"

--- a/src/Developer/ImageSource.hxx
+++ b/src/Developer/ImageSource.hxx
@@ -8,7 +8,7 @@
 namespace itk
 {
 
-template <class TImage>
+template <typename TImage>
 void
 ImageSource<TImage>::GenerateData()
 {

--- a/src/Developer/MultiThreadedImageFilter.h
+++ b/src/Developer/MultiThreadedImageFilter.h
@@ -9,6 +9,8 @@ template <class TImage>
 class MultiThreadedImageFilter : public ImageToImageFilter<TImage, TImage>
 {
 public:
+  ITK_DISALLOW_COPY_AND_MOVE(MultiThreadedImageFilter);
+
   /** Standard class type alias. */
   using Self = MultiThreadedImageFilter;
   using Superclass = ImageToImageFilter<TImage, TImage>;
@@ -28,11 +30,6 @@ protected:
 
   void
   DynamicThreadedGenerateData(const OutputImageRegionType &) override;
-
-private:
-  MultiThreadedImageFilter(const Self &) = delete; // purposely not implemented
-  void
-  operator=(const Self &) = delete; // purposely not implemented
 };
 } // namespace itk
 

--- a/src/Developer/MultiThreadedImageFilter.h
+++ b/src/Developer/MultiThreadedImageFilter.h
@@ -1,5 +1,5 @@
-#ifndef __MultiThreadedImageFilter_h
-#define __MultiThreadedImageFilter_h
+#ifndef MultiThreadedImageFilter_h
+#define MultiThreadedImageFilter_h
 
 #include "itkImageToImageFilter.h"
 
@@ -42,4 +42,4 @@ private:
 #endif
 
 
-#endif // __MultiThreadedImageFilter_h
+#endif // MultiThreadedImageFilter_h

--- a/src/Developer/MultiThreadedImageFilter.h
+++ b/src/Developer/MultiThreadedImageFilter.h
@@ -1,5 +1,5 @@
-#ifndef __itkImageFilter_h
-#define __itkImageFilter_h
+#ifndef __MultiThreadedImageFilter_h
+#define __MultiThreadedImageFilter_h
 
 #include "itkImageToImageFilter.h"
 
@@ -42,4 +42,4 @@ private:
 #endif
 
 
-#endif // __itkMultiThreadedImageFilter_h
+#endif // __MultiThreadedImageFilter_h

--- a/src/Developer/MultiThreadedImageFilter.h
+++ b/src/Developer/MultiThreadedImageFilter.h
@@ -5,7 +5,7 @@
 
 namespace itk
 {
-template <class TImage>
+template <typename TImage>
 class MultiThreadedImageFilter : public ImageToImageFilter<TImage, TImage>
 {
 public:

--- a/src/Developer/MultiThreadedImageFilter.h
+++ b/src/Developer/MultiThreadedImageFilter.h
@@ -15,6 +15,7 @@ public:
   using Self = MultiThreadedImageFilter;
   using Superclass = ImageToImageFilter<TImage, TImage>;
   using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   using OutputImageRegionType = typename Superclass::OutputImageRegionType;
 

--- a/src/Developer/MultiThreadedImageFilter.hxx
+++ b/src/Developer/MultiThreadedImageFilter.hxx
@@ -1,5 +1,5 @@
-#ifndef __MultiThreadedImageFilter_hxx
-#define __MultiThreadedImageFilter_hxx
+#ifndef MultiThreadedImageFilter_hxx
+#define MultiThreadedImageFilter_hxx
 
 
 #include "itkObjectFactory.h"

--- a/src/Developer/MultiThreadedImageFilter.hxx
+++ b/src/Developer/MultiThreadedImageFilter.hxx
@@ -9,7 +9,7 @@
 namespace itk
 {
 
-template <class TImage>
+template <typename TImage>
 void
 MultiThreadedImageFilter<TImage>::DynamicThreadedGenerateData(const OutputImageRegionType & region)
 {

--- a/src/Developer/MultiThreadedImageFilter.hxx
+++ b/src/Developer/MultiThreadedImageFilter.hxx
@@ -1,5 +1,5 @@
-#ifndef __itkMultiThreadedImageFilter_hxx
-#define __itkMultiThreadedImageFilter_hxx
+#ifndef __MultiThreadedImageFilter_hxx
+#define __MultiThreadedImageFilter_hxx
 
 
 #include "itkObjectFactory.h"

--- a/src/Developer/MyInPlaceImageFilter.h
+++ b/src/Developer/MyInPlaceImageFilter.h
@@ -5,7 +5,7 @@
 
 namespace itk
 {
-template <class TImage>
+template <typename TImage>
 class MyInPlaceImageFilter : public InPlaceImageFilter<TImage>
 {
 public:

--- a/src/Developer/MyInPlaceImageFilter.h
+++ b/src/Developer/MyInPlaceImageFilter.h
@@ -1,5 +1,5 @@
-#ifndef __MyInPlaceImageFilter_h
-#define __MyInPlaceImageFilter_h
+#ifndef MyInPlaceImageFilter_h
+#define MyInPlaceImageFilter_h
 
 #include "itkInPlaceImageFilter.h"
 

--- a/src/Developer/MyInPlaceImageFilter.h
+++ b/src/Developer/MyInPlaceImageFilter.h
@@ -1,5 +1,5 @@
-#ifndef __itkMyInPlaceImageFilter_h
-#define __itkMyInPlaceImageFilter_h
+#ifndef __MyInPlaceImageFilter_h
+#define __MyInPlaceImageFilter_h
 
 #include "itkInPlaceImageFilter.h"
 

--- a/src/Developer/MyInPlaceImageFilter.h
+++ b/src/Developer/MyInPlaceImageFilter.h
@@ -14,6 +14,7 @@ public:
   using Self = MyInPlaceImageFilter;
   using Superclass = InPlaceImageFilter<TImage>;
   using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/src/Developer/MyInPlaceImageFilter.hxx
+++ b/src/Developer/MyInPlaceImageFilter.hxx
@@ -1,5 +1,5 @@
-#ifndef __itkMyInPlaceImageFilter_hxx
-#define __itkMyInPlaceImageFilter_hxx
+#ifndef __MyInPlaceImageFilter_hxx
+#define __MyInPlaceImageFilter_hxx
 
 
 #include "itkObjectFactory.h"

--- a/src/Developer/MyInPlaceImageFilter.hxx
+++ b/src/Developer/MyInPlaceImageFilter.hxx
@@ -1,5 +1,5 @@
-#ifndef __MyInPlaceImageFilter_hxx
-#define __MyInPlaceImageFilter_hxx
+#ifndef MyInPlaceImageFilter_hxx
+#define MyInPlaceImageFilter_hxx
 
 
 #include "itkObjectFactory.h"

--- a/src/Developer/MyInPlaceImageFilter.hxx
+++ b/src/Developer/MyInPlaceImageFilter.hxx
@@ -9,7 +9,7 @@
 namespace itk
 {
 
-template <class TImage>
+template <typename TImage>
 void
 MyInPlaceImageFilter<TImage>::GenerateData()
 {

--- a/src/Developer/itkImageFilterMultipleInputs.h
+++ b/src/Developer/itkImageFilterMultipleInputs.h
@@ -14,6 +14,7 @@ public:
   using Self = ImageFilterMultipleInputs;
   using Superclass = ImageToImageFilter<TImage, TImage>;
   using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/src/Developer/itkImageFilterMultipleInputs.h
+++ b/src/Developer/itkImageFilterMultipleInputs.h
@@ -5,7 +5,7 @@
 
 namespace itk
 {
-template <class TImage>
+template <typename TImage>
 class ImageFilterMultipleInputs : public ImageToImageFilter<TImage, TImage>
 {
 public:

--- a/src/Developer/itkImageFilterMultipleInputs.hxx
+++ b/src/Developer/itkImageFilterMultipleInputs.hxx
@@ -9,27 +9,27 @@
 namespace itk
 {
 
-template <class TImage>
+template <typename TImage>
 ImageFilterMultipleInputs<TImage>::ImageFilterMultipleInputs()
 {
   this->SetNumberOfRequiredInputs(2);
 }
 
-template <class TImage>
+template <typename TImage>
 void
 ImageFilterMultipleInputs<TImage>::SetInputImage(const TImage * image)
 {
   this->SetNthInput(0, const_cast<TImage *>(image));
 }
 
-template <class TImage>
+template <typename TImage>
 void
 ImageFilterMultipleInputs<TImage>::SetInputMask(const TImage * mask)
 {
   this->SetNthInput(1, const_cast<TImage *>(mask));
 }
 
-template <class TImage>
+template <typename TImage>
 void
 ImageFilterMultipleInputs<TImage>::GenerateData()
 {

--- a/src/Developer/itkOilPaintingImageFilter.h
+++ b/src/Developer/itkOilPaintingImageFilter.h
@@ -23,6 +23,8 @@ public:
   using Self = OilPaintingImageFilter;
   using Superclass = ImageToImageFilter<TImage, TImage>;
   using Pointer = SmartPointer<Self>;
+  using ConstPointer = SmartPointer<const Self>;
+
   using RadiusType = typename NeighborhoodIterator<TImage>::RadiusType;
 
   /** Method for creation through the object factory. */

--- a/src/Developer/itkOilPaintingImageFilter.h
+++ b/src/Developer/itkOilPaintingImageFilter.h
@@ -1,5 +1,5 @@
-#ifndef __itkOilPaintingImageFilter_h
-#define __itkOilPaintingImageFilter_h
+#ifndef itkOilPaintingImageFilter_h
+#define itkOilPaintingImageFilter_h
 
 #include "itkImageToImageFilter.h"
 #include "itkNeighborhoodIterator.h"
@@ -62,4 +62,4 @@ private:
 #  include "itkOilPaintingImageFilter.hxx"
 #endif
 
-#endif // __itkOilPaintingImageFilter_h
+#endif // itkOilPaintingImageFilter_h

--- a/src/Developer/itkOilPaintingImageFilter.h
+++ b/src/Developer/itkOilPaintingImageFilter.h
@@ -14,7 +14,7 @@ namespace itk
  *
  * \ingroup ImageFilters
  */
-template <class TImage>
+template <typename TImage>
 class OilPaintingImageFilter : public ImageToImageFilter<TImage, TImage>
 {
 public:

--- a/src/Developer/itkOilPaintingImageFilter.hxx
+++ b/src/Developer/itkOilPaintingImageFilter.hxx
@@ -9,14 +9,14 @@
 
 namespace itk
 {
-template <class TImage>
+template <typename TImage>
 OilPaintingImageFilter<TImage>::OilPaintingImageFilter()
 {
   this->m_NumberOfBins = 20;
   this->SetRadius(5);
 }
 
-template <class TImage>
+template <typename TImage>
 void
 OilPaintingImageFilter<TImage>::SetRadius(unsigned int radius)
 {
@@ -26,7 +26,7 @@ OilPaintingImageFilter<TImage>::SetRadius(unsigned int radius)
   }
 }
 
-template <class TImage>
+template <typename TImage>
 void
 OilPaintingImageFilter<TImage>::BeforeThreadedGenerateData()
 {
@@ -38,7 +38,7 @@ OilPaintingImageFilter<TImage>::BeforeThreadedGenerateData()
   m_Minimum = calculatorI->GetMinimum();
 }
 
-template <class TImage>
+template <typename TImage>
 void
 OilPaintingImageFilter<TImage>::DynamicThreadedGenerateData(const typename TImage::RegionType & outputRegionForThread)
 {

--- a/src/Developer/itkOilPaintingImageFilter.hxx
+++ b/src/Developer/itkOilPaintingImageFilter.hxx
@@ -1,5 +1,5 @@
-#ifndef __itkOilPaintingImageFilter_hxx
-#define __itkOilPaintingImageFilter_hxx
+#ifndef itkOilPaintingImageFilter_hxx
+#define itkOilPaintingImageFilter_hxx
 
 #include "itkObjectFactory.h"
 #include "itkImageRegionIterator.h"
@@ -90,4 +90,4 @@ OilPaintingImageFilter<TImage>::DynamicThreadedGenerateData(const typename TImag
 
 } // namespace itk
 
-#endif //__itkOilPaintingImageFilter_hxx
+#endif // itkOilPaintingImageFilter_hxx


### PR DESCRIPTION
- BUG: Include the appropriate implementation file 
- BUG: Fix the class name in the `ImageSource` source files 
- BUG: Inherit `ImageSource` from ProcessObject`
- BUG: Make the include guards match the filenames 
- STYLE: Do not use double underscore defines 
- COMP: Use and move ITK_DISALLOW_COPY_AND_MOVE calls to public section
- STYLE: Move default construtor to .h
- STYLE: Prefer = default to explicitly trivial implementations
- COMP: Mark class destructors with `override`
- STYLE: Use typename instead of class in template definitions 
- ENH: Add `const` smart pointer type alias 