### PR TITLE
STYLE: Remove parameters from `main(int, char *[])` when both are unused

### DIFF
--- a/src/Core/Common/AddOffsetToIndex/Code.cxx
+++ b/src/Core/Common/AddOffsetToIndex/Code.cxx
@@ -22,7 +22,7 @@
 #include <iostream>
 
 int
-main(int, char *[])
+main()
 {
   constexpr unsigned int Dimension = 2;
 

--- a/src/Core/Common/ApplyAFilterOnlyToASpecifiedRegionOfAnImage/Code.cxx
+++ b/src/Core/Common/ApplyAFilterOnlyToASpecifiedRegionOfAnImage/Code.cxx
@@ -21,7 +21,7 @@
 #include "itkDerivativeImageFilter.h"
 
 int
-main(int, char *[])
+main()
 {
   constexpr unsigned int Dimension = 2;
   using PixelType = float;

--- a/src/Core/Common/ApplyCustomOperationToEachPixelInImage/Code.cxx
+++ b/src/Core/Common/ApplyCustomOperationToEachPixelInImage/Code.cxx
@@ -62,7 +62,7 @@ public:
 };
 
 int
-main(int, char *[])
+main()
 {
   using ImageType = itk::VectorImage<float, 2>;
 

--- a/src/Core/Common/BoundingBoxOfAPointSet/Code.cxx
+++ b/src/Core/Common/BoundingBoxOfAPointSet/Code.cxx
@@ -21,7 +21,7 @@
 #include "itkBoundingBox.h"
 
 int
-main(int, char *[])
+main()
 {
   using CoordType = float;
   constexpr unsigned int Dimension = 3;

--- a/src/Core/Common/BuildAHelloWorldProgram/Code.cxx
+++ b/src/Core/Common/BuildAHelloWorldProgram/Code.cxx
@@ -19,7 +19,7 @@
 #include "itkImage.h"
 
 int
-main(int, char *[])
+main()
 {
   using ImageType = itk::Image<unsigned short, 3>;
   ImageType::Pointer image = ImageType::New();

--- a/src/Core/Common/ComputeTimeBetweenPoints/Code.cxx
+++ b/src/Core/Common/ComputeTimeBetweenPoints/Code.cxx
@@ -33,7 +33,7 @@ LongFunction()
 }
 
 int
-main(int, char *[])
+main()
 {
   itk::TimeProbe clock;
 

--- a/src/Core/Common/ConceptCheckingIsFloatingPoint/Code.cxx
+++ b/src/Core/Common/ConceptCheckingIsFloatingPoint/Code.cxx
@@ -27,7 +27,7 @@ IsPixelTypeFloatingPoint(const TImage * const)
 }
 
 int
-main(int, char *[])
+main()
 {
   constexpr unsigned int Dimension = 2;
   using FloatImageType = itk::Image<float, Dimension>;

--- a/src/Core/Common/ConceptCheckingIsSameDimension/Code.cxx
+++ b/src/Core/Common/ConceptCheckingIsSameDimension/Code.cxx
@@ -26,7 +26,7 @@ CheckIfDimensionIsTheSame(const TImage * const)
   itkConceptMacro(nameOfCheck, (itk::Concept::SameDimension<TImage::ImageDimension, VDimension>));
 }
 int
-main(int, char *[])
+main()
 {
   constexpr unsigned int Dimension = 2;
   using PixelType = unsigned char;

--- a/src/Core/Common/ConceptCheckingIsSameType/Code.cxx
+++ b/src/Core/Common/ConceptCheckingIsSameType/Code.cxx
@@ -26,7 +26,7 @@ CheckIfPixelTypeIsTheSameAs(const TImage * const)
   itkConceptMacro(nameOfCheck, (itk::Concept::SameType<typename TImage::PixelType, TValue>));
 }
 int
-main(int, char *[])
+main()
 {
   constexpr unsigned int Dimension = 2;
   using PixelType = unsigned char;

--- a/src/Core/Common/ConvertArrayToImage/Code.cxx
+++ b/src/Core/Common/ConvertArrayToImage/Code.cxx
@@ -21,7 +21,7 @@
 #include "itkImageFileWriter.h"
 
 int
-main(int, char *[])
+main()
 {
   using PixelType = unsigned char;
   constexpr unsigned int Dimension = 3;

--- a/src/Core/Common/CovariantVectorDotProduct/Code.cxx
+++ b/src/Core/Common/CovariantVectorDotProduct/Code.cxx
@@ -19,7 +19,7 @@
 #include "itkCovariantVector.h"
 
 int
-main(int, char *[])
+main()
 {
   constexpr unsigned int Dimension = 3;
   using CoordType = double;

--- a/src/Core/Common/CovariantVectorNorm/Code.cxx
+++ b/src/Core/Common/CovariantVectorNorm/Code.cxx
@@ -19,7 +19,7 @@
 #include "itkCovariantVector.h"
 
 int
-main(int, char *[])
+main()
 {
   using VectorType = itk::CovariantVector<double, 3>;
   VectorType v;

--- a/src/Core/Common/CreateABackwardDifferenceOperator/Code.cxx
+++ b/src/Core/Common/CreateABackwardDifferenceOperator/Code.cxx
@@ -19,7 +19,7 @@
 #include <itkBackwardDifferenceOperator.h>
 
 int
-main(int, char *[])
+main()
 {
   using PixelType = float;
   constexpr unsigned int Dimension = 2;

--- a/src/Core/Common/CreateACovariantVector/Code.cxx
+++ b/src/Core/Common/CreateACovariantVector/Code.cxx
@@ -19,7 +19,7 @@
 #include "itkCovariantVector.h"
 
 int
-main(int, char *[])
+main()
 {
   constexpr unsigned int Dimension = 3;
   using CoordType = double;

--- a/src/Core/Common/CreateAFixedArray/Code.cxx
+++ b/src/Core/Common/CreateAFixedArray/Code.cxx
@@ -20,7 +20,7 @@
 #include "itkFixedArray.h"
 
 int
-main(int, char *[])
+main()
 {
   itk::FixedArray<double, 2> array;
   array[0] = 0;

--- a/src/Core/Common/CreateAIndex/Code.cxx
+++ b/src/Core/Common/CreateAIndex/Code.cxx
@@ -19,7 +19,7 @@
 #include "itkIndex.h"
 
 int
-main(int, char *[])
+main()
 {
   constexpr unsigned int Dimension = 2;
 

--- a/src/Core/Common/CreateAPointSet/Code.cxx
+++ b/src/Core/Common/CreateAPointSet/Code.cxx
@@ -20,7 +20,7 @@
 #include "itkPointSet.h"
 
 int
-main(int, char *[])
+main()
 {
   using PixelType = float;
   constexpr unsigned int Dimension = 3;

--- a/src/Core/Common/CreateASize/Code.cxx
+++ b/src/Core/Common/CreateASize/Code.cxx
@@ -20,7 +20,7 @@
 #include "itkSize.h"
 
 int
-main(int, char *[])
+main()
 {
   constexpr unsigned int Dimension = 2;
   itk::Size<Dimension>   size;

--- a/src/Core/Common/CreateAVector/Code.cxx
+++ b/src/Core/Common/CreateAVector/Code.cxx
@@ -19,7 +19,7 @@
 #include "itkVector.h"
 
 int
-main(int, char *[])
+main()
 {
   constexpr unsigned int Dimension = 3;
   using CoordType = double;

--- a/src/Core/Common/CreateAnImage/Code.cxx
+++ b/src/Core/Common/CreateAnImage/Code.cxx
@@ -19,7 +19,7 @@
 #include "itkImage.h"
 
 int
-main(int, char *[])
+main()
 {
   using ImageType = itk::Image<unsigned char, 3>;
   ImageType::Pointer image = ImageType::New();

--- a/src/Core/Common/CreateAnImageOfVectors/Code.cxx
+++ b/src/Core/Common/CreateAnImageOfVectors/Code.cxx
@@ -20,7 +20,7 @@
 #include "itkImage.h"
 
 int
-main(int, char *[])
+main()
 {
   using PixelType = itk::Vector<float, 3>;
   using ImageType = itk::Image<PixelType, 3>;

--- a/src/Core/Common/CreateAnImageRegion/Code.cxx
+++ b/src/Core/Common/CreateAnImageRegion/Code.cxx
@@ -19,7 +19,7 @@
 #include "itkImageRegion.h"
 
 int
-main(int, char *[])
+main()
 {
   constexpr unsigned int Dimension = 2;
 

--- a/src/Core/Common/CreateAnRGBImage/Code.cxx
+++ b/src/Core/Common/CreateAnRGBImage/Code.cxx
@@ -20,7 +20,7 @@
 #include "itkRGBPixel.h"
 
 int
-main(int, char *[])
+main()
 {
   constexpr unsigned int Dimension = 2;
   using RGBPixelType = itk::RGBPixel<unsigned char>;

--- a/src/Core/Common/CreateAnother/Code.cxx
+++ b/src/Core/Common/CreateAnother/Code.cxx
@@ -38,7 +38,7 @@ CreateImage(typename TImage::Pointer image)
 }
 
 int
-main(int, char *[])
+main()
 {
   constexpr unsigned int Dimension = 2;
   using PixelType = double;

--- a/src/Core/Common/CreateAnotherInstanceOfAnImage/Code.cxx
+++ b/src/Core/Common/CreateAnotherInstanceOfAnImage/Code.cxx
@@ -25,7 +25,7 @@ void
 OutputImageType(const itk::ImageBase<2> * input);
 
 int
-main(int, char *[])
+main()
 {
   FloatScalarImageType::Pointer floatImage = FloatScalarImageType::New();
   itk::ImageBase<2>::Pointer    floatCopy = CreateImageWithSameType(floatImage);

--- a/src/Core/Common/CreateDerivativeKernel/Code.cxx
+++ b/src/Core/Common/CreateDerivativeKernel/Code.cxx
@@ -18,7 +18,7 @@
 #include <itkDerivativeOperator.h>
 
 int
-main(int, char *[])
+main()
 {
   using DerivativeOperatorType = itk::DerivativeOperator<float, 2>;
   DerivativeOperatorType derivativeOperator;

--- a/src/Core/Common/CreateForwardDifferenceKernel/Code.cxx
+++ b/src/Core/Common/CreateForwardDifferenceKernel/Code.cxx
@@ -18,7 +18,7 @@
 #include <itkForwardDifferenceOperator.h>
 
 int
-main(int, char *[])
+main()
 {
   using ForwardDifferenceOperatorType = itk::ForwardDifferenceOperator<float, 2>;
   ForwardDifferenceOperatorType forwardDifferenceOperator;

--- a/src/Core/Common/CreateGaussianDerivativeKernel/Code.cxx
+++ b/src/Core/Common/CreateGaussianDerivativeKernel/Code.cxx
@@ -18,7 +18,7 @@
 #include <itkGaussianDerivativeOperator.h>
 
 int
-main(int, char *[])
+main()
 {
   using GaussianDerivativeOperatorType = itk::GaussianDerivativeOperator<float, 2>;
   GaussianDerivativeOperatorType gaussianDerivativeOperator;

--- a/src/Core/Common/CreateGaussianKernel/Code.cxx
+++ b/src/Core/Common/CreateGaussianKernel/Code.cxx
@@ -18,7 +18,7 @@
 #include <itkGaussianOperator.h>
 
 int
-main(int, char *[])
+main()
 {
   using GaussianOperatorType = itk::GaussianOperator<float, 2>;
   GaussianOperatorType gaussianOperator;

--- a/src/Core/Common/CreateLaplacianKernel/Code.cxx
+++ b/src/Core/Common/CreateLaplacianKernel/Code.cxx
@@ -18,7 +18,7 @@
 #include <itkLaplacianOperator.h>
 
 int
-main(int, char *[])
+main()
 {
   using LaplacianOperatorType = itk::LaplacianOperator<float, 2>;
   LaplacianOperatorType laplacianOperator;

--- a/src/Core/Common/CreateSobelKernel/Code.cxx
+++ b/src/Core/Common/CreateSobelKernel/Code.cxx
@@ -18,7 +18,7 @@
 #include <itkSobelOperator.h>
 
 int
-main(int, char *[])
+main()
 {
   using SobelOperatorType = itk::SobelOperator<float, 2>;
   SobelOperatorType sobelOperator;

--- a/src/Core/Common/CreateVectorImage/Code.cxx
+++ b/src/Core/Common/CreateVectorImage/Code.cxx
@@ -18,7 +18,7 @@
 #include "itkVectorImage.h"
 
 int
-main(int, char *[])
+main()
 {
   // Create an image
   using ImageType = itk::VectorImage<float, 2>;

--- a/src/Core/Common/CropImageBySpecifyingRegion/Code.cxx
+++ b/src/Core/Common/CropImageBySpecifyingRegion/Code.cxx
@@ -21,7 +21,7 @@
 #include <itkExtractImageFilter.h>
 
 int
-main(int, char *[])
+main()
 {
   using ImageType = itk::Image<unsigned char, 2>;
 

--- a/src/Core/Common/DeepCopyImage/Code.cxx
+++ b/src/Core/Common/DeepCopyImage/Code.cxx
@@ -37,7 +37,7 @@ DeepCopy(typename TImage::Pointer input, typename TImage::Pointer output)
 }
 
 int
-main(int, char *[])
+main()
 {
   using ImageType = itk::Image<unsigned char, 2>;
   ImageType::Pointer image1 = ImageType::New();

--- a/src/Core/Common/DemonstrateAllOperators/Code.cxx
+++ b/src/Core/Common/DemonstrateAllOperators/Code.cxx
@@ -30,7 +30,7 @@
 #include <vector>
 
 int
-main(int, char *[])
+main()
 {
   using DerivativeOperatorType = itk::DerivativeOperator<float, 2>;
   using ForwardDifferenceOperatorType = itk::ForwardDifferenceOperator<float, 2>;

--- a/src/Core/Common/DistanceBetweenIndices/Code.cxx
+++ b/src/Core/Common/DistanceBetweenIndices/Code.cxx
@@ -23,7 +23,7 @@
 #include <iostream>
 
 int
-main(int, char *[])
+main()
 {
   itk::Index<2> pixel1;
   pixel1.Fill(2);

--- a/src/Core/Common/DistanceBetweenPoints/Code.cxx
+++ b/src/Core/Common/DistanceBetweenPoints/Code.cxx
@@ -22,7 +22,7 @@
 #include <iostream>
 
 int
-main(int, char *[])
+main()
 {
   constexpr unsigned int Dimension = 3;
   using CoordType = double;

--- a/src/Core/Common/DoDataParallelThreading/Code.cxx
+++ b/src/Core/Common/DoDataParallelThreading/Code.cxx
@@ -198,7 +198,7 @@ private:
 
 
 int
-main(int, char *[])
+main()
 {
   // Our cells.
   static const CELL_TYPE cellsArr[] = { NEURON, ASTROCYTE, ASTROCYTE, OLIGODENDROCYTE, ASTROCYTE,

--- a/src/Core/Common/DuplicateAnImage/Code.cxx
+++ b/src/Core/Common/DuplicateAnImage/Code.cxx
@@ -21,7 +21,7 @@
 #include "itkRandomImageSource.h"
 
 int
-main(int, char *[])
+main()
 {
   constexpr unsigned int Dimension = 2;
   using PixelType = unsigned char;

--- a/src/Core/Common/FilterAndParallelizeImageRegion/Code.cxx
+++ b/src/Core/Common/FilterAndParallelizeImageRegion/Code.cxx
@@ -71,7 +71,7 @@ log1xViaParallelizeImageRegion(ImageType::Pointer & image)
 }
 
 int
-main(int, char *[])
+main()
 {
   int result = EXIT_SUCCESS;
 

--- a/src/Core/Common/FilterImage/Code.cxx
+++ b/src/Core/Common/FilterImage/Code.cxx
@@ -24,7 +24,7 @@ static void
 CreateImage(TImage * const image);
 
 int
-main(int, char *[])
+main()
 {
   // Setup types
   using ImageType = itk::Image<int, 2>;

--- a/src/Core/Common/FilterImageUsingMultipleThreads/Code.cxx
+++ b/src/Core/Common/FilterImageUsingMultipleThreads/Code.cxx
@@ -30,7 +30,7 @@ static void
 OutputImage(TImage * const image);
 
 int
-main(int, char *[])
+main()
 {
   // Setup types
   using ImageType = itk::Image<int, 2>;

--- a/src/Core/Common/FilterImageWithoutCopying/Code.cxx
+++ b/src/Core/Common/FilterImageWithoutCopying/Code.cxx
@@ -24,7 +24,7 @@ static void
 CreateImage(TImage * const image);
 
 int
-main(int, char *[])
+main()
 {
   // Setup types
   using ImageType = itk::Image<int, 2>;

--- a/src/Core/Common/GetNameOfClass/Code.cxx
+++ b/src/Core/Common/GetNameOfClass/Code.cxx
@@ -19,7 +19,7 @@
 #include "itkImage.h"
 
 int
-main(int, char *[])
+main()
 {
   constexpr unsigned int Dimension = 2;
   using PixelType = unsigned char;

--- a/src/Core/Common/GetOrSetMemberVariableOfITKClass/Code.cxx
+++ b/src/Core/Common/GetOrSetMemberVariableOfITKClass/Code.cxx
@@ -20,7 +20,7 @@
 #include "ImageFilterX.h"
 
 int
-main(int, char *[])
+main()
 {
   // Setup types
   using ImageType = itk::Image<unsigned char, 2>;

--- a/src/Core/Common/GetTypeBasicInformation/Code.cxx
+++ b/src/Core/Common/GetTypeBasicInformation/Code.cxx
@@ -20,7 +20,7 @@
 #include "itkNumericTraits.h"
 
 int
-main(int, char *[])
+main()
 {
   using MyType = float;
 

--- a/src/Core/Common/ImageRegionIntersection/Code.cxx
+++ b/src/Core/Common/ImageRegionIntersection/Code.cxx
@@ -19,7 +19,7 @@
 #include "itkImage.h"
 
 int
-main(int, char *[])
+main()
 {
   constexpr unsigned int Dimension = 2;
   using PixelType = unsigned char;

--- a/src/Core/Common/IsPixelInsideRegion/Code.cxx
+++ b/src/Core/Common/IsPixelInsideRegion/Code.cxx
@@ -21,7 +21,7 @@
 #include "itkSize.h"
 
 int
-main(int, char *[])
+main()
 {
   constexpr unsigned int Dimension = 2;
 

--- a/src/Core/Common/IterateLineThroughImageWithoutWriteAccess/Code.cxx
+++ b/src/Core/Common/IterateLineThroughImageWithoutWriteAccess/Code.cxx
@@ -25,7 +25,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Core/Common/IterateOnAVectorContainer/Code.cxx
+++ b/src/Core/Common/IterateOnAVectorContainer/Code.cxx
@@ -20,7 +20,7 @@
 #include "itkPoint.h"
 
 int
-main(int, char *[])
+main()
 {
   constexpr unsigned int Dimension = 2;
   using CoordType = double;

--- a/src/Core/Common/IterateOverARegionWithAShapedNeighborhoodIterator/Code.cxx
+++ b/src/Core/Common/IterateOverARegionWithAShapedNeighborhoodIterator/Code.cxx
@@ -22,7 +22,7 @@
 #include "itkNeighborhoodAlgorithm.h"
 
 int
-main(int, char *[])
+main()
 {
   constexpr unsigned int Dimension = 2;
 

--- a/src/Core/Common/IterateOverARegionWithAShapedNeighborhoodIteratorManual/Code.cxx
+++ b/src/Core/Common/IterateOverARegionWithAShapedNeighborhoodIteratorManual/Code.cxx
@@ -32,7 +32,7 @@ void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Core/Common/IterateOverSpecificRegion/Code.cxx
+++ b/src/Core/Common/IterateOverSpecificRegion/Code.cxx
@@ -26,7 +26,7 @@ using ImageType = itk::Image<int, 2>;
 static void CreateImage(ImageType::Pointer);
 
 int
-main(int, char *[])
+main()
 {
 
   ImageType::SizeType exclusionRegionSize;

--- a/src/Core/Common/MakeOutOfBoundsPixelsReturnConstValue/Code.cxx
+++ b/src/Core/Common/MakeOutOfBoundsPixelsReturnConstValue/Code.cxx
@@ -36,7 +36,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Core/Common/Matrix/Code.cxx
+++ b/src/Core/Common/Matrix/Code.cxx
@@ -28,7 +28,7 @@ Multiply();
 // static void Inverse();
 
 int
-main(int, char *[])
+main()
 {
   Construct();
   Multiply();

--- a/src/Core/Common/MatrixInverse/Code.cxx
+++ b/src/Core/Common/MatrixInverse/Code.cxx
@@ -20,7 +20,7 @@
 #include <iostream>
 
 int
-main(int, char *[])
+main()
 {
   using MatrixType = itk::Matrix<double, 2, 2>;
   MatrixType M;

--- a/src/Core/Common/MersenneTwisterRandomIntegerGenerator/Code.cxx
+++ b/src/Core/Common/MersenneTwisterRandomIntegerGenerator/Code.cxx
@@ -19,7 +19,7 @@
 #include "itkMersenneTwisterRandomVariateGenerator.h"
 
 int
-main(int, char *[])
+main()
 {
   using GeneratorType = itk::Statistics::MersenneTwisterRandomVariateGenerator;
   GeneratorType::Pointer generator = GeneratorType::New();

--- a/src/Core/Common/MersenneTwisterRandomNumberGenerator/Code.cxx
+++ b/src/Core/Common/MersenneTwisterRandomNumberGenerator/Code.cxx
@@ -19,7 +19,7 @@
 #include "itkMersenneTwisterRandomVariateGenerator.h"
 
 int
-main(int, char *[])
+main()
 {
   using GeneratorType = itk::Statistics::MersenneTwisterRandomVariateGenerator;
   GeneratorType::Pointer generator = GeneratorType::New();

--- a/src/Core/Common/MiniPipeline/Code.cxx
+++ b/src/Core/Common/MiniPipeline/Code.cxx
@@ -26,7 +26,7 @@ static void
 CreateImage(TImage * const image);
 
 int
-main(int, char *[])
+main()
 {
   // Setup types
   using ImageType = itk::Image<unsigned char, 2>;

--- a/src/Core/Common/MultipleInputsOfDifferentType/Code.cxx
+++ b/src/Core/Common/MultipleInputsOfDifferentType/Code.cxx
@@ -23,7 +23,7 @@
 #include "ImageFilterMultipleInputsDifferentType.h"
 
 int
-main(int, char *[])
+main()
 {
   // Setup types
   using VectorImageType = itk::Image<itk::CovariantVector<unsigned char, 3>, 2>;

--- a/src/Core/Common/MultipleInputsOfSameType/Code.cxx
+++ b/src/Core/Common/MultipleInputsOfSameType/Code.cxx
@@ -20,7 +20,7 @@
 #include "itkImageFilterMultipleInputs.h"
 
 int
-main(int, char *[])
+main()
 {
   // Setup types
   using ImageType = itk::Image<unsigned char, 2>;

--- a/src/Core/Common/MultipleOutputsOfDifferentType/Code.cxx
+++ b/src/Core/Common/MultipleOutputsOfDifferentType/Code.cxx
@@ -22,7 +22,7 @@
 #include "ImageFilterMultipleOutputsDifferentType.h"
 
 int
-main(int, char *[])
+main()
 {
   // Setup types
   using InputImageType = itk::Image<unsigned char, 2>;

--- a/src/Core/Common/MultipleOutputsOfSameType/Code.cxx
+++ b/src/Core/Common/MultipleOutputsOfSameType/Code.cxx
@@ -22,7 +22,7 @@
 #include "ImageFilterMultipleOutputs.h"
 
 int
-main(int, char *[])
+main()
 {
   // Setup types
   using ImageType = itk::Image<unsigned char, 2>;

--- a/src/Core/Common/NeighborhoodIteratorOnVectorImage/Code.cxx
+++ b/src/Core/Common/NeighborhoodIteratorOnVectorImage/Code.cxx
@@ -21,7 +21,7 @@
 using VectorImageType = itk::VectorImage<unsigned char, 2>;
 
 int
-main(int, char *[])
+main()
 {
   // Create an image
   VectorImageType::Pointer image = VectorImageType::New();

--- a/src/Core/Common/ObserveAnEvent/Code.cxx
+++ b/src/Core/Common/ObserveAnEvent/Code.cxx
@@ -49,7 +49,7 @@ public:
 
 
 int
-main(int, char *[])
+main()
 {
   constexpr unsigned int Dimension = 2;
   using PixelType = unsigned char;

--- a/src/Core/Common/PassImageToFunction/Code.cxx
+++ b/src/Core/Common/PassImageToFunction/Code.cxx
@@ -39,7 +39,7 @@ TemplateStandardPointer(const TImage *)
 {}
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer  image = ImageType::New();
   itk::Index<2>       corner = { { 0, 0 } };

--- a/src/Core/Common/PermuteSequenceOfIndices/Code.cxx
+++ b/src/Core/Common/PermuteSequenceOfIndices/Code.cxx
@@ -18,7 +18,7 @@
 #include <itkImageRandomNonRepeatingConstIteratorWithIndex.h>
 
 int
-main(int, char *[])
+main()
 {
   itk::RandomPermutation rp(5);
 

--- a/src/Core/Common/RandomSelectOfPixelsFromRegion/Code.cxx
+++ b/src/Core/Common/RandomSelectOfPixelsFromRegion/Code.cxx
@@ -19,7 +19,7 @@
 #include "itkImageRandomConstIteratorWithIndex.h"
 
 int
-main(int, char *[])
+main()
 {
   using ImageType = itk::Image<unsigned char, 2>;
   ImageType::Pointer image = ImageType::New();

--- a/src/Core/Common/RandomSelectPixelFromRegionWithoutReplacee/Code.cxx
+++ b/src/Core/Common/RandomSelectPixelFromRegionWithoutReplacee/Code.cxx
@@ -19,7 +19,7 @@
 #include "itkImageRandomNonRepeatingConstIteratorWithIndex.h"
 
 int
-main(int, char *[])
+main()
 {
   using ImageType = itk::Image<unsigned char, 2>;
   ImageType::Pointer image = ImageType::New();

--- a/src/Core/Common/ReturnObjectFromFunction/Code.cxx
+++ b/src/Core/Common/ReturnObjectFromFunction/Code.cxx
@@ -49,7 +49,7 @@ ReturnPointer()
 }
 
 int
-main(int, char *[])
+main()
 {
   {
     // This is how it should be done.

--- a/src/Core/Common/SortITKIndex/Code.cxx
+++ b/src/Core/Common/SortITKIndex/Code.cxx
@@ -19,7 +19,7 @@
 #include <map>
 
 int
-main(int, char *[])
+main()
 {
   using IndexType = itk::Index<2>;
   IndexType                  index = { { 3, 4 } };

--- a/src/Core/Common/StoreNonPixelDataInImage/Code.cxx
+++ b/src/Core/Common/StoreNonPixelDataInImage/Code.cxx
@@ -28,7 +28,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   // Create an image
   ImageType::Pointer image = ImageType::New();

--- a/src/Core/Common/ThrowException/Code.cxx
+++ b/src/Core/Common/ThrowException/Code.cxx
@@ -20,7 +20,7 @@
 
 // TODO: Incomplete example
 int
-main(int, char *[])
+main()
 {
   // Setup types
   using ImageType = itk::Image<unsigned char, 2>;

--- a/src/Core/Common/TryCatchException/Code.cxx
+++ b/src/Core/Common/TryCatchException/Code.cxx
@@ -20,7 +20,7 @@
 #include "itkImageFileReader.h"
 
 int
-main(int, char *[])
+main()
 {
   constexpr unsigned int Dimension = 2;
   using PixelType = double;

--- a/src/Core/Common/VariableLengthVector/Code.cxx
+++ b/src/Core/Common/VariableLengthVector/Code.cxx
@@ -24,7 +24,7 @@ void
 VariableLengthVectorToVector();
 
 int
-main(int, char *[])
+main()
 {
   using VectorType = itk::VariableLengthVector<double>;
   VectorType v;

--- a/src/Core/Common/VectorDotProduct/Code.cxx
+++ b/src/Core/Common/VectorDotProduct/Code.cxx
@@ -19,7 +19,7 @@
 #include "itkVector.h"
 
 int
-main(int, char *[])
+main()
 {
   constexpr unsigned int Dimension = 3;
   using CoordType = double;

--- a/src/Core/Common/WatchAFilter/Code.cxx
+++ b/src/Core/Common/WatchAFilter/Code.cxx
@@ -50,7 +50,7 @@ CreateImage(typename TImage::Pointer image)
   }
 }
 int
-main(int, char *[])
+main()
 {
   constexpr unsigned int Dimension = 2;
   using PixelType = unsigned char;

--- a/src/Core/ImageAdaptors/AddConstantToPixelsWithoutDuplicatingImage/Code.cxx
+++ b/src/Core/ImageAdaptors/AddConstantToPixelsWithoutDuplicatingImage/Code.cxx
@@ -26,7 +26,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Core/ImageAdaptors/ExtractChannelOfImageWithMultipleComponents/Code.cxx
+++ b/src/Core/ImageAdaptors/ExtractChannelOfImageWithMultipleComponents/Code.cxx
@@ -25,7 +25,7 @@ static void
 CreateImage(VectorImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   VectorImageType::Pointer image = VectorImageType::New();
   CreateImage(image);

--- a/src/Core/ImageAdaptors/PresentImageAfterOperation/Code.cxx
+++ b/src/Core/ImageAdaptors/PresentImageAfterOperation/Code.cxx
@@ -52,7 +52,7 @@ private:
 };
 
 int
-main(int, char *[])
+main()
 {
   VectorImageType::Pointer image = VectorImageType::New();
   CreateImage(image);

--- a/src/Core/ImageAdaptors/ProcessNthComponentOfVectorImage/Code.cxx
+++ b/src/Core/ImageAdaptors/ProcessNthComponentOfVectorImage/Code.cxx
@@ -26,7 +26,7 @@ static void
 CreateImage(VectorImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   VectorImageType::Pointer image = VectorImageType::New();
   CreateImage(image);

--- a/src/Core/ImageAdaptors/ViewComponentVectorImageAsScaleImage/Code.cxx
+++ b/src/Core/ImageAdaptors/ViewComponentVectorImageAsScaleImage/Code.cxx
@@ -27,7 +27,7 @@ void
 CreateImage(VectorImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   VectorImageType::Pointer image = VectorImageType::New();
   CreateImage(image);

--- a/src/Core/ImageFunction/ComputeMedianOfImageAtPixel/Code.cxx
+++ b/src/Core/ImageFunction/ComputeMedianOfImageAtPixel/Code.cxx
@@ -26,7 +26,7 @@ void
 CreateImage(UnsignedCharImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   UnsignedCharImageType::Pointer image = UnsignedCharImageType::New();
   CreateImage(image);

--- a/src/Core/ImageFunction/LinearlyInterpolatePositionInImage/Code.cxx
+++ b/src/Core/ImageFunction/LinearlyInterpolatePositionInImage/Code.cxx
@@ -25,7 +25,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Core/ImageFunction/MultiplyKernelWithAnImageAtLocation/Code.cxx
+++ b/src/Core/ImageFunction/MultiplyKernelWithAnImageAtLocation/Code.cxx
@@ -25,7 +25,7 @@ static void
 CreateImage(UnsignedCharImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   UnsignedCharImageType::Pointer image = UnsignedCharImageType::New();
   CreateImage(image);

--- a/src/Core/Mesh/AddPointsAndEdges/Code.cxx
+++ b/src/Core/Mesh/AddPointsAndEdges/Code.cxx
@@ -27,7 +27,7 @@ void
 CreateMeshWithEdges();
 
 int
-main(int, char *[])
+main()
 {
   // CreatePointOnlyMesh();
   CreateMeshWithEdges();

--- a/src/Core/Mesh/CalculateAreaAndVolumeOfSimplexMesh/Code.cxx
+++ b/src/Core/Mesh/CalculateAreaAndVolumeOfSimplexMesh/Code.cxx
@@ -28,7 +28,7 @@ using TConvert = itk::TriangleMeshToSimplexMeshFilter<TMesh, TSimplex>;
 using TVolume = itk::SimplexMeshVolumeCalculator<TSimplex>;
 
 int
-main(int, char *[])
+main()
 {
 
   // Create a spherical mesh with known radius and resolution.

--- a/src/Core/Mesh/ConvertMeshToUnstructeredGrid/Code.cxx
+++ b/src/Core/Mesh/ConvertMeshToUnstructeredGrid/Code.cxx
@@ -99,7 +99,7 @@ public:
 };
 
 int
-main(int, char *[])
+main()
 {
   MeshType::Pointer mesh = CreateMeshWithEdges();
 

--- a/src/Core/Mesh/WorkingWithPointAndCellData/Code.cxx
+++ b/src/Core/Mesh/WorkingWithPointAndCellData/Code.cxx
@@ -30,7 +30,7 @@ using TSphere = itk::RegularSphereMeshSource<TMesh>;
 using TMeshWriter = itk::MeshFileWriter<TMesh>;
 
 int
-main(int, char *[])
+main()
 {
 
   // Create the sphere source.

--- a/src/Core/Mesh/WriteMeshToVTP/Code.cxx
+++ b/src/Core/Mesh/WriteMeshToVTP/Code.cxx
@@ -26,7 +26,7 @@ MeshType::Pointer
 CreateMeshWithEdges();
 
 int
-main(int, char *[])
+main()
 {
 
   MeshType::Pointer mesh = CreateMeshWithEdges();

--- a/src/Core/Transform/CartesianToAzimuthElevation/Code.cxx
+++ b/src/Core/Transform/CartesianToAzimuthElevation/Code.cxx
@@ -19,7 +19,7 @@
 #include "itkAzimuthElevationToCartesianTransform.h"
 
 int
-main(int, char *[])
+main()
 {
   using PointType = itk::Point<double, 3>;
   PointType spherical;

--- a/src/Core/Transform/CopyACompositeTransform/Code.cxx
+++ b/src/Core/Transform/CopyACompositeTransform/Code.cxx
@@ -22,7 +22,7 @@
 #include "itkCompositeTransformIOHelper.h"
 
 int
-main(int, char *[])
+main()
 {
   using ScalarType = float;
   constexpr unsigned int Dimension = 3;

--- a/src/Core/Transform/CopyANonCompositeTransform/Code.cxx
+++ b/src/Core/Transform/CopyANonCompositeTransform/Code.cxx
@@ -19,7 +19,7 @@
 #include "itkEuler3DTransform.h"
 
 int
-main(int, char *[])
+main()
 {
   using TransformType = itk::Euler3DTransform<float>;
 

--- a/src/Core/Transform/GlobalRegistrationTwoImagesAffine/Code.cxx
+++ b/src/Core/Transform/GlobalRegistrationTwoImagesAffine/Code.cxx
@@ -40,7 +40,7 @@ static void
 CreateSphereImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   //  The transform that will map the fixed image into the moving image.
   using TransformType = itk::AffineTransform<double, Dimension>;

--- a/src/Core/Transform/ScaleAnImage/Code.cxx
+++ b/src/Core/Transform/ScaleAnImage/Code.cxx
@@ -26,7 +26,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Core/Transform/TranslateAVectorImage/Code.cxx
+++ b/src/Core/Transform/TranslateAVectorImage/Code.cxx
@@ -23,7 +23,7 @@
 #include "itkNumericTraits.h"
 
 int
-main(int, char *[])
+main()
 {
   using VectorType = itk::CovariantVector<double, 3>;
   using VectorImageType = itk::Image<VectorType, 2>;

--- a/src/Developer/ConceptChecking.cxx
+++ b/src/Developer/ConceptChecking.cxx
@@ -9,7 +9,7 @@ MyFunction(const TImage * const image)
 }
 
 int
-main(int, char *[])
+main()
 {
   using FloatImageType = itk::Image<float, 2>;
   FloatImageType::Pointer floatImage = FloatImageType::New();

--- a/src/Developer/Exceptions.cxx
+++ b/src/Developer/Exceptions.cxx
@@ -3,7 +3,7 @@
 #include "ImageSource.h"
 
 int
-main(int, char *[])
+main()
 {
   // Setup types
   using ImageType = itk::Image<unsigned char, 2>;

--- a/src/Developer/ImageFilter.cxx
+++ b/src/Developer/ImageFilter.cxx
@@ -7,7 +7,7 @@ static void
 CreateImage(TImage * const image);
 
 int
-main(int, char *[])
+main()
 {
   // Setup types
   using ImageType = itk::Image<int, 2>;

--- a/src/Developer/ImageFilterMultipleInputs.cxx
+++ b/src/Developer/ImageFilterMultipleInputs.cxx
@@ -3,7 +3,7 @@
 #include "ImageFilterMultipleInputs.h"
 
 int
-main(int, char *[])
+main()
 {
   // Setup types
   using ImageType = itk::Image<unsigned char, 2>;

--- a/src/Developer/ImageFilterMultipleInputsDifferentType.cxx
+++ b/src/Developer/ImageFilterMultipleInputsDifferentType.cxx
@@ -6,7 +6,7 @@
 #include "ImageFilterMultipleInputsDifferentType.h"
 
 int
-main(int, char *[])
+main()
 {
   // Setup types
   using VectorImageType = itk::Image<itk::CovariantVector<unsigned char, 3>, 2>;

--- a/src/Developer/ImageFilterMultipleOutputs.cxx
+++ b/src/Developer/ImageFilterMultipleOutputs.cxx
@@ -4,7 +4,7 @@
 #include "ImageFilterMultipleOutputs.h"
 
 int
-main(int, char *[])
+main()
 {
   // Setup types
   using ImageType = itk::Image<unsigned char, 2>;

--- a/src/Developer/ImageFilterMultipleOutputsDifferentType.cxx
+++ b/src/Developer/ImageFilterMultipleOutputsDifferentType.cxx
@@ -5,7 +5,7 @@
 #include "ImageFilterMultipleOutputsDifferentType.h"
 
 int
-main(int, char *[])
+main()
 {
   // Setup types
   using InputImageType = itk::Image<unsigned char, 2>;

--- a/src/Developer/InplaceImageFilter.cxx
+++ b/src/Developer/InplaceImageFilter.cxx
@@ -7,7 +7,7 @@ static void
 CreateImage(TImage * const image);
 
 int
-main(int, char *[])
+main()
 {
   // Setup types
   using ImageType = itk::Image<int, 2>;

--- a/src/Developer/MiniPipeline.cxx
+++ b/src/Developer/MiniPipeline.cxx
@@ -8,7 +8,7 @@ static void
 CreateImage(TImage * const image);
 
 int
-main(int, char *[])
+main()
 {
   // Setup types
   using ImageType = itk::Image<unsigned char, 2>;

--- a/src/Developer/MultiThreadedImageFilter.cxx
+++ b/src/Developer/MultiThreadedImageFilter.cxx
@@ -11,7 +11,7 @@ static void
 OutputImage(TImage * const image);
 
 int
-main(int, char *[])
+main()
 {
   // Setup types
   using ImageType = itk::Image<int, 2>;

--- a/src/Developer/SetGetMacro.cxx
+++ b/src/Developer/SetGetMacro.cxx
@@ -3,7 +3,7 @@
 #include "ImageFilterX.h"
 
 int
-main(int, char *[])
+main()
 {
   // Setup types
   using ImageType = itk::Image<unsigned char, 2>;

--- a/src/Filtering/Colormap/MapScalarsIntoJetColormap/Code.cxx
+++ b/src/Filtering/Colormap/MapScalarsIntoJetColormap/Code.cxx
@@ -19,7 +19,7 @@
 #include "itkRGBPixel.h"
 
 int
-main(int, char *[])
+main()
 {
   using PixelType = itk::RGBPixel<unsigned char>;
   using ColormapType = itk::Function::JetColormapFunction<float, PixelType>;

--- a/src/Filtering/Convolution/NormalizedCorrelationOfMaskedImage/Code.cxx
+++ b/src/Filtering/Convolution/NormalizedCorrelationOfMaskedImage/Code.cxx
@@ -40,7 +40,7 @@ void
 CreateImageOfSquare(ImageType * const image, const itk::Index<2> & cornerOfSquare);
 
 int
-main(int, char *[])
+main()
 {
   // Setup mask
   MaskType::Pointer mask = MaskType::New();

--- a/src/Filtering/Convolution/NormalizedCorrelationUsingFFT/Code.cxx
+++ b/src/Filtering/Convolution/NormalizedCorrelationUsingFFT/Code.cxx
@@ -38,7 +38,7 @@ static void
 CreateImage(ImageType::Pointer image, const itk::Index<2> & cornerOfSquare);
 
 int
-main(int, char *[])
+main()
 {
   itk::Index<2> offset;
   offset[0] = 5;

--- a/src/Filtering/Convolution/NormalizedCorrelationUsingFFTWithMaskImages/Code.cxx
+++ b/src/Filtering/Convolution/NormalizedCorrelationUsingFFTWithMaskImages/Code.cxx
@@ -39,7 +39,7 @@ static void
 CreateImage(ImageType::Pointer image, const itk::Index<2> & cornerOfSquare);
 
 int
-main(int, char *[])
+main()
 {
   itk::Index<2> offset;
   offset[0] = 5;

--- a/src/Filtering/DistanceMap/MeanDistanceBetweenAllPointsOnTwoCurves/Code.cxx
+++ b/src/Filtering/DistanceMap/MeanDistanceBetweenAllPointsOnTwoCurves/Code.cxx
@@ -31,7 +31,7 @@ static void
 CreateImage2(TImage * const);
 
 int
-main(int, char *[])
+main()
 {
   using ImageType = itk::Image<unsigned char, 2>;
 

--- a/src/Filtering/ImageCompare/AbsValueOfTwoImages/Code.cxx
+++ b/src/Filtering/ImageCompare/AbsValueOfTwoImages/Code.cxx
@@ -28,7 +28,7 @@ static void
 CreateImage2(UnsignedCharImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   UnsignedCharImageType::Pointer image1 = UnsignedCharImageType::New();
   CreateImage1(image1);

--- a/src/Filtering/ImageCompare/SquaredDifferenceOfTwoImages/Code.cxx
+++ b/src/Filtering/ImageCompare/SquaredDifferenceOfTwoImages/Code.cxx
@@ -28,7 +28,7 @@ static void
 CreateImage2(UnsignedCharImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   UnsignedCharImageType::Pointer image1 = UnsignedCharImageType::New();
   CreateImage1(image1);

--- a/src/Filtering/ImageCompose/ComposeVectorFromThreeScalarImages/Code.cxx
+++ b/src/Filtering/ImageCompose/ComposeVectorFromThreeScalarImages/Code.cxx
@@ -26,7 +26,7 @@ static void
 CreateImage(ScalarImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ScalarImageType::Pointer image = ScalarImageType::New();
   CreateImage(image);

--- a/src/Filtering/ImageCompose/CreateVectorImageFromScalarImages/Code.cxx
+++ b/src/Filtering/ImageCompose/CreateVectorImageFromScalarImages/Code.cxx
@@ -29,7 +29,7 @@ static void
 CreateImage(ScalarImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ScalarImageType::Pointer image0 = ScalarImageType::New();
   CreateImage(image0);

--- a/src/Filtering/ImageCompose/JoinImages/Code.cxx
+++ b/src/Filtering/ImageCompose/JoinImages/Code.cxx
@@ -26,7 +26,7 @@ static void
 CreateImage(ImageType::Pointer image, unsigned char value);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image1 = ImageType::New();
   CreateImage(image1, 0);

--- a/src/Filtering/ImageFeature/ApplyAFilterOnlyToASpecifiedImageRegion/Code.cxx
+++ b/src/Filtering/ImageFeature/ApplyAFilterOnlyToASpecifiedImageRegion/Code.cxx
@@ -20,7 +20,7 @@
 #include "itkDerivativeImageFilter.h"
 
 int
-main(int, char *[])
+main()
 {
   using ImageType = itk::Image<float, 2>;
 

--- a/src/Filtering/ImageFeature/ExtractContoursFromImage/Code.cxx
+++ b/src/Filtering/ImageFeature/ExtractContoursFromImage/Code.cxx
@@ -25,7 +25,7 @@ using UnsignedCharImageType = itk::Image<unsigned char, 2>;
 
 static void CreateImage(UnsignedCharImageType::Pointer image);
 
-int main(int, char *[])
+int main()
 {
   UnsignedCharImageType::Pointer image = UnsignedCharImageType::New();
   CreateImage(image);

--- a/src/Filtering/ImageFilterBase/ApplyKernelToEveryPixel/Code.cxx
+++ b/src/Filtering/ImageFilterBase/ApplyKernelToEveryPixel/Code.cxx
@@ -29,7 +29,7 @@ void
 CastRescaleAndWrite(FloatImageType::Pointer image, const std::string & filename);
 
 int
-main(int, char *[])
+main()
 {
   FloatImageType::Pointer image = FloatImageType::New();
   CreateImage(image);

--- a/src/Filtering/ImageFilterBase/ApplyKernelToEveryPixelInNonZeroImage/Code.cxx
+++ b/src/Filtering/ImageFilterBase/ApplyKernelToEveryPixelInNonZeroImage/Code.cxx
@@ -34,7 +34,7 @@ static void
 CreateHalfMask(UnsignedCharImageType::Pointer image, UnsignedCharImageType::Pointer mask);
 
 int
-main(int, char *[])
+main()
 {
   UnsignedCharImageType::Pointer image = UnsignedCharImageType::New();
   CreateImage(image);

--- a/src/Filtering/ImageFilterBase/CustomOperationToCorrespondingPixelsInTwoImages/Code.cxx
+++ b/src/Filtering/ImageFilterBase/CustomOperationToCorrespondingPixelsInTwoImages/Code.cxx
@@ -58,7 +58,7 @@ public:
 } // namespace Functor
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image1 = ImageType::New();
   CreateImage(image1);

--- a/src/Filtering/ImageFilterBase/PredefinedOperationToCorrespondingPixelsInTwoImages/Code.cxx
+++ b/src/Filtering/ImageFilterBase/PredefinedOperationToCorrespondingPixelsInTwoImages/Code.cxx
@@ -24,7 +24,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image1 = ImageType::New();
   CreateImage(image1);

--- a/src/Filtering/ImageFusion/ColorBoundariesOfRegions/Code.cxx
+++ b/src/Filtering/ImageFusion/ColorBoundariesOfRegions/Code.cxx
@@ -32,7 +32,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Filtering/ImageFusion/ColorLabeledRegions/Code.cxx
+++ b/src/Filtering/ImageFusion/ColorLabeledRegions/Code.cxx
@@ -28,7 +28,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Filtering/ImageFusion/OverlayLabelMapOnImage/Code.cxx
+++ b/src/Filtering/ImageFusion/OverlayLabelMapOnImage/Code.cxx
@@ -28,7 +28,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Filtering/ImageGrid/PadImageByWrapping/Code.cxx
+++ b/src/Filtering/ImageGrid/PadImageByWrapping/Code.cxx
@@ -26,7 +26,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Filtering/ImageGrid/ShrinkImage/Code.cxx
+++ b/src/Filtering/ImageGrid/ShrinkImage/Code.cxx
@@ -25,7 +25,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Filtering/ImageIntensity/AbsValueOfImage/Code.cxx
+++ b/src/Filtering/ImageIntensity/AbsValueOfImage/Code.cxx
@@ -31,7 +31,7 @@ static void
 CreateImage(FloatImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   FloatImageType::Pointer image = FloatImageType::New();
   CreateImage(image);

--- a/src/Filtering/ImageIntensity/AddConstantToEveryPixel/Code.cxx
+++ b/src/Filtering/ImageIntensity/AddConstantToEveryPixel/Code.cxx
@@ -24,7 +24,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Filtering/ImageIntensity/AddTwoImages/Code.cxx
+++ b/src/Filtering/ImageIntensity/AddTwoImages/Code.cxx
@@ -38,7 +38,7 @@ static void
 CreateImage2(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image1 = ImageType::New();
   CreateImage1(image1);

--- a/src/Filtering/ImageIntensity/BinaryANDTwoImages/Code.cxx
+++ b/src/Filtering/ImageIntensity/BinaryANDTwoImages/Code.cxx
@@ -28,7 +28,7 @@ static void
 CreateImage2(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image1 = ImageType::New();
   CreateImage1(image1);

--- a/src/Filtering/ImageIntensity/BinaryORTwoImages/Code.cxx
+++ b/src/Filtering/ImageIntensity/BinaryORTwoImages/Code.cxx
@@ -28,7 +28,7 @@ static void
 CreateImage2(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image1 = ImageType::New();
   CreateImage1(image1);

--- a/src/Filtering/ImageIntensity/BinaryXORTwoImages/Code.cxx
+++ b/src/Filtering/ImageIntensity/BinaryXORTwoImages/Code.cxx
@@ -28,7 +28,7 @@ static void
 CreateImage2(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image1 = ImageType::New();
   CreateImage1(image1);

--- a/src/Filtering/ImageIntensity/CompareTwoImagesAndSetOutputPixelToMax/Code.cxx
+++ b/src/Filtering/ImageIntensity/CompareTwoImagesAndSetOutputPixelToMax/Code.cxx
@@ -27,7 +27,7 @@ static void
 CreateImage2(ImageType * image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image1 = ImageType::New();
   CreateImage1(image1);

--- a/src/Filtering/ImageIntensity/CompareTwoImagesAndSetOutputPixelToMin/Code.cxx
+++ b/src/Filtering/ImageIntensity/CompareTwoImagesAndSetOutputPixelToMin/Code.cxx
@@ -27,7 +27,7 @@ static void
 CreateImage2(ImageType * image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image1 = ImageType::New();
   CreateImage1(image1);

--- a/src/Filtering/ImageIntensity/ExtractComponentOfVectorImage/Code.cxx
+++ b/src/Filtering/ImageIntensity/ExtractComponentOfVectorImage/Code.cxx
@@ -27,7 +27,7 @@ static void
 CreateImage(VectorImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   VectorImageType::Pointer image = VectorImageType::New();
   CreateImage(image);

--- a/src/Filtering/ImageIntensity/IntensityWindowing/Code.cxx
+++ b/src/Filtering/ImageIntensity/IntensityWindowing/Code.cxx
@@ -26,7 +26,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Filtering/ImageIntensity/InverseOfMaskToImage/Code.cxx
+++ b/src/Filtering/ImageIntensity/InverseOfMaskToImage/Code.cxx
@@ -27,7 +27,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Filtering/ImageIntensity/PixelDivisionOfTwoImages/Code.cxx
+++ b/src/Filtering/ImageIntensity/PixelDivisionOfTwoImages/Code.cxx
@@ -27,7 +27,7 @@ void
 CreateImage2(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image1 = ImageType::New();
   CreateImage1(image1);

--- a/src/Filtering/ImageIntensity/ScalePixelSumToConstant/Code.cxx
+++ b/src/Filtering/ImageIntensity/ScalePixelSumToConstant/Code.cxx
@@ -25,7 +25,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   // Create an image
   ImageType::Pointer image = ImageType::New();

--- a/src/Filtering/ImageIntensity/SquareEveryPixel/Code.cxx
+++ b/src/Filtering/ImageIntensity/SquareEveryPixel/Code.cxx
@@ -24,7 +24,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Filtering/ImageIntensity/SubtractConstantFromEveryPixel/Code.cxx
+++ b/src/Filtering/ImageIntensity/SubtractConstantFromEveryPixel/Code.cxx
@@ -24,7 +24,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Filtering/ImageIntensity/SubtractTwoImages/Code.cxx
+++ b/src/Filtering/ImageIntensity/SubtractTwoImages/Code.cxx
@@ -38,7 +38,7 @@ static void
 CreateImage2(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image1 = ImageType::New();
   CreateImage1(image1);

--- a/src/Filtering/ImageLabel/ExtractBoundariesOfConnectedRegionsInBinaryImage/Code.cxx
+++ b/src/Filtering/ImageLabel/ExtractBoundariesOfConnectedRegionsInBinaryImage/Code.cxx
@@ -28,7 +28,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Filtering/ImageLabel/ExtractInnerAndOuterBoundariesOfBlobsInBinaryImage/Code.cxx
+++ b/src/Filtering/ImageLabel/ExtractInnerAndOuterBoundariesOfBlobsInBinaryImage/Code.cxx
@@ -29,7 +29,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Filtering/ImageStatistics/StatisticalPropertiesOfRegions/Code.cxx
+++ b/src/Filtering/ImageStatistics/StatisticalPropertiesOfRegions/Code.cxx
@@ -27,7 +27,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Filtering/LabelMap/ConvertImageToLabelMap/Code.cxx
+++ b/src/Filtering/LabelMap/ConvertImageToLabelMap/Code.cxx
@@ -25,7 +25,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Filtering/LabelMap/ConvertImageWithLabelsToShapeLabelMap/Code.cxx
+++ b/src/Filtering/LabelMap/ConvertImageWithLabelsToShapeLabelMap/Code.cxx
@@ -25,7 +25,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Filtering/LabelMap/ConvertLabelMapToImage/Code.cxx
+++ b/src/Filtering/LabelMap/ConvertLabelMapToImage/Code.cxx
@@ -26,7 +26,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Filtering/LabelMap/InvertImageUsingBinaryNot/Code.cxx
+++ b/src/Filtering/LabelMap/InvertImageUsingBinaryNot/Code.cxx
@@ -27,7 +27,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
 #if ITK_VERSION_MAJOR >= 4
   ImageType::Pointer image = ImageType::New();

--- a/src/Filtering/LabelMap/KeepBinaryRegionsThatMeetSpecific/Code.cxx
+++ b/src/Filtering/LabelMap/KeepBinaryRegionsThatMeetSpecific/Code.cxx
@@ -23,7 +23,7 @@ void
 CreateImage(ImageType::Pointer image1, ImageType::Pointer image2);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer binaryImage = ImageType::New();
   ImageType::Pointer featureImage = ImageType::New();

--- a/src/Filtering/LabelMap/KeepRegionsAboveLevel/Code.cxx
+++ b/src/Filtering/LabelMap/KeepRegionsAboveLevel/Code.cxx
@@ -29,7 +29,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Filtering/LabelMap/KeepRegionsThatMeetSpecific/Code.cxx
+++ b/src/Filtering/LabelMap/KeepRegionsThatMeetSpecific/Code.cxx
@@ -29,7 +29,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Filtering/LabelMap/LabelBinaryRegionsAndGetProperties/Code.cxx
+++ b/src/Filtering/LabelMap/LabelBinaryRegionsAndGetProperties/Code.cxx
@@ -25,7 +25,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Filtering/LabelMap/LabelBinaryRegionsInImage/Code.cxx
+++ b/src/Filtering/LabelMap/LabelBinaryRegionsInImage/Code.cxx
@@ -25,7 +25,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Filtering/LabelMap/MergeLabelMaps/Code.cxx
+++ b/src/Filtering/LabelMap/MergeLabelMaps/Code.cxx
@@ -19,7 +19,7 @@
 #include "itkMergeLabelMapFilter.h"
 
 int
-main(int, char *[])
+main()
 {
   using ImageType = itk::Image<int, 3>;
 

--- a/src/Filtering/LabelMap/RemoveLabelsFromLabelMap/Code.cxx
+++ b/src/Filtering/LabelMap/RemoveLabelsFromLabelMap/Code.cxx
@@ -24,7 +24,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Filtering/MathematicalMorphology/CreateABinaryBallStructuringElement/Code.cxx
+++ b/src/Filtering/MathematicalMorphology/CreateABinaryBallStructuringElement/Code.cxx
@@ -19,7 +19,7 @@
 #include "itkBinaryBallStructuringElement.h"
 
 int
-main(int, char *[])
+main()
 {
   constexpr unsigned int Dimension = 3;
   using PixelType = float;

--- a/src/Filtering/MathematicalMorphology/GenerateStructureElementsWithAccurateArea/Code.cxx
+++ b/src/Filtering/MathematicalMorphology/GenerateStructureElementsWithAccurateArea/Code.cxx
@@ -23,7 +23,7 @@ bool
 ComputeAreaError(SEType k, unsigned int thickness = 0);
 
 int
-main(int, char *[])
+main()
 {
   int  scalarRadius = 5;
   int  scalarThickness = 2;

--- a/src/Filtering/MathematicalMorphology/RegionalMaximal/Code.cxx
+++ b/src/Filtering/MathematicalMorphology/RegionalMaximal/Code.cxx
@@ -26,7 +26,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Filtering/MathematicalMorphology/RegionalMinimal/Code.cxx
+++ b/src/Filtering/MathematicalMorphology/RegionalMinimal/Code.cxx
@@ -25,7 +25,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Filtering/MathematicalMorphology/ValuedRegionalMaximaImage/Code.cxx
+++ b/src/Filtering/MathematicalMorphology/ValuedRegionalMaximaImage/Code.cxx
@@ -26,7 +26,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Filtering/MathematicalMorphology/ValuedRegionalMinimalImage/Code.cxx
+++ b/src/Filtering/MathematicalMorphology/ValuedRegionalMinimalImage/Code.cxx
@@ -25,7 +25,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Filtering/Path/DataStructureForPieceWiseLinearCurve/Code.cxx
+++ b/src/Filtering/Path/DataStructureForPieceWiseLinearCurve/Code.cxx
@@ -18,7 +18,7 @@
 #include "itkPolyLineParametricPath.h"
 
 int
-main(int, char *[])
+main()
 {
   using PathType = itk::PolyLineParametricPath<2>;
 

--- a/src/Filtering/Path/ExtractContoursFromImage/Code.cxx
+++ b/src/Filtering/Path/ExtractContoursFromImage/Code.cxx
@@ -27,7 +27,7 @@ static void
 CreateImage(UnsignedCharImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   UnsignedCharImageType::Pointer image = UnsignedCharImageType::New();
   CreateImage(image);

--- a/src/IO/ImageBase/ConvertImageToAnotherType/Code.cxx
+++ b/src/IO/ImageBase/ConvertImageToAnotherType/Code.cxx
@@ -23,7 +23,7 @@
 #include "itkImageRandomConstIteratorWithIndex.h"
 
 int
-main(int, char *[])
+main()
 {
   constexpr int xDimension = 200;
   constexpr int yDimension = 100;

--- a/src/IO/ImageBase/CreateAListOfFileNames/Code.cxx
+++ b/src/IO/ImageBase/CreateAListOfFileNames/Code.cxx
@@ -19,7 +19,7 @@
 #include "itkNumericSeriesFileNames.h"
 
 int
-main(int, char *[])
+main()
 {
   itk::NumericSeriesFileNames::Pointer numericSeriesFileNames = itk::NumericSeriesFileNames::New();
   numericSeriesFileNames->SetStartIndex(0);

--- a/src/Numerics/Optimizers/AmoebaOptimizer/Code.cxx
+++ b/src/Numerics/Optimizers/AmoebaOptimizer/Code.cxx
@@ -26,7 +26,7 @@ using CostType = itk::ExampleCostFunction2;
 } // namespace
 
 int
-main(int, char *[])
+main()
 {
 
   // Instantiate the optimizer

--- a/src/Numerics/Optimizers/LevenbergMarquardtOptimization/Code.cxx
+++ b/src/Numerics/Optimizers/LevenbergMarquardtOptimization/Code.cxx
@@ -24,7 +24,7 @@ using OptimizerType = itk::LevenbergMarquardtOptimizer;
 using CostType = itk::ExampleCostFunction;
 
 int
-main(int, char *[])
+main()
 {
 
   // Instantiate the cost function and optimizer

--- a/src/Numerics/Statistics/2DGaussianMixtureModelExpectMax/Code.cxx
+++ b/src/Numerics/Statistics/2DGaussianMixtureModelExpectMax/Code.cxx
@@ -22,7 +22,7 @@
 #include "itkNormalVariateGenerator.h"
 
 int
-main(int, char *[])
+main()
 {
   unsigned int numberOfClasses = 2;
   using MeasurementVectorType = itk::Vector<double, 2>;

--- a/src/Numerics/Statistics/ComputeHistogramOfMaskedRegion/Code.cxx
+++ b/src/Numerics/Statistics/ComputeHistogramOfMaskedRegion/Code.cxx
@@ -33,7 +33,7 @@ static void
 static void CreateHalfMask(itk::ImageRegion<2>, UnsignedCharImageType::Pointer mask);
 
 int
-main(int, char *[])
+main()
 {
   constexpr unsigned int MeasurementVectorSize = 3; // RGB
 

--- a/src/Numerics/Statistics/ComputeTextureFeatures/Code.cxx
+++ b/src/Numerics/Statistics/ComputeTextureFeatures/Code.cxx
@@ -24,7 +24,7 @@ using ImageType = itk::Image<float, 2>;
 static void CreateImage(ImageType::Pointer);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Numerics/Statistics/CreateGaussianDistribution/Code.cxx
+++ b/src/Numerics/Statistics/CreateGaussianDistribution/Code.cxx
@@ -18,7 +18,7 @@
 #include "itkGaussianDistribution.h"
 
 int
-main(int, char *[])
+main()
 {
   itk::Statistics::GaussianDistribution::Pointer gaussian = itk::Statistics::GaussianDistribution::New();
   gaussian->SetMean(2.0);

--- a/src/Numerics/Statistics/CreateHistogramFromListOfMeasurements/Code.cxx
+++ b/src/Numerics/Statistics/CreateHistogramFromListOfMeasurements/Code.cxx
@@ -28,7 +28,7 @@ void
 CreateSample(SampleType::Pointer sample);
 
 int
-main(int, char *[])
+main()
 {
   SampleType::Pointer sample = SampleType::New();
   CreateSample(sample);

--- a/src/Numerics/Statistics/CreateListOfSampleMeasurements/Code.cxx
+++ b/src/Numerics/Statistics/CreateListOfSampleMeasurements/Code.cxx
@@ -19,7 +19,7 @@
 #include "itkVector.h"
 
 int
-main(int, char *[])
+main()
 {
   using MeasurementVectorType = itk::Vector<float, 3>;
   using SampleType = itk::Statistics::ListSample<MeasurementVectorType>;

--- a/src/Numerics/Statistics/CreateListOfSamplesFromImageWithoutDuplication/Code.cxx
+++ b/src/Numerics/Statistics/CreateListOfSamplesFromImageWithoutDuplication/Code.cxx
@@ -21,7 +21,7 @@
 #include "itkComposeImageFilter.h"
 
 int
-main(int, char *[])
+main()
 {
   using FloatImage2DType = itk::Image<float, 2>;
 

--- a/src/Numerics/Statistics/CreateListOfSamplesWithIDs/Code.cxx
+++ b/src/Numerics/Statistics/CreateListOfSamplesWithIDs/Code.cxx
@@ -20,7 +20,7 @@
 #include "itkVector.h"
 
 int
-main(int, char *[])
+main()
 {
   using MeasurementVectorType = itk::Vector<float, 3>;
   using SampleType = itk::Statistics::ListSample<MeasurementVectorType>;

--- a/src/Numerics/Statistics/DistributeSamplingUsingGMM/Code.cxx
+++ b/src/Numerics/Statistics/DistributeSamplingUsingGMM/Code.cxx
@@ -22,7 +22,7 @@
 #include "itkNormalVariateGenerator.h"
 
 int
-main(int, char *[])
+main()
 {
   unsigned int numberOfClasses = 2;
   using MeasurementVectorType = itk::Vector<double, 1>;

--- a/src/Numerics/Statistics/SpatialSearch/Code.cxx
+++ b/src/Numerics/Statistics/SpatialSearch/Code.cxx
@@ -21,7 +21,7 @@
 #include "itkEuclideanDistanceMetric.h"
 
 int
-main(int, char *[])
+main()
 {
   using MeasurementVectorType = itk::Vector<float, 2>;
 

--- a/src/Registration/Common/GlobalRegistrationOfTwoImages/Code.cxx
+++ b/src/Registration/Common/GlobalRegistrationOfTwoImages/Code.cxx
@@ -39,7 +39,7 @@ static void
 CreateSphereImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   //  The transform that will map the fixed image into the moving image.
   using TransformType = itk::TranslationTransform<double, Dimension>;

--- a/src/Registration/Common/MultiresolutionPyramidFromImage/Code.cxx
+++ b/src/Registration/Common/MultiresolutionPyramidFromImage/Code.cxx
@@ -26,7 +26,7 @@ static void
 CreateImage(UnsignedCharImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   UnsignedCharImageType::Pointer image = UnsignedCharImageType::New();
   CreateImage(image);

--- a/src/Segmentation/Classifiers/ClusterPixelsInGrayscaleImage/Code.cxx
+++ b/src/Segmentation/Classifiers/ClusterPixelsInGrayscaleImage/Code.cxx
@@ -37,7 +37,7 @@ static void
 CreateImage(ImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
   CreateImage(image);

--- a/src/Segmentation/Classifiers/KMeansClusterOfPixelsInImage/Code.cxx
+++ b/src/Segmentation/Classifiers/KMeansClusterOfPixelsInImage/Code.cxx
@@ -34,7 +34,7 @@ static void
 CreateImage(ColorImageType::Pointer image);
 
 int
-main(int, char *[])
+main()
 {
   // Create a demo image
   ColorImageType::Pointer image = ColorImageType::New();

--- a/src/Segmentation/ConnectedComponents/AssignContiguousLabelsToConnectedRegions/Code.cxx
+++ b/src/Segmentation/ConnectedComponents/AssignContiguousLabelsToConnectedRegions/Code.cxx
@@ -38,7 +38,7 @@ static void
 CreateRandomColormap(unsigned int size, ColormapType::Pointer colormap);
 
 int
-main(int, char *[])
+main()
 {
   ImageType::Pointer image = ImageType::New();
 

--- a/src/Segmentation/Voronoi/VoronoiDiagram/Code.cxx
+++ b/src/Segmentation/Voronoi/VoronoiDiagram/Code.cxx
@@ -20,7 +20,7 @@
 #include "itkVTKPolyDataWriter.h"
 
 int
-main(int, char *[])
+main()
 {
   constexpr double height = 100;
   constexpr double width = 100;


### PR DESCRIPTION
I guess this is just a matter of taste. I just find those `int, char *[]` parameters distracting, whenever they are both unused.