### PR TITLE
BUG: Update paths for Fleek source

### DIFF
--- a/.fleek.json
+++ b/.fleek.json
@@ -1,5 +1,5 @@
 {
   "build": {
-    "publicDir": "./site"
+    "publicDir": "/home/runner/work/site"
   }
 }

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -362,8 +362,8 @@ jobs:
       - name: Unpack site
         shell: bash
         run: |
-          mkdir site
-          tar --strip-components=1 -xf /home/runner/work/bld/ITKEx-build/ITKSphinxExamples-*-html.tar.gz -C site
+          mkdir /home/runner/work/site
+          tar --strip-components=1 -xf /home/runner/work/bld/ITKEx-build/ITKSphinxExamples-*-html.tar.gz -C /home/runner/work/site
 
       - name: Deploy website to Fleek
         uses: fleekhq/action-deploy@v1


### PR DESCRIPTION
Attempts to resolve #335.

Updated code only touches docs publish CI step which only runs in `main` branch. Going to preemptively merge to avoid redundancy.