### PR TITLE
ENH: Adjust site dir for Fleek container reference

### DIFF
--- a/.fleek.json
+++ b/.fleek.json
@@ -1,5 +1,5 @@
 {
   "build": {
-    "publicDir": "/home/runner/work/site"
+    "publicDir": "./site"
   }
 }

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -290,6 +290,8 @@ jobs:
           python -m pip install --ignore-installed six
           python -m pip install ipython
 
+          echo "Workspace: ${{ GITHUB_WORKSPACE }}"
+
       - name: Remove Duplicate Declaration Warnings
         run: |
           SITE_PACKAGES_DIR=$(python3 "-c" "from distutils import sysconfig; print(sysconfig.get_python_lib())")
@@ -362,15 +364,16 @@ jobs:
       - name: Unpack site
         shell: bash
         run: |
-          mkdir /home/runner/work/site
-          tar --strip-components=1 -xf /home/runner/work/bld/ITKEx-build/ITKSphinxExamples-*-html.tar.gz -C /home/runner/work/site
+          mkdir ${{ GITHUB_WORKSPACE }}/site
+          echo "Unpack to ${{ GITHUB_WORKSPACE }}/site"
+          tar --strip-components=1 -xf /home/runner/work/bld/ITKEx-build/ITKSphinxExamples-*-html.tar.gz -C ${{ GITHUB_WORKSPACE }}/site
 
       - name: Deploy website to Fleek
         uses: fleekhq/action-deploy@v1
         id: deploy
         with:
           apiKey: ${{ secrets.FLEEK_API_KEY }}
-          workDir: /home/runner/work/Ex
+          #workDir: /home/runner/work/Ex
         timeout-minutes: 15
 
       - name: Get Fleek output URL


### PR DESCRIPTION
Continuing investigation into Fleek publish path issues.

Unfortunately we can only test Fleek publishing in the main branch. As publishing is currently failing this will not break anything, though it is not guaranteed to fix either. Moving ahead with merge.