### PR TITLE
STYLE: Catch exceptions by _const_ reference

### DIFF
--- a/src/Bridge/VtkGlue/ConvertAnRGBitkImageTovtkImageData/Code.cxx
+++ b/src/Bridge/VtkGlue/ConvertAnRGBitkImageTovtkImageData/Code.cxx
@@ -50,7 +50,7 @@ main(int argc, char * argv[])
   {
     filter->Update();
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Bridge/VtkGlue/ConvertAnitkImageTovtkImageData/Code.cxx
+++ b/src/Bridge/VtkGlue/ConvertAnitkImageTovtkImageData/Code.cxx
@@ -48,7 +48,7 @@ main(int argc, char * argv[])
   {
     filter->Update();
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Bridge/VtkGlue/ConvertRGBvtkImageDataToAnitkImage/Code.cxx
+++ b/src/Bridge/VtkGlue/ConvertRGBvtkImageDataToAnitkImage/Code.cxx
@@ -54,7 +54,7 @@ main(int argc, char * argv[])
     reader->Update();
     filter->Update();
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Bridge/VtkGlue/ConvertvtkImageDataToAnitkImage/Code.cxx
+++ b/src/Bridge/VtkGlue/ConvertvtkImageDataToAnitkImage/Code.cxx
@@ -56,7 +56,7 @@ main(int argc, char * argv[])
   {
     filter->Update();
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Bridge/VtkGlue/VisualizeStaticDense2DLevelSetAsElevationMap/Code.cxx
+++ b/src/Bridge/VtkGlue/VisualizeStaticDense2DLevelSetAsElevationMap/Code.cxx
@@ -93,7 +93,7 @@ main(int argc, char * argv[])
   {
     visualizer->Update();
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Bridge/VtkGlue/VisualizeStaticDense2DLevelSetZeroSet/Code.cxx
+++ b/src/Bridge/VtkGlue/VisualizeStaticDense2DLevelSetZeroSet/Code.cxx
@@ -93,7 +93,7 @@ main(int argc, char * argv[])
   {
     visualizer->Update();
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Bridge/VtkGlue/VisualizeStaticMalcolm2DLevelSetLayers/Code.cxx
+++ b/src/Bridge/VtkGlue/VisualizeStaticMalcolm2DLevelSetLayers/Code.cxx
@@ -84,7 +84,7 @@ main(int argc, char * argv[])
   {
     visualizer->Update();
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Bridge/VtkGlue/VisualizeStaticShi2DLevelSetLayers/Code.cxx
+++ b/src/Bridge/VtkGlue/VisualizeStaticShi2DLevelSetLayers/Code.cxx
@@ -84,7 +84,7 @@ main(int argc, char * argv[])
   {
     visualizer->Update();
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Bridge/VtkGlue/VisualizeStaticWhitaker2DLevelSetLayers/Code.cxx
+++ b/src/Bridge/VtkGlue/VisualizeStaticWhitaker2DLevelSetLayers/Code.cxx
@@ -85,7 +85,7 @@ main(int argc, char * argv[])
   {
     visualizer->Update();
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Core/Common/ImageRegionOverlap/Code.cxx
+++ b/src/Core/Common/ImageRegionOverlap/Code.cxx
@@ -140,7 +140,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(image, out_file_name);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Core/Common/ImportPixelBufferIntoAnImage/Code.cxx
+++ b/src/Core/Common/ImportPixelBufferIntoAnImage/Code.cxx
@@ -110,7 +110,7 @@ main(int argc, char * argv[])
   {
     writer->Update();
   }
-  catch (itk::ExceptionObject & exp)
+  catch (const itk::ExceptionObject & exp)
   {
     std::cerr << "Exception caught !" << std::endl;
     std::cerr << exp << std::endl;

--- a/src/Core/Common/ReRunPipelineWithChangingLargestPossibleRegion/Code.cxx
+++ b/src/Core/Common/ReRunPipelineWithChangingLargestPossibleRegion/Code.cxx
@@ -61,7 +61,7 @@ main(int argc, char * argv[])
     std::cout << largestRegion << std::endl;
     ;
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
@@ -77,7 +77,7 @@ main(int argc, char * argv[])
     reader->SetFileNames(fileNames);
     reader->Update();
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     // Print out the error that occurs
     std::cout << "Error: " << error << std::endl;
@@ -97,7 +97,7 @@ main(int argc, char * argv[])
     std::cout << largestRegion << std::endl;
     ;
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Core/Common/ReadAPointSet/Code.cxx
+++ b/src/Core/Common/ReadAPointSet/Code.cxx
@@ -57,7 +57,7 @@ main(int argc, char * argv[])
   {
     polyDataReader->Update();
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Core/Common/ReadWriteVectorImage/Code.cxx
+++ b/src/Core/Common/ReadWriteVectorImage/Code.cxx
@@ -45,7 +45,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(input, argv[2]);
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cerr << "ExceptionObject caught !" << std::endl;
     std::cerr << err << std::endl;

--- a/src/Core/Common/SetPixelValueInOneImage/Code.cxx
+++ b/src/Core/Common/SetPixelValueInOneImage/Code.cxx
@@ -109,7 +109,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(image, argv[1]);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Core/Common/StreamAPipeline/Code.cxx
+++ b/src/Core/Common/StreamAPipeline/Code.cxx
@@ -56,7 +56,7 @@ main(int argc, char * argv[])
   {
     streamingFilter->Update();
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Core/Common/TryCatchException/Code.cxx
+++ b/src/Core/Common/TryCatchException/Code.cxx
@@ -35,7 +35,7 @@ main(int, char *[])
   {
     reader->Update();
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cerr << "ExceptionObject caught !" << std::endl;
     std::cerr << err << std::endl;

--- a/src/Core/Common/UseParallelizeImageRegion/Code.cxx
+++ b/src/Core/Common/UseParallelizeImageRegion/Code.cxx
@@ -93,7 +93,7 @@ main(int argc, char * argv[])
     OutputImageType::Pointer outImage = segmentationAndCustomColorization(input);
     itk::WriteImage(outImage, argv[2], true); // compression
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Core/ImageFunction/ResampleSegmentedImage/Code.cxx
+++ b/src/Core/ImageFunction/ResampleSegmentedImage/Code.cxx
@@ -101,7 +101,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(resizeFilter->GetOutput(), outputImageFileLabelImageInterpolator, true); // compress
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
@@ -115,7 +115,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(resizeFilter->GetOutput(), outputImageFileNearestNeighborInterpolator, true); // compress
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Core/Mesh/ConvertTriangleMeshToBinaryImage/Code.cxx
+++ b/src/Core/Mesh/ConvertTriangleMeshToBinaryImage/Code.cxx
@@ -72,7 +72,7 @@ main(int argc, char * argv[])
   {
     filter->Update();
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
@@ -82,7 +82,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), outputImageName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Core/Mesh/ExtractIsoSurface/Code.cxx
+++ b/src/Core/Mesh/ExtractIsoSurface/Code.cxx
@@ -71,7 +71,7 @@ main(int argc, char * argv[])
   {
     writer->Update();
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Core/Mesh/TranslateOneMesh/Code.cxx
+++ b/src/Core/Mesh/TranslateOneMesh/Code.cxx
@@ -67,7 +67,7 @@ main(int argc, char * argv[])
   {
     writer->Update();
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Core/QuadEdgeMesh/CreateTriangularQuadEdgeMesh/Code.cxx
+++ b/src/Core/QuadEdgeMesh/CreateTriangularQuadEdgeMesh/Code.cxx
@@ -88,7 +88,7 @@ main(int argc, char * argv[])
   {
     writer->Update();
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Core/QuadEdgeMesh/CutMesh/Code.cxx
+++ b/src/Core/QuadEdgeMesh/CutMesh/Code.cxx
@@ -142,7 +142,7 @@ main(int argc, char * argv[])
   {
     writer->Update();
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     std::cerr << "Error: " << e << std::endl;
     return EXIT_FAILURE;

--- a/src/Core/QuadEdgeMesh/ExtractVertexOnMeshBoundaries/Code.cxx
+++ b/src/Core/QuadEdgeMesh/ExtractVertexOnMeshBoundaries/Code.cxx
@@ -42,7 +42,7 @@ main(int argc, char * argv[])
   {
     reader->Update();
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     std::cerr << e.what() << std::endl;
     return EXIT_FAILURE;

--- a/src/Core/QuadEdgeMesh/GetListOfFacesAroundAGivenVertex/Code.cxx
+++ b/src/Core/QuadEdgeMesh/GetListOfFacesAroundAGivenVertex/Code.cxx
@@ -43,7 +43,7 @@ main(int argc, char * argv[])
   {
     reader->Update();
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     std::cerr << e.what() << std::endl;
     return EXIT_FAILURE;

--- a/src/Core/QuadEdgeMesh/PrintVertexNeighbors/Code.cxx
+++ b/src/Core/QuadEdgeMesh/PrintVertexNeighbors/Code.cxx
@@ -42,7 +42,7 @@ main(int argc, char * argv[])
   {
     reader->Update();
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     std::cerr << e.what() << std::endl;
     return EXIT_FAILURE;

--- a/src/Core/SpatialObjects/ConvertSpatialObjectToImage/Code.cxx
+++ b/src/Core/SpatialObjects/ConvertSpatialObjectToImage/Code.cxx
@@ -92,7 +92,7 @@ main(int argc, char * argv[])
     imageFilter->Update();
     itk::WriteImage(imageFilter->GetOutput(), argv[1], true); // compress
   }
-  catch (itk::ExceptionObject & excp)
+  catch (const itk::ExceptionObject & excp)
   {
     std::cerr << excp << std::endl;
     return EXIT_FAILURE;

--- a/src/Core/SpatialObjects/Ellipse/Code.cxx
+++ b/src/Core/SpatialObjects/Ellipse/Code.cxx
@@ -92,7 +92,7 @@ main(int argc, char * argv[])
     imageFilter->Update();
     itk::WriteImage(imageFilter->GetOutput(), argv[1]);
   }
-  catch (itk::ExceptionObject & excp)
+  catch (const itk::ExceptionObject & excp)
   {
     std::cerr << excp << std::endl;
     return EXIT_FAILURE;

--- a/src/Core/TestKernel/GenerateRandomImage/Code.cxx
+++ b/src/Core/TestKernel/GenerateRandomImage/Code.cxx
@@ -49,7 +49,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(randomImageSource->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Core/Transform/ApplyAffineTransformFromHomogeneousMatrixAndResample/Code.cxx
+++ b/src/Core/Transform/ApplyAffineTransformFromHomogeneousMatrixAndResample/Code.cxx
@@ -100,7 +100,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(resample->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Core/Transform/GlobalRegistrationTwoImagesAffine/Code.cxx
+++ b/src/Core/Transform/GlobalRegistrationTwoImagesAffine/Code.cxx
@@ -126,7 +126,7 @@ main(int, char *[])
   {
     registration->Update();
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cerr << "ExceptionObject caught !" << std::endl;
     std::cerr << err << std::endl;

--- a/src/Core/Transform/GlobalRegistrationTwoImagesBSpline/Code.cxx
+++ b/src/Core/Transform/GlobalRegistrationTwoImagesBSpline/Code.cxx
@@ -146,7 +146,7 @@ main(int itkNotUsed(argc), char * itkNotUsed(argv)[])
     std::cout << "Optimizer stop condition = " << registration->GetOptimizer()->GetStopConditionDescription()
               << std::endl;
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cerr << "ExceptionObject caught !" << std::endl;
     std::cerr << err << std::endl;
@@ -186,7 +186,7 @@ main(int itkNotUsed(argc), char * itkNotUsed(argv)[])
   {
     itk::WriteImage(caster->GetOutput(), "output.png");
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cerr << "ExceptionObject caught !" << std::endl;
     std::cerr << err << std::endl;

--- a/src/Core/Transform/MutualInformationAffine/Code.cxx
+++ b/src/Core/Transform/MutualInformationAffine/Code.cxx
@@ -208,7 +208,7 @@ main(int argc, char * argv[])
     std::cout << "Optimizer stop condition: " << registration->GetOptimizer()->GetStopConditionDescription()
               << std::endl;
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cout << "ExceptionObject caught !" << std::endl;
     std::cout << err << std::endl;

--- a/src/Core/Transform/TranslateImage/Code.cxx
+++ b/src/Core/Transform/TranslateImage/Code.cxx
@@ -62,7 +62,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(resampleFilter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/AnisotropicSmoothing/ComputeCurvatureAnisotropicDiffusion/Code.cxx
+++ b/src/Filtering/AnisotropicSmoothing/ComputeCurvatureAnisotropicDiffusion/Code.cxx
@@ -67,7 +67,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(rescaler->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/AnisotropicSmoothing/ComputeCurvatureFlow/Code.cxx
+++ b/src/Filtering/AnisotropicSmoothing/ComputeCurvatureFlow/Code.cxx
@@ -65,7 +65,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(rescaler->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/AnisotropicSmoothing/ComputeGradientAnisotropicDiffusion/Code.cxx
+++ b/src/Filtering/AnisotropicSmoothing/ComputeGradientAnisotropicDiffusion/Code.cxx
@@ -67,7 +67,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(rescaler->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/AnisotropicSmoothing/ComputePeronaMalikAnisotropicDiffusion/Code.cxx
+++ b/src/Filtering/AnisotropicSmoothing/ComputePeronaMalikAnisotropicDiffusion/Code.cxx
@@ -55,7 +55,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), argv[2]);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/AntiAlias/SmoothBinaryImageBeforeSurfaceExtraction/Code.cxx
+++ b/src/Filtering/AntiAlias/SmoothBinaryImageBeforeSurfaceExtraction/Code.cxx
@@ -68,7 +68,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/BinaryMathematicalMorphology/DilateABinaryImage/Code.cxx
+++ b/src/Filtering/BinaryMathematicalMorphology/DilateABinaryImage/Code.cxx
@@ -58,7 +58,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(dilateFilter->GetOutput(), outputImage);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/BinaryMathematicalMorphology/ErodeABinaryImage/Code.cxx
+++ b/src/Filtering/BinaryMathematicalMorphology/ErodeABinaryImage/Code.cxx
@@ -59,7 +59,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(erodeFilter->GetOutput(), outputImage);
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     std::cerr << "Error: " << e << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/Colormap/ApplyAColormapToAnImage/Code.cxx
+++ b/src/Filtering/Colormap/ApplyAColormapToAnImage/Code.cxx
@@ -54,7 +54,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(rgbfilter->GetOutput(), argv[2]);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/Colormap/CreateACustomColormap/Code.cxx
+++ b/src/Filtering/Colormap/CreateACustomColormap/Code.cxx
@@ -82,7 +82,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(colormapFilter1->GetOutput(), argv[2]);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/FFT/ComputeForwardFFT/Code.cxx
+++ b/src/Filtering/FFT/ComputeForwardFFT/Code.cxx
@@ -86,7 +86,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(realRescaleFilter->GetOutput(), realFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
@@ -106,7 +106,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(imaginaryRescaleFilter->GetOutput(), imaginaryFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
@@ -126,7 +126,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(magnitudeRescaleFilter->GetOutput(), modulusFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/FFT/ComputeImageSpectralDensity/Code.cxx
+++ b/src/Filtering/FFT/ComputeImageSpectralDensity/Code.cxx
@@ -84,7 +84,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(fftShiftFilter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/FFT/FilterImageInFourierDomain/Code.cxx
+++ b/src/Filtering/FFT/FilterImageInFourierDomain/Code.cxx
@@ -74,7 +74,7 @@ main(int argc, char * argv[])
   {
     forwardFFTFilter->UpdateOutputInformation();
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
@@ -124,7 +124,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(inverseFFTFilter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/FastMarching/ComputeGeodesicDistanceOnMesh/Code.cxx
+++ b/src/Filtering/FastMarching/ComputeGeodesicDistanceOnMesh/Code.cxx
@@ -94,7 +94,7 @@ main(int argc, char * argv[])
   {
     writer->Update();
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/FastMarching/CreateDistanceMapFromSeeds/Code.cxx
+++ b/src/Filtering/FastMarching/CreateDistanceMapFromSeeds/Code.cxx
@@ -120,7 +120,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(marcher->GetOutput(), argv[1]);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageCompare/CombineTwoImagesWithCheckerBoardPattern/Code.cxx
+++ b/src/Filtering/ImageCompare/CombineTwoImagesWithCheckerBoardPattern/Code.cxx
@@ -64,7 +64,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(checkerBoardFilter->GetOutput(), argv[1]);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageFeature/AdditiveGaussianNoiseImageFilter/Code.cxx
+++ b/src/Filtering/ImageFeature/AdditiveGaussianNoiseImageFilter/Code.cxx
@@ -60,7 +60,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), outputImage);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageFeature/ComputeLaplacian/Code.cxx
+++ b/src/Filtering/ImageFeature/ComputeLaplacian/Code.cxx
@@ -59,7 +59,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(rescaler->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageFeature/DetectEdgesWithCannyEdgeDetectionFilter/Code.cxx
+++ b/src/Filtering/ImageFeature/DetectEdgesWithCannyEdgeDetectionFilter/Code.cxx
@@ -67,7 +67,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(rescaler->GetOutput(), outputImage);
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     std::cerr << "Error: " << e << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageFeature/LaplacianRecursiveGaussianImageFilter/Code.cxx
+++ b/src/Filtering/ImageFeature/LaplacianRecursiveGaussianImageFilter/Code.cxx
@@ -52,7 +52,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), argv[2]);
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     std::cerr << "Error: " << e << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageFeature/SegmentBloodVessels/Code.cxx
+++ b/src/Filtering/ImageFeature/SegmentBloodVessels/Code.cxx
@@ -68,7 +68,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(vesselnessFilter->GetOutput(), outputImage);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageFeature/SobelEdgeDetectionImageFilter/Code.cxx
+++ b/src/Filtering/ImageFeature/SobelEdgeDetectionImageFilter/Code.cxx
@@ -51,7 +51,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), argv[2]);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageFilterBase/CastAnImageToAnotherType/Code.cxx
+++ b/src/Filtering/ImageFilterBase/CastAnImageToAnotherType/Code.cxx
@@ -60,7 +60,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), outputImage);
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     std::cerr << "Error: " << e << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageFusion/OverlayLabelMapOnTopOfAnImage/Code.cxx
+++ b/src/Filtering/ImageFusion/OverlayLabelMapOnTopOfAnImage/Code.cxx
@@ -65,7 +65,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageGradient/ApplyGradientRecursiveGaussian/Code.cxx
+++ b/src/Filtering/ImageGradient/ApplyGradientRecursiveGaussian/Code.cxx
@@ -86,7 +86,7 @@ main(int argc, char * argv[])
     {
       itk::WriteImage(rescaler->GetOutput(), filenames[i]);
     }
-    catch (itk::ExceptionObject & error)
+    catch (const itk::ExceptionObject & error)
     {
       std::cerr << "Error: " << error << std::endl;
       return EXIT_FAILURE;
@@ -105,7 +105,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(rescaler->GetOutput(), outputFileNameMagnitude);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageGradient/ApplyGradientRecursiveGaussianWithVectorInput/Code.cxx
+++ b/src/Filtering/ImageGradient/ApplyGradientRecursiveGaussianWithVectorInput/Code.cxx
@@ -113,7 +113,7 @@ main(int argc, char * argv[])
     {
       itk::WriteImage(rescaler->GetOutput(), filenames[i]);
     }
-    catch (itk::ExceptionObject & error)
+    catch (const itk::ExceptionObject & error)
     {
       std::cerr << "Error: " << error << std::endl;
       return EXIT_FAILURE;

--- a/src/Filtering/ImageGradient/ComputeGradientMagnitude/Code.cxx
+++ b/src/Filtering/ImageGradient/ComputeGradientMagnitude/Code.cxx
@@ -55,7 +55,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(gradientFilter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageGradient/ComputeGradientMagnitudeRecursiveGaussian/Code.cxx
+++ b/src/Filtering/ImageGradient/ComputeGradientMagnitudeRecursiveGaussian/Code.cxx
@@ -51,7 +51,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), outputImage);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageGradient/ImplementationOfSnakes/Code.cxx
+++ b/src/Filtering/ImageGradient/ImplementationOfSnakes/Code.cxx
@@ -75,7 +75,7 @@ main(int argc, char * argv[])
       w = image->GetLargestPossibleRegion().GetSize()[0];
       h = image->GetLargestPossibleRegion().GetSize()[1];
     }
-    catch (itk::ExceptionObject & err)
+    catch (const itk::ExceptionObject & err)
     {
       std::cerr << "Caught unexpected exception " << err;
       return EXIT_FAILURE;

--- a/src/Filtering/ImageGrid/AppendTwo3DVolumes/Code.cxx
+++ b/src/Filtering/ImageGrid/AppendTwo3DVolumes/Code.cxx
@@ -57,7 +57,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(tileFilter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageGrid/ChangeImageOriginSpacingOrDirection/Code.cxx
+++ b/src/Filtering/ImageGrid/ChangeImageOriginSpacingOrDirection/Code.cxx
@@ -71,7 +71,7 @@ main(int argc, char * argv[])
   {
     reader->UpdateOutputInformation();
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
@@ -108,7 +108,7 @@ main(int argc, char * argv[])
   {
     filter->UpdateOutputInformation();
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageGrid/Create3DVolume/Code.cxx
+++ b/src/Filtering/ImageGrid/Create3DVolume/Code.cxx
@@ -58,7 +58,7 @@ main(int argc, char * argv[])
     {
       input = itk::ReadImage<InputImageType>(argv[ii]);
     }
-    catch (itk::ExceptionObject & e)
+    catch (const itk::ExceptionObject & e)
     {
       std::cerr << e << std::endl;
       return EXIT_FAILURE;
@@ -75,7 +75,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), argv[argc - 1]);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageGrid/ExtractRegionOfInterestInOneImage/Code.cxx
+++ b/src/Filtering/ImageGrid/ExtractRegionOfInterestInOneImage/Code.cxx
@@ -70,7 +70,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageGrid/FlipAnImageOverSpecifiedAxes/Code.cxx
+++ b/src/Filtering/ImageGrid/FlipAnImageOverSpecifiedAxes/Code.cxx
@@ -62,7 +62,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(flipFilter->GetOutput(), argv[2]);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageGrid/PadAnImageByMirroring/Code.cxx
+++ b/src/Filtering/ImageGrid/PadAnImageByMirroring/Code.cxx
@@ -58,7 +58,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), argv[2]);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageGrid/PadAnImageWithAConstant/Code.cxx
+++ b/src/Filtering/ImageGrid/PadAnImageWithAConstant/Code.cxx
@@ -58,7 +58,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), argv[2]);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageGrid/PasteImageIntoAnotherOne/Code.cxx
+++ b/src/Filtering/ImageGrid/PasteImageIntoAnotherOne/Code.cxx
@@ -62,7 +62,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageGrid/PermuteAxesOfAnImage/Code.cxx
+++ b/src/Filtering/ImageGrid/PermuteAxesOfAnImage/Code.cxx
@@ -56,7 +56,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageGrid/ProcessA2DSliceOfA3DImage/Code.cxx
+++ b/src/Filtering/ImageGrid/ProcessA2DSliceOfA3DImage/Code.cxx
@@ -46,7 +46,7 @@ main(int argc, char ** argv)
   {
     inputImage = itk::ReadImage<ImageType>(inputFileName);
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cerr << "ExceptionObject caught !" << std::endl;
     std::cerr << err << std::endl;
@@ -92,7 +92,7 @@ main(int argc, char ** argv)
   {
     itk::WriteImage(pasteFilter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cerr << "ExceptionObject caught !" << std::endl;
     std::cerr << err << std::endl;

--- a/src/Filtering/ImageGrid/ResampleAScalarImage/Code.cxx
+++ b/src/Filtering/ImageGrid/ResampleAScalarImage/Code.cxx
@@ -81,7 +81,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageGrid/ResampleAVectorImage/Code.cxx
+++ b/src/Filtering/ImageGrid/ResampleAVectorImage/Code.cxx
@@ -93,7 +93,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageGrid/ResampleAnImage/Code.cxx
+++ b/src/Filtering/ImageGrid/ResampleAnImage/Code.cxx
@@ -103,7 +103,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(resampleFilter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageGrid/Stack2DImagesInto3DImage/Code.cxx
+++ b/src/Filtering/ImageGrid/Stack2DImagesInto3DImage/Code.cxx
@@ -77,7 +77,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(tiler->GetOutput(), argv[argc - 1]);
   }
-  catch (itk::ExceptionObject & excp)
+  catch (const itk::ExceptionObject & excp)
   {
     std::cerr << excp << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageGrid/WarpAnImageUsingADeformationField/Code.cxx
+++ b/src/Filtering/ImageGrid/WarpAnImageUsingADeformationField/Code.cxx
@@ -71,7 +71,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageIntensity/ApplyAtanImageFilter/Code.cxx
+++ b/src/Filtering/ImageIntensity/ApplyAtanImageFilter/Code.cxx
@@ -58,7 +58,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), argv[1]);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageIntensity/ApplyCosImageFilter/Code.cxx
+++ b/src/Filtering/ImageIntensity/ApplyCosImageFilter/Code.cxx
@@ -51,7 +51,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageIntensity/ApplyExpNegativeImageFilter/Code.cxx
+++ b/src/Filtering/ImageIntensity/ApplyExpNegativeImageFilter/Code.cxx
@@ -51,7 +51,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageIntensity/ApplySinImageFilter/Code.cxx
+++ b/src/Filtering/ImageIntensity/ApplySinImageFilter/Code.cxx
@@ -51,7 +51,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageIntensity/ComputeSigmoid/Code.cxx
+++ b/src/Filtering/ImageIntensity/ComputeSigmoid/Code.cxx
@@ -61,7 +61,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(sigmoidFilter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageIntensity/ConvertRGBImageToGrayscaleImage/Code.cxx
+++ b/src/Filtering/ImageIntensity/ConvertRGBImageToGrayscaleImage/Code.cxx
@@ -52,7 +52,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), argv[2]);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageIntensity/MultiplyImageByScalar/Code.cxx
+++ b/src/Filtering/ImageIntensity/MultiplyImageByScalar/Code.cxx
@@ -54,7 +54,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageIntensity/MultiplyTwoImages/Code.cxx
+++ b/src/Filtering/ImageIntensity/MultiplyTwoImages/Code.cxx
@@ -56,7 +56,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageIntensity/RescaleIntensity/Code.cxx
+++ b/src/Filtering/ImageIntensity/RescaleIntensity/Code.cxx
@@ -50,7 +50,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), argv[2]);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/ImageStatistics/ApplyAccumulateImageFilter/Code.cxx
+++ b/src/Filtering/ImageStatistics/ApplyAccumulateImageFilter/Code.cxx
@@ -55,7 +55,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/LabelMap/ApplyMorphologicalClosingOnAllLabelObjects/Code.cxx
+++ b/src/Filtering/LabelMap/ApplyMorphologicalClosingOnAllLabelObjects/Code.cxx
@@ -84,7 +84,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(labelImageConverter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/LabelMap/ApplyMorphologicalClosingOnSpecificLabelObject/Code.cxx
+++ b/src/Filtering/LabelMap/ApplyMorphologicalClosingOnSpecificLabelObject/Code.cxx
@@ -98,7 +98,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(labelImageConverter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/LabelMap/ExtractGivenLabelObject/Code.cxx
+++ b/src/Filtering/LabelMap/ExtractGivenLabelObject/Code.cxx
@@ -72,7 +72,7 @@ main(int argc, char * argv[])
     {
       itk::WriteImage(labelImageConverter->GetOutput(), outputFileName[i]);
     }
-    catch (itk::ExceptionObject & error)
+    catch (const itk::ExceptionObject & error)
     {
       std::cerr << "Error: " << error << std::endl;
       return EXIT_FAILURE;

--- a/src/Filtering/LabelMap/MaskOneImageGivenLabelMap/Code.cxx
+++ b/src/Filtering/LabelMap/MaskOneImageGivenLabelMap/Code.cxx
@@ -101,7 +101,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/LabelMap/RemoveHolesNotConnectedToImageBoundaries/Code.cxx
+++ b/src/Filtering/LabelMap/RemoveHolesNotConnectedToImageBoundaries/Code.cxx
@@ -51,7 +51,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/MathematicalMorphology/DilateAGrayscaleImage/Code.cxx
+++ b/src/Filtering/MathematicalMorphology/DilateAGrayscaleImage/Code.cxx
@@ -58,7 +58,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(dilateFilter->GetOutput(), outputImage);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/MathematicalMorphology/ErodeAGrayscaleImage/Code.cxx
+++ b/src/Filtering/MathematicalMorphology/ErodeAGrayscaleImage/Code.cxx
@@ -58,7 +58,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(erodeFilter->GetOutput(), outputImage);
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     std::cerr << "Error: " << e << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/QuadEdgeMeshFiltering/CleanQuadEdgeMesh/Code.cxx
+++ b/src/Filtering/QuadEdgeMeshFiltering/CleanQuadEdgeMesh/Code.cxx
@@ -64,7 +64,7 @@ main(int argc, char * argv[])
   {
     writer->Update();
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/QuadEdgeMeshFiltering/ComputePlanarParameterizationOfAMesh/Code.cxx
+++ b/src/Filtering/QuadEdgeMeshFiltering/ComputePlanarParameterizationOfAMesh/Code.cxx
@@ -132,7 +132,7 @@ main(int argc, char * argv[])
   {
     writer->Update();
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/QuadEdgeMeshFiltering/DelaunayConformEdgeFlipping/Code.cxx
+++ b/src/Filtering/QuadEdgeMeshFiltering/DelaunayConformEdgeFlipping/Code.cxx
@@ -60,7 +60,7 @@ main(int argc, char * argv[])
   {
     writer->Update();
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/Smoothing/ComputesSmoothingWithGaussianKernel/Code.cxx
+++ b/src/Filtering/Smoothing/ComputesSmoothingWithGaussianKernel/Code.cxx
@@ -52,7 +52,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(smoothFilter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/Smoothing/MeanFilteringOfAnImage/Code.cxx
+++ b/src/Filtering/Smoothing/MeanFilteringOfAnImage/Code.cxx
@@ -55,7 +55,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(meanFilter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/Smoothing/MedianFilteringOfAnImage/Code.cxx
+++ b/src/Filtering/Smoothing/MedianFilteringOfAnImage/Code.cxx
@@ -55,7 +55,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(medianFilter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/Smoothing/MedianFilteringOfAnRGBImage/Code.cxx
+++ b/src/Filtering/Smoothing/MedianFilteringOfAnRGBImage/Code.cxx
@@ -93,7 +93,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(cast->GetOutput(), argv[2]);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/Thresholding/ThresholdAnImage/Code.cxx
+++ b/src/Filtering/Thresholding/ThresholdAnImage/Code.cxx
@@ -55,7 +55,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/Thresholding/ThresholdAnImageUsingBinary/Code.cxx
+++ b/src/Filtering/Thresholding/ThresholdAnImageUsingBinary/Code.cxx
@@ -60,7 +60,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), OutputImage);
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     std::cerr << "Error: " << e << std::endl;
     return EXIT_FAILURE;

--- a/src/Filtering/Thresholding/ThresholdAnImageUsingOtsu/Code.cxx
+++ b/src/Filtering/Thresholding/ThresholdAnImageUsingOtsu/Code.cxx
@@ -76,7 +76,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(rescaler->GetOutput(), OutputImage);
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     std::cerr << "Error: " << e << std::endl;
     return EXIT_FAILURE;

--- a/src/IO/GDCM/ReadAndPrintDICOMTags/Code.cxx
+++ b/src/IO/GDCM/ReadAndPrintDICOMTags/Code.cxx
@@ -79,7 +79,7 @@ main(int argc, char * argv[])
   {
     reader->Update();
   }
-  catch (itk::ExceptionObject & ex)
+  catch (const itk::ExceptionObject & ex)
   {
     std::cout << ex << std::endl;
     return EXIT_FAILURE;

--- a/src/IO/GDCM/ReadDICOMSeriesAndWrite3DImage/Code.cxx
+++ b/src/IO/GDCM/ReadDICOMSeriesAndWrite3DImage/Code.cxx
@@ -116,14 +116,14 @@ main(int argc, char * argv[])
       {
         itk::WriteImage(reader->GetOutput(), outFileName, true); // compression
       }
-      catch (itk::ExceptionObject & ex)
+      catch (const itk::ExceptionObject & ex)
       {
         std::cout << ex << std::endl;
         continue;
       }
     }
   }
-  catch (itk::ExceptionObject & ex)
+  catch (const itk::ExceptionObject & ex)
   {
     std::cout << ex << std::endl;
     return EXIT_FAILURE;

--- a/src/IO/GDCM/ResampleDICOMSeries/Code.cxx
+++ b/src/IO/GDCM/ResampleDICOMSeries/Code.cxx
@@ -110,7 +110,7 @@ main(int argc, char * argv[])
   {
     reader->Update();
   }
-  catch (itk::ExceptionObject & excp)
+  catch (const itk::ExceptionObject & excp)
   {
     std::cerr << "Exception thrown while reading the series" << std::endl;
     std::cerr << excp << std::endl;
@@ -338,7 +338,7 @@ main(int argc, char * argv[])
   {
     seriesWriter->Update();
   }
-  catch (itk::ExceptionObject & excp)
+  catch (const itk::ExceptionObject & excp)
   {
     std::cerr << "Exception thrown while writing the series " << std::endl;
     std::cerr << excp << std::endl;

--- a/src/IO/ImageBase/ConvertFileFormats/Code.cxx
+++ b/src/IO/ImageBase/ConvertFileFormats/Code.cxx
@@ -42,7 +42,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(input, argv[2]);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/IO/ImageBase/Create3DFromSeriesOf2D/Code.cxx
+++ b/src/IO/ImageBase/Create3DFromSeriesOf2D/Code.cxx
@@ -69,7 +69,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(reader->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cerr << "ExceptionObject caught !" << std::endl;
     std::cerr << err << std::endl;

--- a/src/IO/ImageBase/GenerateSlicesFromVolume/Code.cxx
+++ b/src/IO/ImageBase/GenerateSlicesFromVolume/Code.cxx
@@ -76,7 +76,7 @@ main(int argc, char * argv[])
   {
     writer->Update();
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/IO/ImageBase/ProcessImageChunks/Code.cxx
+++ b/src/IO/ImageBase/ProcessImageChunks/Code.cxx
@@ -118,7 +118,7 @@ main(int argc, char * argv[])
         {
           writer->Update();
         }
-        catch (itk::ExceptionObject & error)
+        catch (const itk::ExceptionObject & error)
         {
           std::cerr << "Exception for chunk: " << x << ' ' << y << ' ' << z << error << std::endl;
           return EXIT_FAILURE;

--- a/src/IO/ImageBase/ReadUnknownImageType/Code.cxx
+++ b/src/IO/ImageBase/ReadUnknownImageType/Code.cxx
@@ -33,7 +33,7 @@ ReadImage(const char * fileName, typename TImage::Pointer image)
   {
     reader->Update();
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     std::cerr << e.what() << std::endl;
     return EXIT_FAILURE;

--- a/src/IO/ImageBase/RegisterIOFactories/Code.cxx
+++ b/src/IO/ImageBase/RegisterIOFactories/Code.cxx
@@ -58,7 +58,7 @@ main(int argc, char * argv[])
   {
     reader->Update();
   }
-  catch (itk::ImageFileReaderException &)
+  catch (const itk::ImageFileReaderException &)
   {
     std::cout << "fail.\n" << std::endl;
   }
@@ -77,7 +77,7 @@ main(int argc, char * argv[])
     reader->Update();
     std::cout << "succeed.\n" << std::endl;
   }
-  catch (itk::ImageFileReaderException & error)
+  catch (const itk::ImageFileReaderException & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
@@ -92,7 +92,7 @@ main(int argc, char * argv[])
   {
     reader->Update();
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/IO/ImageBase/WriteAnImage/Code.cxx
+++ b/src/IO/ImageBase/WriteAnImage/Code.cxx
@@ -68,7 +68,7 @@ main(int argc, char * argv[])
   {
     writer->Update();
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/IO/TIFF/WriteATIFFImage/Code.cxx
+++ b/src/IO/TIFF/WriteATIFFImage/Code.cxx
@@ -85,7 +85,7 @@ main(int argc, char * argv[])
   {
     writer->Update();
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/ImageCompareCommand.cxx
+++ b/src/ImageCompareCommand.cxx
@@ -201,7 +201,7 @@ main(int argc, char ** argv)
                           toleranceNumberOfPixels);
     }
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     std::cerr << "ITK test driver caught an ITK exception:\n";
     std::cerr << e << "\n";
@@ -246,7 +246,7 @@ RegressionTestImage(const char * testImageFilename,
   {
     baselineReader->UpdateLargestPossibleRegion();
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     std::cerr << "Exception detected while reading " << baselineImageFilename << " : " << e;
     return 1000;
@@ -259,7 +259,7 @@ RegressionTestImage(const char * testImageFilename,
   {
     testReader->UpdateLargestPossibleRegion();
   }
-  catch (itk::ExceptionObject & e)
+  catch (const itk::ExceptionObject & e)
   {
     std::cerr << "Exception detected while reading " << testImageFilename << " : " << e << std::endl;
     return 1000;

--- a/src/Nonunit/Review/MultiphaseChanAndVeseSparseFieldLevelSetSegmentation/Code.cxx
+++ b/src/Nonunit/Review/MultiphaseChanAndVeseSparseFieldLevelSetSegmentation/Code.cxx
@@ -110,7 +110,7 @@ main(int argc, char ** argv)
   {
     itk::WriteImage(levelSetFilter->GetOutput(), argv[5]);
   }
-  catch (itk::ExceptionObject & excep)
+  catch (const itk::ExceptionObject & excep)
   {
     std::cerr << "Exception caught !" << std::endl;
     std::cerr << excep << std::endl;

--- a/src/Nonunit/Review/SegmentBloodVesselsWithMultiScaleHessianBasedMeasure/Code.cxx
+++ b/src/Nonunit/Review/SegmentBloodVesselsWithMultiScaleHessianBasedMeasure/Code.cxx
@@ -90,7 +90,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(rescaleFilter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Nonunit/Review/SinglephaseChanAndVeseDenseFieldLevelSetSegmentation/Code.cxx
+++ b/src/Nonunit/Review/SinglephaseChanAndVeseDenseFieldLevelSetSegmentation/Code.cxx
@@ -231,7 +231,7 @@ main(int argc, char ** argv)
   {
     itk::WriteImage(levelSetFilter->GetOutput(), argv[1]);
   }
-  catch (itk::ExceptionObject & excep)
+  catch (const itk::ExceptionObject & excep)
   {
     std::cerr << "Exception caught !" << std::endl;
     std::cerr << excep << std::endl;

--- a/src/Nonunit/Review/SinglephaseChanAndVeseSparseFieldLevelSetSegmentation/Code.cxx
+++ b/src/Nonunit/Review/SinglephaseChanAndVeseSparseFieldLevelSetSegmentation/Code.cxx
@@ -229,7 +229,7 @@ main(int argc, char ** argv)
   {
     itk::WriteImage(levelSetFilter->GetOutput(), argv[2]);
   }
-  catch (itk::ExceptionObject & excep)
+  catch (const itk::ExceptionObject & excep)
   {
     std::cerr << "Exception caught !" << std::endl;
     std::cerr << excep << std::endl;

--- a/src/Numerics/Optimizers/ExhaustiveOptimizer/Code.cxx
+++ b/src/Numerics/Optimizers/ExhaustiveOptimizer/Code.cxx
@@ -131,7 +131,7 @@ main(int argc, char * argv[])
     std::cout << "  MaximumMetricValuePosition: " << optimizer->GetMaximumMetricValuePosition() << std::endl;
     std::cout << "  StopConditionDescription: " << optimizer->GetStopConditionDescription() << std::endl;
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cerr << "ExceptionObject caught !" << std::endl;
     std::cerr << err << std::endl;

--- a/src/Numerics/Statistics/ComputeHistogramFromGrayscaleImage/Code.cxx
+++ b/src/Numerics/Statistics/ComputeHistogramFromGrayscaleImage/Code.cxx
@@ -60,7 +60,7 @@ main(int argc, char * argv[])
   {
     imageToHistogramFilter->Update();
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Registration/Common/GlobalRegistrationOfTwoImages/Code.cxx
+++ b/src/Registration/Common/GlobalRegistrationOfTwoImages/Code.cxx
@@ -115,7 +115,7 @@ main(int, char *[])
   {
     registration->Update();
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cerr << "ExceptionObject caught !" << std::endl;
     std::cerr << err << std::endl;

--- a/src/Registration/Common/MutualInformation/Code.cxx
+++ b/src/Registration/Common/MutualInformation/Code.cxx
@@ -188,7 +188,7 @@ main(int argc, char * argv[])
     std::cout << "Optimizer stop condition: " << registration->GetOptimizer()->GetStopConditionDescription()
               << std::endl;
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cout << "ExceptionObject caught !" << std::endl;
     std::cout << err << std::endl;

--- a/src/Registration/Common/Perform2DTranslationRegistrationWithMeanSquares/Code.cxx
+++ b/src/Registration/Common/Perform2DTranslationRegistrationWithMeanSquares/Code.cxx
@@ -110,7 +110,7 @@ main(int argc, char * argv[])
     std::cout << "Optimizer stop condition: " << registration->GetOptimizer()->GetStopConditionDescription()
               << std::endl;
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cerr << "ExceptionObject caught !" << std::endl;
     std::cerr << err << std::endl;

--- a/src/Registration/Common/PerformMultiModalityRegistrationWithMutualInformation/Code.cxx
+++ b/src/Registration/Common/PerformMultiModalityRegistrationWithMutualInformation/Code.cxx
@@ -268,7 +268,7 @@ main(int argc, char * argv[])
     std::cout << "Optimizer stop condition: " << registration->GetOptimizer()->GetStopConditionDescription()
               << std::endl;
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cout << "ExceptionObject caught !" << std::endl;
     std::cout << err << std::endl;

--- a/src/Registration/Common/WatchRegistration/Code.cxx
+++ b/src/Registration/Common/WatchRegistration/Code.cxx
@@ -311,7 +311,7 @@ main(int argc, char * argv[])
     std::cout << "Optimizer stop condition: " << registration->GetOptimizer()->GetStopConditionDescription()
               << std::endl;
   }
-  catch (itk::ExceptionObject & err)
+  catch (const itk::ExceptionObject & err)
   {
     std::cout << "ExceptionObject caught !" << std::endl;
     std::cout << err << std::endl;

--- a/src/Registration/Metricsv4/PerformRegistrationOnVectorImages/Code.cxx
+++ b/src/Registration/Metricsv4/PerformRegistrationOnVectorImages/Code.cxx
@@ -193,7 +193,7 @@ main(int argc, char * argv[])
       std::cout << "*** Skipping displacement field optimization.\n";
     }
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
@@ -218,7 +218,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(caster->GetOutput(), resampledMovingImageFile);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Segmentation/Classifiers/KMeansClustering/Code.cxx
+++ b/src/Segmentation/Classifiers/KMeansClustering/Code.cxx
@@ -91,7 +91,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(kmeansFilter->GetOutput(), outputImageFileName);
   }
-  catch (itk::ExceptionObject & excp)
+  catch (const itk::ExceptionObject & excp)
   {
     std::cerr << "Problem encountered while writing ";
     std::cerr << " image file : " << outputImageFileName << std::endl;

--- a/src/Segmentation/ConnectedComponents/LabelConnectComponentsInBinaryImage/Code.cxx
+++ b/src/Segmentation/ConnectedComponents/LabelConnectComponentsInBinaryImage/Code.cxx
@@ -109,7 +109,7 @@ main(int argc, char * argv[])
     {
       (*it).second->Update();
     }
-    catch (itk::ExceptionObject & err)
+    catch (const itk::ExceptionObject & err)
     {
       std::cout << "Caught exception" << std::endl;
       std::cout << err << std::endl;

--- a/src/Segmentation/LabelVoting/IterativeHoleFilling/Code.cxx
+++ b/src/Segmentation/LabelVoting/IterativeHoleFilling/Code.cxx
@@ -62,7 +62,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(filter->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Segmentation/LevelSets/SegmentWithGeodesicActiveContourLevelSet/Code.cxx
+++ b/src/Segmentation/LevelSets/SegmentWithGeodesicActiveContourLevelSet/Code.cxx
@@ -155,7 +155,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(thresholder->GetOutput(), outputFileName);
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
@@ -172,7 +172,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(caster4->GetOutput(), "GeodesicActiveContourImageFilterOutput4.png");
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
@@ -182,7 +182,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(fastMarching->GetOutput(), "GeodesicActiveContourImageFilterOutput4.mha");
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
@@ -192,7 +192,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(sigmoid->GetOutput(), "GeodesicActiveContourImageFilterOutput3.mha");
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;
@@ -202,7 +202,7 @@ main(int argc, char * argv[])
   {
     itk::WriteImage(gradientMagnitude->GetOutput(), "GeodesicActiveContourImageFilterOutput2.mha");
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;

--- a/src/Video/BridgeOpenCV/ConvertAnITKGrayScaleImageToCVMat/Code.cxx
+++ b/src/Video/BridgeOpenCV/ConvertAnITKGrayScaleImageToCVMat/Code.cxx
@@ -49,7 +49,7 @@ main(int argc, char * argv[])
   {
     reader->Update();
   }
-  catch (itk::ExceptionObject & error)
+  catch (const itk::ExceptionObject & error)
   {
     std::cerr << "Error: " << error << std::endl;
     return EXIT_FAILURE;


### PR DESCRIPTION
Replaced `catch \((\S+) &` & with `catch \(const $1 &`, using Notepad++ v8.3.3,
Find in Files, Search Mode: Regular expression.

Follow-up to ITK pull request https://github.com/InsightSoftwareConsortium/ITK/pull/3419
commit https://github.com/InsightSoftwareConsortium/ITK/commit/f222a5e06bb0ebf3e74c84e6e5e1c7dea7a25a05
(merged on May 11, 2022)

Triggered by the discussion starting at https://github.com/InsightSoftwareConsortium/ITK/pull/3339#discussion_r867977397