### PR TITLE
BUG: Use Doxygen 5.2.0 archives rather than nightly

### DIFF
--- a/CMake/DownloadDoxygen.cmake
+++ b/CMake/DownloadDoxygen.cmake
@@ -1,3 +1,3 @@
-file( DOWNLOAD https://public.kitware.com/pub/itk/NightlyDoxygen/InsightDoxygenDocHtml.tar.gz
-  ${ITKDoxygen_TEMP_DIR}/itk-doxygen.tar.gz SHOW_PROGRESS
+file( DOWNLOAD https://data.kitware.com/api/v1/file/606753b52fa25629b9476eaa/download
+      ${ITKDoxygen_TEMP_DIR}/itk-doxygen.tar.gz SHOW_PROGRESS
   )

--- a/CMake/DownloadDoxygenTAG.cmake
+++ b/CMake/DownloadDoxygenTAG.cmake
@@ -1,4 +1,4 @@
-file( DOWNLOAD https://itk.org/files/NightlyDoxygen/InsightDoxygenDocTag.gz
+file( DOWNLOAD https://data.kitware.com/api/v1/file/60674d8a2fa25629b94769d4/download
   ${ITKDoxygenTAG_TEMP_DIR}/InsightDoxygen.tag.gz SHOW_PROGRESS
   )
 

--- a/CMake/DownloadDoxygenXML.cmake
+++ b/CMake/DownloadDoxygenXML.cmake
@@ -1,3 +1,3 @@
-file( DOWNLOAD https://itk.org/files/NightlyDoxygen/InsightDoxygenDocXml.tar.gz
+file( DOWNLOAD https://data.kitware.com/api/v1/file/60674d892fa25629b94769ca/download
   ${ITKDoxygenXML_TEMP_DIR}/itk-doxygen-xml.tar.gz SHOW_PROGRESS
   )


### PR DESCRIPTION
Workaround to address #362 by getting Doxygen archives for ITK v5.2.0 rather than latest nightly.