### PR TITLE
BUG: Fix ITKDoxygenXML by copying instead of renaming directory

### DIFF
--- a/CMake/ITKDoxygenXML.cmake
+++ b/CMake/ITKDoxygenXML.cmake
@@ -5,7 +5,7 @@ set( ITKDoxygenXML_TEMP_DIR ${CMAKE_BINARY_DIR}/ITKDoxygenXML-TEMP )
 add_custom_command( OUTPUT ${ITKDoxygenXML_DIR}/index.xml
   COMMAND ${CMAKE_COMMAND} -DITKDoxygenXML_TEMP_DIR="${ITKDoxygenXML_TEMP_DIR}" -P ${ITKSphinxExamples_SOURCE_DIR}/CMake/DownloadDoxygenXML.cmake
   COMMAND ${CMAKE_COMMAND} -E chdir "${ITKDoxygenXML_TEMP_DIR}" ${CMAKE_COMMAND} -E tar xzf "${ITKDoxygenXML_TEMP_DIR}/itk-doxygen-xml.tar.gz"
-  COMMAND ${CMAKE_COMMAND} -E rename "${ITKDoxygenXML_TEMP_DIR}/xml" "${ITKDoxygenXML_DIR}"
+  COMMAND ${CMAKE_COMMAND} -E copy_directory "${ITKDoxygenXML_TEMP_DIR}/xml" "${ITKDoxygenXML_DIR}"
   COMMAND ${CMAKE_COMMAND} -E remove_directory "${ITKDoxygenXML_TEMP_DIR}"
   COMMENT "Downloading and unpacking the Doxygen XML"
   )


### PR DESCRIPTION
Resolves build issue on Windows where directory populated with ITKDoxygenXML archive contents could not be directly renamed, but could be copied and then deleted as a one-time build operation. Temp archive directory is successfully removed in subsequent call to `remove_directory`.