### PR TITLE
WIP: Debug CI paths with tmate

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -369,6 +369,9 @@ jobs:
           echo "Unpack to ${{ github.workspace }}/site"
           tar --strip-components=1 -xf /home/runner/work/bld/ITKEx-build/ITKSphinxExamples-*-html.tar.gz -C ${{ github.workspace }}/site
 
+      - name: Debug paths in Github Actions with tmate session
+        uses: mxschmitt/action-tmate@v3
+
       - name: Deploy website to Fleek
         uses: fleekhq/action-deploy@v1
         id: deploy


### PR DESCRIPTION
Adding CI step to examine state of Github Actions instance so that we can manually determine paths. Relevant to #337 

I believe I can get paths from the draft PR here.