### PR TITLE
STYLE: Replace postfix by prefix increment in C++ `for` loops

### DIFF
--- a/src/Core/Common/ComputeTimeBetweenPoints/Code.cxx
+++ b/src/Core/Common/ComputeTimeBetweenPoints/Code.cxx
@@ -25,7 +25,7 @@
 void
 LongFunction()
 {
-  for (int i = 0; i < itk::NumericTraits<int>::max() / 100; i++)
+  for (int i = 0; i < itk::NumericTraits<int>::max() / 100; ++i)
   {
     double a = 0;
     (void)a;

--- a/src/Core/Common/ConvertArrayToImage/Code.cxx
+++ b/src/Core/Common/ConvertArrayToImage/Code.cxx
@@ -66,13 +66,13 @@ main()
   const double radius2 = radius * radius;
   PixelType *  it = localBuffer;
 
-  for (unsigned int z = 0; z < size[2]; z++)
+  for (unsigned int z = 0; z < size[2]; ++z)
   {
     const double dz = static_cast<double>(z) - static_cast<double>(size[2]) / 2.0;
-    for (unsigned int y = 0; y < size[1]; y++)
+    for (unsigned int y = 0; y < size[1]; ++y)
     {
       const double dy = static_cast<double>(y) - static_cast<double>(size[1]) / 2.0;
-      for (unsigned int x = 0; x < size[0]; x++)
+      for (unsigned int x = 0; x < size[0]; ++x)
       {
         const double dx = static_cast<double>(x) - static_cast<double>(size[0]) / 2.0;
         const double d2 = dx * dx + dy * dy + dz * dz;

--- a/src/Core/Common/CovariantVectorNorm/Code.cxx
+++ b/src/Core/Common/CovariantVectorNorm/Code.cxx
@@ -45,7 +45,7 @@ main()
   // another way to normalize
   if (vnorm != 0.)
   {
-    for (unsigned int i = 0; i < u.GetNumberOfComponents(); i++)
+    for (unsigned int i = 0; i < u.GetNumberOfComponents(); ++i)
     {
       u[i] /= vnorm;
     }

--- a/src/Core/Common/CreateABackwardDifferenceOperator/Code.cxx
+++ b/src/Core/Common/CreateABackwardDifferenceOperator/Code.cxx
@@ -39,7 +39,7 @@ main()
 
   std::cout << backwardDifferenceOperator << std::endl;
 
-  for (unsigned int i = 0; i < 9; i++)
+  for (unsigned int i = 0; i < 9; ++i)
   {
     std::cout << backwardDifferenceOperator.GetOffset(i) << " " << backwardDifferenceOperator.GetElement(i)
               << std::endl;

--- a/src/Core/Common/CreateDerivativeKernel/Code.cxx
+++ b/src/Core/Common/CreateDerivativeKernel/Code.cxx
@@ -31,7 +31,7 @@ main()
 
   std::cout << derivativeOperator << std::endl;
 
-  for (unsigned int i = 0; i < 9; i++)
+  for (unsigned int i = 0; i < 9; ++i)
   {
     std::cout << derivativeOperator.GetOffset(i) << " " << derivativeOperator.GetElement(i) << std::endl;
   }

--- a/src/Core/Common/CreateForwardDifferenceKernel/Code.cxx
+++ b/src/Core/Common/CreateForwardDifferenceKernel/Code.cxx
@@ -31,7 +31,7 @@ main()
 
   std::cout << forwardDifferenceOperator << std::endl;
 
-  for (unsigned int i = 0; i < 9; i++)
+  for (unsigned int i = 0; i < 9; ++i)
   {
     std::cout << forwardDifferenceOperator.GetOffset(i) << " " << forwardDifferenceOperator.GetElement(i) << std::endl;
   }

--- a/src/Core/Common/CreateGaussianDerivativeKernel/Code.cxx
+++ b/src/Core/Common/CreateGaussianDerivativeKernel/Code.cxx
@@ -31,7 +31,7 @@ main()
 
   std::cout << gaussianDerivativeOperator << std::endl;
 
-  for (unsigned int i = 0; i < 9; i++)
+  for (unsigned int i = 0; i < 9; ++i)
   {
     std::cout << gaussianDerivativeOperator.GetOffset(i) << " " << gaussianDerivativeOperator.GetElement(i)
               << std::endl;

--- a/src/Core/Common/CreateGaussianKernel/Code.cxx
+++ b/src/Core/Common/CreateGaussianKernel/Code.cxx
@@ -31,7 +31,7 @@ main()
 
   std::cout << gaussianOperator << std::endl;
 
-  for (unsigned int i = 0; i < 9; i++)
+  for (unsigned int i = 0; i < 9; ++i)
   {
     std::cout << gaussianOperator.GetOffset(i) << " " << gaussianOperator.GetElement(i) << std::endl;
   }

--- a/src/Core/Common/CreateLaplacianKernel/Code.cxx
+++ b/src/Core/Common/CreateLaplacianKernel/Code.cxx
@@ -30,7 +30,7 @@ main()
 
   std::cout << laplacianOperator << std::endl;
 
-  for (unsigned int i = 0; i < laplacianOperator.GetSize()[0] * laplacianOperator.GetSize()[1]; i++)
+  for (unsigned int i = 0; i < laplacianOperator.GetSize()[0] * laplacianOperator.GetSize()[1]; ++i)
   {
     std::cout << laplacianOperator.GetOffset(i) << " " << laplacianOperator.GetElement(i) << std::endl;
   }

--- a/src/Core/Common/CreateSobelKernel/Code.cxx
+++ b/src/Core/Common/CreateSobelKernel/Code.cxx
@@ -29,7 +29,7 @@ main()
 
   std::cout << sobelOperator << std::endl;
 
-  for (unsigned int i = 0; i < 9; i++)
+  for (unsigned int i = 0; i < 9; ++i)
   {
     std::cout << sobelOperator.GetElement(i) << std::endl;
   }

--- a/src/Core/Common/DemonstrateAllOperators/Code.cxx
+++ b/src/Core/Common/DemonstrateAllOperators/Code.cxx
@@ -64,9 +64,9 @@ main()
     // operators[operatorId]->Print(std::cout);
     // std::cout << operators[operatorId]->GetNameOfClass() << std::endl;
 
-    for (auto i = -operatorId->GetSize()[0] / 2; i <= operatorId->GetSize()[0] / 2; i++)
+    for (auto i = -operatorId->GetSize()[0] / 2; i <= operatorId->GetSize()[0] / 2; ++i)
     {
-      for (auto j = -operatorId->GetSize()[1] / 2; j <= operatorId->GetSize()[1] / 2; j++)
+      for (auto j = -operatorId->GetSize()[1] / 2; j <= operatorId->GetSize()[1] / 2; ++j)
       {
         itk::Offset<2> offset;
         offset[0] = i;

--- a/src/Core/Common/DisplayImage/Code.cxx
+++ b/src/Core/Common/DisplayImage/Code.cxx
@@ -80,9 +80,9 @@ CreateImage(ImageType * const image)
   image->Allocate();
 
   // Make a square
-  for (unsigned int r = 40; r < 100; r++)
+  for (unsigned int r = 40; r < 100; ++r)
   {
-    for (unsigned int c = 40; c < 100; c++)
+    for (unsigned int c = 40; c < 100; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = r;

--- a/src/Core/Common/ImportPixelBufferIntoAnImage/Code.cxx
+++ b/src/Core/Common/ImportPixelBufferIntoAnImage/Code.cxx
@@ -73,10 +73,10 @@ main(int argc, char * argv[])
   const double radius2 = radius * radius;
   PixelType *  it = localBuffer;
 
-  for (unsigned int y = 0; y < size[1]; y++)
+  for (unsigned int y = 0; y < size[1]; ++y)
   {
     const double dy = static_cast<double>(y) - static_cast<double>(size[1]) / 2.0;
-    for (unsigned int x = 0; x < size[0]; x++)
+    for (unsigned int x = 0; x < size[0]; ++x)
     {
       const double dx = static_cast<double>(x) - static_cast<double>(size[0]) / 2.0;
       const double d2 = dx * dx + dy * dy;

--- a/src/Core/Common/IterateRegionWithNeighborhood/Code.cxx
+++ b/src/Core/Common/IterateRegionWithNeighborhood/Code.cxx
@@ -67,7 +67,7 @@ main(int argc, char * argv[])
     // Set the current pixel to white
     iterator.SetCenterPixel(255);
 
-    for (unsigned int i = 0; i < 9; i++)
+    for (unsigned int i = 0; i < 9; ++i)
     {
       ImageType::IndexType index = iterator.GetIndex(i);
       std::cout << index[0] << " " << index[1] << std::endl;

--- a/src/Core/Common/IterateWithNeighborhoodWithoutAccess/Code.cxx
+++ b/src/Core/Common/IterateWithNeighborhoodWithoutAccess/Code.cxx
@@ -53,7 +53,7 @@ main(int argc, char * argv[])
 
   while (!iterator.IsAtEnd())
   {
-    for (unsigned int i = 0; i < 9; i++)
+    for (unsigned int i = 0; i < 9; ++i)
     {
       ImageType::IndexType index = iterator.GetIndex(i);
       std::cout << index[0] << " " << index[1] << std::endl;

--- a/src/Core/Common/MakeOutOfBoundsPixelsReturnConstValue/Code.cxx
+++ b/src/Core/Common/MakeOutOfBoundsPixelsReturnConstValue/Code.cxx
@@ -62,7 +62,7 @@ main()
 
   while (!iterator.IsAtEnd())
   {
-    for (unsigned int i = 0; i < 9; i++)
+    for (unsigned int i = 0; i < 9; ++i)
     {
       ImageType::IndexType index = iterator.GetIndex(i);
 

--- a/src/Core/Common/MiniPipeline/Code.cxx
+++ b/src/Core/Common/MiniPipeline/Code.cxx
@@ -71,9 +71,9 @@ CreateImage(TImage * const image)
   image->Allocate();
 
   // Make another square
-  for (unsigned int r = 40; r < 100; r++)
+  for (unsigned int r = 40; r < 100; ++r)
   {
-    for (unsigned int c = 40; c < 100; c++)
+    for (unsigned int c = 40; c < 100; ++c)
     {
       typename TImage::IndexType pixelIndex;
       pixelIndex[0] = r;

--- a/src/Core/Common/PermuteSequenceOfIndices/Code.cxx
+++ b/src/Core/Common/PermuteSequenceOfIndices/Code.cxx
@@ -24,7 +24,7 @@ main()
 
   std::cout << std::endl;
 
-  for (unsigned int i = 0; i < 5; i++)
+  for (unsigned int i = 0; i < 5; ++i)
   {
     std::cout << rp[i] << " ";
   }
@@ -32,7 +32,7 @@ main()
 
   rp.Shuffle();
   std::cout << "After shuffle" << std::endl;
-  for (unsigned int i = 0; i < 5; i++)
+  for (unsigned int i = 0; i < 5; ++i)
   {
     std::cout << rp[i] << " ";
   }

--- a/src/Core/Common/ReadAPointSet/Code.cxx
+++ b/src/Core/Common/ReadAPointSet/Code.cxx
@@ -91,7 +91,7 @@ main(int argc, char * argv[])
   }
 
   // Retrieve points
-  for (unsigned int i = 0; i < numberOfPoints; i++)
+  for (unsigned int i = 0; i < numberOfPoints; ++i)
   {
     PointType pp;
     bool      pointExists = mesh->GetPoint(i, &pp);

--- a/src/Core/Common/SetPixelValueInOneImage/Code.cxx
+++ b/src/Core/Common/SetPixelValueInOneImage/Code.cxx
@@ -54,7 +54,7 @@ main(int argc, char * argv[])
 
   ImageType::IndexType pixelIndex;
 
-  for (ImageType::IndexValueType r = 0; r < 50; r++)
+  for (ImageType::IndexValueType r = 0; r < 50; ++r)
   {
     pixelIndex[0] = 4 * r;
     pixelIndex[1] = 4 * r;
@@ -67,7 +67,7 @@ main(int argc, char * argv[])
     image->SetPixel(pixelIndex, 255);
   }
 
-  for (ImageType::IndexValueType r = 0; r < 25; r++)
+  for (ImageType::IndexValueType r = 0; r < 25; ++r)
   {
     pixelIndex[0] = 8 * r;
     pixelIndex[1] = 200 + 4 * r;

--- a/src/Core/Common/UseParallelizeImageRegion/Code.cxx
+++ b/src/Core/Common/UseParallelizeImageRegion/Code.cxx
@@ -62,7 +62,7 @@ segmentationAndCustomColorization(InputImageType::Pointer inImage)
         OutputPixelType             p;
         p.SetAlpha(iIt.Get());
         static_assert(Dimension <= 3, "Dimension has to be 2 or 3");
-        for (unsigned d = 0; d < Dimension; d++)
+        for (unsigned d = 0; d < Dimension; ++d)
         {
           p.SetElement(d, ind[d]);
         }

--- a/src/Core/Common/VariableLengthVector/Code.cxx
+++ b/src/Core/Common/VariableLengthVector/Code.cxx
@@ -33,7 +33,7 @@ main()
   v[1] = 2;
   std::cout << v << std::endl;
 
-  for (unsigned int i = 0; i < v.Size(); i++)
+  for (unsigned int i = 0; i < v.Size(); ++i)
   {
     std::cout << v[i] << " ";
   }
@@ -81,7 +81,7 @@ VariableLengthVectorToVector()
   using FixedVectorType = itk::Vector<double, 2>;
   FixedVectorType fixedLengthVector;
 
-  for (unsigned int i = 0; i < FixedVectorType::GetVectorDimension(); i++)
+  for (unsigned int i = 0; i < FixedVectorType::GetVectorDimension(); ++i)
   {
     fixedLengthVector[i] = variableLengthVector[i];
   }

--- a/src/Core/ImageFunction/LinearlyInterpolatePositionInImage/Code.cxx
+++ b/src/Core/ImageFunction/LinearlyInterpolatePositionInImage/Code.cxx
@@ -60,7 +60,7 @@ CreateImage(ImageType::Pointer image)
   image->SetRegions(region);
   image->Allocate();
 
-  for (unsigned int i = 0; i < 10; i++)
+  for (unsigned int i = 0; i < 10; ++i)
   {
     ImageType::IndexType pixelIndex;
     pixelIndex[0] = i;

--- a/src/Core/ImageFunction/MultiplyKernelWithAnImageAtLocation/Code.cxx
+++ b/src/Core/ImageFunction/MultiplyKernelWithAnImageAtLocation/Code.cxx
@@ -87,9 +87,9 @@ CreateImage(UnsignedCharImageType::Pointer image)
   image->FillBuffer(0);
 
   // Make a square
-  for (unsigned int r = 20; r < 80; r++)
+  for (unsigned int r = 20; r < 80; ++r)
   {
-    for (unsigned int c = 20; c < 80; c++)
+    for (unsigned int c = 20; c < 80; ++c)
     {
       UnsignedCharImageType::IndexType pixelIndex;
       pixelIndex[0] = r;

--- a/src/Core/QuadEdgeMesh/CreateTriangularQuadEdgeMesh/Code.cxx
+++ b/src/Core/QuadEdgeMesh/CreateTriangularQuadEdgeMesh/Code.cxx
@@ -53,11 +53,11 @@ main(int argc, char * argv[])
   using PointIdentifier = MeshType::PointIdentifier;
   PointIdentifier k = 0;
 
-  for (int i = 0; i < 10; i++)
+  for (int i = 0; i < 10; ++i)
   {
     p[0] = static_cast<CoordType>(i);
 
-    for (int j = 0; j < 10; j++)
+    for (int j = 0; j < 10; ++j)
     {
       p[1] = static_cast<CoordType>(j);
       points->SetElement(k, p);
@@ -69,9 +69,9 @@ main(int argc, char * argv[])
 
   k = 0;
 
-  for (int i = 0; i < 9; i++)
+  for (int i = 0; i < 9; ++i)
   {
-    for (int j = 0; j < 9; j++)
+    for (int j = 0; j < 9; ++j)
     {
       mesh->AddFaceTriangle(k, k + 1, k + 11);
       mesh->AddFaceTriangle(k, k + 11, k + 10);

--- a/src/Core/SpatialObjects/Blob/Code.cxx
+++ b/src/Core/SpatialObjects/Blob/Code.cxx
@@ -24,7 +24,7 @@ main(int itkNotUsed(argc), char * itkNotUsed(argv)[])
 
   // Create a list of points
   BlobType::BlobPointListType points;
-  for (unsigned int i = 0; i < 20; i++)
+  for (unsigned int i = 0; i < 20; ++i)
   {
     BlobType::BlobPointType point;
     point.SetPositionInObjectSpace(i, i);

--- a/src/Core/SpatialObjects/CreateALineSpatialObject/Code.cxx
+++ b/src/Core/SpatialObjects/CreateALineSpatialObject/Code.cxx
@@ -35,7 +35,7 @@ main(int itkNotUsed(argc), char * itkNotUsed(argv)[])
 
   // Create a list of points
   std::vector<LineType::LinePointType> points;
-  for (unsigned int i = 0; i < 20; i++)
+  for (unsigned int i = 0; i < 20; ++i)
   {
     LineType::LinePointType point;
     point.SetPositionInObjectSpace(10, i);

--- a/src/Core/Transform/ApplyAffineTransformFromHomogeneousMatrixAndResample/Code.cxx
+++ b/src/Core/Transform/ApplyAffineTransformFromHomogeneousMatrixAndResample/Code.cxx
@@ -81,14 +81,14 @@ main(int argc, char * argv[])
 
   // get transform parameters from MatrixType
   TransformType::ParametersType parameters(Dimension * Dimension + Dimension);
-  for (unsigned int i = 0; i < Dimension; i++)
+  for (unsigned int i = 0; i < Dimension; ++i)
   {
-    for (unsigned int j = 0; j < Dimension; j++)
+    for (unsigned int j = 0; j < Dimension; ++j)
     {
       parameters[i * Dimension + j] = matrix[i][j];
     }
   }
-  for (unsigned int i = 0; i < Dimension; i++)
+  for (unsigned int i = 0; i < Dimension; ++i)
   {
     parameters[i + Dimension * Dimension] = matrix[i][Dimension];
   }

--- a/src/Core/Transform/GlobalRegistrationTwoImagesBSpline/Code.cxx
+++ b/src/Core/Transform/GlobalRegistrationTwoImagesBSpline/Code.cxx
@@ -100,7 +100,7 @@ main(int itkNotUsed(argc), char * itkNotUsed(argv)[])
 
   TransformType::PhysicalDimensionsType fixedPhysicalDimensions;
   TransformType::MeshSizeType           meshSize;
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     fixedPhysicalDimensions[i] =
       fixedImage->GetSpacing()[i] * static_cast<double>(fixedImage->GetLargestPossibleRegion().GetSize()[i] - 1);

--- a/src/Core/Transform/ScaleAnImage/Code.cxx
+++ b/src/Core/Transform/ScaleAnImage/Code.cxx
@@ -75,9 +75,9 @@ CreateImage(ImageType::Pointer image)
   image->FillBuffer(0);
 
   // Make a white square
-  for (unsigned int r = 40; r < 60; r++)
+  for (unsigned int r = 40; r < 60; ++r)
   {
-    for (unsigned int c = 40; c < 60; c++)
+    for (unsigned int c = 40; c < 60; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = r;

--- a/src/Developer/ImageFilterY.hxx
+++ b/src/Developer/ImageFilterY.hxx
@@ -14,7 +14,7 @@ ImageFilter<TImage>::GenerateData()
   InternalGaussianFilterPointer smoothingFilters[ImageDimension];
 
   // Instantiate all filters
-  for (unsigned int i = 0; i < ImageDimension; i++)
+  for (unsigned int i = 0; i < ImageDimension; ++i)
   {
     smoothingFilters[i] = InternalGaussianFilterType::New();
     smoothingFilters[i]->SetOrder(GaussianOrderEnum::ZeroOrder);
@@ -22,7 +22,7 @@ ImageFilter<TImage>::GenerateData()
   }
 
   // Connect all filters (start at 1 because 0th filter is connected to the input
-  for (unsigned int i = 1; i < ImageDimension; i++)
+  for (unsigned int i = 1; i < ImageDimension; ++i)
   {
     smoothingFilters[i]->SetInput(smoothingFilters[i - 1]->GetOutput());
   }

--- a/src/Developer/MiniPipeline.cxx
+++ b/src/Developer/MiniPipeline.cxx
@@ -49,9 +49,9 @@ CreateImage(TImage * const image)
   image->Allocate();
 
   // Make another square
-  for (unsigned int r = 40; r < 100; r++)
+  for (unsigned int r = 40; r < 100; ++r)
   {
-    for (unsigned int c = 40; c < 100; c++)
+    for (unsigned int c = 40; c < 100; ++c)
     {
       typename TImage::IndexType pixelIndex;
       pixelIndex[0] = r;

--- a/src/Developer/itkOilPaintingImageFilter.hxx
+++ b/src/Developer/itkOilPaintingImageFilter.hxx
@@ -52,7 +52,7 @@ OilPaintingImageFilter<TImage>::DynamicThreadedGenerateData(const typename TImag
 
   while (!out.IsAtEnd())
   {
-    for (unsigned int i = 0; i < m_NumberOfBins; i++)
+    for (unsigned int i = 0; i < m_NumberOfBins; ++i)
     {
       bins[i] = 0; // reset histogram
     }
@@ -69,7 +69,7 @@ OilPaintingImageFilter<TImage>::DynamicThreadedGenerateData(const typename TImag
     // find the peak
     unsigned           maxIndex = 0;
     unsigned long long maxBin = bins[0];
-    for (unsigned int i = 1; i < m_NumberOfBins; i++)
+    for (unsigned int i = 1; i < m_NumberOfBins; ++i)
     {
       if (bins[i] > maxBin)
       {

--- a/src/Filtering/BinaryMathematicalMorphology/ClosingBinaryImage/Code.cxx
+++ b/src/Filtering/BinaryMathematicalMorphology/ClosingBinaryImage/Code.cxx
@@ -113,9 +113,9 @@ CreateImage(ImageType * const image)
   image->Allocate(true);
 
   // Make a square
-  for (unsigned int r = 40; r < 100; r++)
+  for (unsigned int r = 40; r < 100; ++r)
   {
-    for (unsigned int c = 40; c < 100; c++)
+    for (unsigned int c = 40; c < 100; ++c)
     {
       itk::Index<2> pixelIndex;
       pixelIndex[0] = r;

--- a/src/Filtering/BinaryMathematicalMorphology/OpeningBinaryImage/Code.cxx
+++ b/src/Filtering/BinaryMathematicalMorphology/OpeningBinaryImage/Code.cxx
@@ -114,9 +114,9 @@ CreateImage(ImageType * const image)
   image->Allocate(true);
 
   // Make a square
-  for (unsigned int r = 40; r < 100; r++)
+  for (unsigned int r = 40; r < 100; ++r)
   {
-    for (unsigned int c = 40; c < 100; c++)
+    for (unsigned int c = 40; c < 100; ++c)
     {
       itk::Index<2> pixelIndex;
       pixelIndex[0] = r;

--- a/src/Filtering/BinaryMathematicalMorphology/PruneBinaryImage/Code.cxx
+++ b/src/Filtering/BinaryMathematicalMorphology/PruneBinaryImage/Code.cxx
@@ -92,9 +92,9 @@ CreateImage(TImage * const image)
   image->Allocate(true);
 
   // Make a square
-  for (int r = 40; r < 100; r++)
+  for (int r = 40; r < 100; ++r)
   {
-    for (int c = 40; c < 100; c++)
+    for (int c = 40; c < 100; ++c)
     {
       typename TImage::IndexType pixelIndex = { { r, c } };
       image->SetPixel(pixelIndex, 50);

--- a/src/Filtering/DistanceMap/MeanDistanceBetweenAllPointsOnTwoCurves/Code.cxx
+++ b/src/Filtering/DistanceMap/MeanDistanceBetweenAllPointsOnTwoCurves/Code.cxx
@@ -76,9 +76,9 @@ CreateImage1(TImage * const image)
   image->FillBuffer(0);
 
   // Create a diagonal white line through the image
-  for (typename TImage::IndexValueType i = 0; i < 20; i++)
+  for (typename TImage::IndexValueType i = 0; i < 20; ++i)
   {
-    for (typename TImage::IndexValueType j = 0; j < 20; j++)
+    for (typename TImage::IndexValueType j = 0; j < 20; ++j)
     {
       if (i == j)
       {
@@ -104,9 +104,9 @@ CreateImage2(TImage * const image)
   image->FillBuffer(0);
 
   // Create a vertical line of white pixels down the center of the image
-  for (typename TImage::IndexValueType i = 0; i < 20; i++)
+  for (typename TImage::IndexValueType i = 0; i < 20; ++i)
   {
-    for (typename TImage::IndexValueType j = 0; j < 20; j++)
+    for (typename TImage::IndexValueType j = 0; j < 20; ++j)
     {
       if (i == 10)
       {

--- a/src/Filtering/FFT/ComputeInverseFFTOfImage/Code.cxx
+++ b/src/Filtering/FFT/ComputeInverseFFTOfImage/Code.cxx
@@ -85,9 +85,9 @@ CreateImage(FloatImageType * const image)
   image->Allocate();
 
   // Make a square
-  for (FloatImageType::IndexValueType r = 40; r < 100; r++)
+  for (FloatImageType::IndexValueType r = 40; r < 100; ++r)
   {
-    for (FloatImageType::IndexValueType c = 40; c < 100; c++)
+    for (FloatImageType::IndexValueType c = 40; c < 100; ++c)
     {
       FloatImageType::IndexType pixelIndex = { { r, c } };
 

--- a/src/Filtering/ImageFilterBase/ApplyKernelToEveryPixel/Code.cxx
+++ b/src/Filtering/ImageFilterBase/ApplyKernelToEveryPixel/Code.cxx
@@ -69,9 +69,9 @@ CreateImage(FloatImageType::Pointer image)
   image->FillBuffer(0);
 
   // Make a square
-  for (unsigned int r = 20; r < 80; r++)
+  for (unsigned int r = 20; r < 80; ++r)
   {
-    for (unsigned int c = 20; c < 80; c++)
+    for (unsigned int c = 20; c < 80; ++c)
     {
       FloatImageType::IndexType pixelIndex;
       pixelIndex[0] = r;

--- a/src/Filtering/ImageFilterBase/ApplyKernelToEveryPixelInNonZeroImage/Code.cxx
+++ b/src/Filtering/ImageFilterBase/ApplyKernelToEveryPixelInNonZeroImage/Code.cxx
@@ -123,9 +123,9 @@ CreateImage(UnsignedCharImageType::Pointer image)
   image->FillBuffer(0);
 
   // Make a square
-  for (unsigned int r = 30; r < 70; r++)
+  for (unsigned int r = 30; r < 70; ++r)
   {
-    for (unsigned int c = 30; c < 70; c++)
+    for (unsigned int c = 30; c < 70; ++c)
     {
       FloatImageType::IndexType pixelIndex;
       pixelIndex[0] = r;

--- a/src/Filtering/ImageGradient/ComputeAndDisplayGradient/Code.cxx
+++ b/src/Filtering/ImageGradient/ComputeAndDisplayGradient/Code.cxx
@@ -136,9 +136,9 @@ VectorImageToVTKImage(itk::Image<itk::CovariantVector<float, 2>, 2>::Pointer vec
   vectors->SetName("GradientVectors");
 
   int counter = 0;
-  for (unsigned int j = 0; j < imageSize[1]; j++)
+  for (unsigned int j = 0; j < imageSize[1]; ++j)
   {
-    for (unsigned int i = 0; i < imageSize[0]; i++)
+    for (unsigned int i = 0; i < imageSize[0]; ++i)
     {
       itk::Image<itk::CovariantVector<float, 2>, 2>::IndexType index;
       index[0] = i;

--- a/src/Filtering/ImageGrid/CropImageBySpecifyingRegion2/Code.cxx
+++ b/src/Filtering/ImageGrid/CropImageBySpecifyingRegion2/Code.cxx
@@ -114,9 +114,9 @@ CreateImage(ImageType::Pointer image)
 
   // Make a rectangle, centered at (100,150) with sides 160 & 240
   // This provides a 20 x 30 border around the square for the crop filter to remove
-  for (unsigned int r = 20; r < 180; r++)
+  for (unsigned int r = 20; r < 180; ++r)
   {
-    for (unsigned int c = 30; c < 270; c++)
+    for (unsigned int c = 30; c < 270; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = r;

--- a/src/Filtering/ImageGrid/ResampleAScalarImage/Code.cxx
+++ b/src/Filtering/ImageGrid/ResampleAScalarImage/Code.cxx
@@ -43,7 +43,7 @@ main(int argc, char * argv[])
 
   ImageType::SizeType outputSize;
 
-  for (unsigned int dim = 0, k = 3; dim < Dimension; dim++)
+  for (unsigned int dim = 0, k = 3; dim < Dimension; ++dim)
   {
     outputSize[dim] = std::stoi(argv[k++]);
   }
@@ -58,7 +58,7 @@ main(int argc, char * argv[])
 
   ImageType::SpacingType outputSpacing;
 
-  for (unsigned int dim = 0; dim < Dimension; dim++)
+  for (unsigned int dim = 0; dim < Dimension; ++dim)
   {
     outputSpacing[dim] = static_cast<double>(inputSpacing[dim]) * static_cast<double>(inputSize[dim]) /
                          static_cast<double>(outputSize[dim]);

--- a/src/Filtering/ImageGrid/ShrinkImage/Code.cxx
+++ b/src/Filtering/ImageGrid/ShrinkImage/Code.cxx
@@ -62,9 +62,9 @@ CreateImage(ImageType::Pointer image)
   image->FillBuffer(0);
 
   // Make a white square
-  for (unsigned int r = 20; r < 80; r++)
+  for (unsigned int r = 20; r < 80; ++r)
   {
-    for (unsigned int c = 20; c < 30; c++)
+    for (unsigned int c = 20; c < 30; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = r;

--- a/src/Filtering/ImageGrid/Stack2DImagesInto3DImage/Code.cxx
+++ b/src/Filtering/ImageGrid/Stack2DImagesInto3DImage/Code.cxx
@@ -58,7 +58,7 @@ main(int argc, char * argv[])
 
   InputImageType::Pointer inputImageTile;
 
-  for (int i = 1; i < argc - 1; i++)
+  for (int i = 1; i < argc - 1; ++i)
   {
     reader->SetFileName(argv[i]);
     reader->UpdateLargestPossibleRegion();

--- a/src/Filtering/ImageIntensity/AddTwoImages/Code.cxx
+++ b/src/Filtering/ImageIntensity/AddTwoImages/Code.cxx
@@ -159,9 +159,9 @@ CreateImage1(ImageType::Pointer image)
   image->Allocate();
 
   // Make a square
-  for (unsigned int r = 20; r < 80; r++)
+  for (unsigned int r = 20; r < 80; ++r)
   {
-    for (unsigned int c = 20; c < 80; c++)
+    for (unsigned int c = 20; c < 80; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = r;
@@ -195,9 +195,9 @@ CreateImage2(ImageType::Pointer image)
   image->Allocate();
 
   // Make another square
-  for (unsigned int r = 40; r < 100; r++)
+  for (unsigned int r = 40; r < 100; ++r)
   {
-    for (unsigned int c = 40; c < 100; c++)
+    for (unsigned int c = 40; c < 100; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = r;

--- a/src/Filtering/ImageIntensity/CastImageToAnotherTypeButClampToOutput/Code.cxx
+++ b/src/Filtering/ImageIntensity/CastImageToAnotherTypeButClampToOutput/Code.cxx
@@ -67,9 +67,9 @@ CreateImage(FloatImageType * const image)
   image->Allocate();
 
   // Make a square
-  for (unsigned int r = 40; r < 100; r++)
+  for (unsigned int r = 40; r < 100; ++r)
   {
-    for (unsigned int c = 40; c < 100; c++)
+    for (unsigned int c = 40; c < 100; ++c)
     {
       FloatImageType::IndexType pixelIndex;
       pixelIndex[0] = r;

--- a/src/Filtering/ImageIntensity/ComputeEdgePotential/Code.cxx
+++ b/src/Filtering/ImageIntensity/ComputeEdgePotential/Code.cxx
@@ -81,9 +81,9 @@ CreateImage(UnsignedCharImageType::Pointer image)
   image->FillBuffer(0);
 
   // Make a square
-  for (unsigned int r = 20; r < 80; r++)
+  for (unsigned int r = 20; r < 80; ++r)
   {
-    for (unsigned int c = 30; c < 100; c++)
+    for (unsigned int c = 30; c < 100; ++c)
     {
       UnsignedCharImageType::IndexType pixelIndex;
       pixelIndex[0] = r;

--- a/src/Filtering/ImageIntensity/InvertImage/Code.cxx
+++ b/src/Filtering/ImageIntensity/InvertImage/Code.cxx
@@ -94,9 +94,9 @@ CreateImage(ImageType::Pointer image)
   image->Allocate();
 
   // Make a square
-  for (unsigned int r = 40; r < 100; r++)
+  for (unsigned int r = 40; r < 100; ++r)
   {
-    for (unsigned int c = 40; c < 100; c++)
+    for (unsigned int c = 40; c < 100; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = r;

--- a/src/Filtering/ImageIntensity/PixelDivisionOfTwoImages/Code.cxx
+++ b/src/Filtering/ImageIntensity/PixelDivisionOfTwoImages/Code.cxx
@@ -69,9 +69,9 @@ CreateImage1(ImageType::Pointer image)
   image->Allocate();
 
   // Make a square
-  for (unsigned int r = 20; r < 80; r++)
+  for (unsigned int r = 20; r < 80; ++r)
   {
-    for (unsigned int c = 20; c < 80; c++)
+    for (unsigned int c = 20; c < 80; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = r;
@@ -105,9 +105,9 @@ CreateImage2(ImageType::Pointer image)
   image->Allocate();
 
   // Make another square
-  for (unsigned int r = 40; r < 100; r++)
+  for (unsigned int r = 40; r < 100; ++r)
   {
-    for (unsigned int c = 40; c < 100; c++)
+    for (unsigned int c = 40; c < 100; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = r;

--- a/src/Filtering/ImageIntensity/SubtractTwoImages/Code.cxx
+++ b/src/Filtering/ImageIntensity/SubtractTwoImages/Code.cxx
@@ -161,9 +161,9 @@ CreateImage1(ImageType::Pointer image)
   image->Allocate();
 
   // Make a square
-  for (unsigned int r = 20; r < 80; r++)
+  for (unsigned int r = 20; r < 80; ++r)
   {
-    for (unsigned int c = 20; c < 80; c++)
+    for (unsigned int c = 20; c < 80; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = r;
@@ -197,9 +197,9 @@ CreateImage2(ImageType::Pointer image)
   image->Allocate();
 
   // Make another square
-  for (unsigned int r = 40; r < 100; r++)
+  for (unsigned int r = 40; r < 100; ++r)
   {
-    for (unsigned int c = 40; c < 100; c++)
+    for (unsigned int c = 40; c < 100; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = r;

--- a/src/Filtering/ImageLabel/ExtractBoundariesOfConnectedRegionsInBinaryImage/Code.cxx
+++ b/src/Filtering/ImageLabel/ExtractBoundariesOfConnectedRegionsInBinaryImage/Code.cxx
@@ -69,9 +69,9 @@ CreateImage(ImageType::Pointer image)
   image->Allocate();
 
   // Make a square
-  for (unsigned int r = 20; r < 80; r++)
+  for (unsigned int r = 20; r < 80; ++r)
   {
-    for (unsigned int c = 30; c < 100; c++)
+    for (unsigned int c = 30; c < 100; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = r;
@@ -82,9 +82,9 @@ CreateImage(ImageType::Pointer image)
   }
 
   // Make another square
-  for (unsigned int r = 100; r < 130; r++)
+  for (unsigned int r = 100; r < 130; ++r)
   {
-    for (unsigned int c = 115; c < 160; c++)
+    for (unsigned int c = 115; c < 160; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = r;

--- a/src/Filtering/ImageLabel/ExtractInnerAndOuterBoundariesOfBlobsInBinaryImage/Code.cxx
+++ b/src/Filtering/ImageLabel/ExtractInnerAndOuterBoundariesOfBlobsInBinaryImage/Code.cxx
@@ -84,9 +84,9 @@ CreateImage(ImageType::Pointer image)
   image->FillBuffer(0);
 
   // Make a square
-  for (unsigned int r = 5; r < 10; r++)
+  for (unsigned int r = 5; r < 10; ++r)
   {
-    for (unsigned int c = 5; c < 10; c++)
+    for (unsigned int c = 5; c < 10; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = r;

--- a/src/Filtering/ImageLabel/LabelContoursOfConnectComponent/Code.cxx
+++ b/src/Filtering/ImageLabel/LabelContoursOfConnectComponent/Code.cxx
@@ -105,9 +105,9 @@ CreateImage(ImageType::Pointer image)
   image->Allocate();
 
   // Make a square
-  for (unsigned int r = 20; r < 80; r++)
+  for (unsigned int r = 20; r < 80; ++r)
   {
-    for (unsigned int c = 30; c < 100; c++)
+    for (unsigned int c = 30; c < 100; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = r;
@@ -118,9 +118,9 @@ CreateImage(ImageType::Pointer image)
   }
 
   // Make another square
-  for (unsigned int r = 100; r < 130; r++)
+  for (unsigned int r = 100; r < 130; ++r)
   {
-    for (unsigned int c = 115; c < 160; c++)
+    for (unsigned int c = 115; c < 160; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = r;

--- a/src/Filtering/ImageStatistics/ComputeMinMaxVarianceMeanOfImage/Code.cxx
+++ b/src/Filtering/ImageStatistics/ComputeMinMaxVarianceMeanOfImage/Code.cxx
@@ -65,9 +65,9 @@ CreateImage(ImageType::Pointer image)
   image->Allocate();
 
   // Make a square
-  for (unsigned int r = 20; r < 80; r++)
+  for (unsigned int r = 20; r < 80; ++r)
   {
-    for (unsigned int c = 30; c < 100; c++)
+    for (unsigned int c = 30; c < 100; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = r;
@@ -78,9 +78,9 @@ CreateImage(ImageType::Pointer image)
   }
 
   // Make another square
-  for (unsigned int r = 100; r < 130; r++)
+  for (unsigned int r = 100; r < 130; ++r)
   {
-    for (unsigned int c = 115; c < 160; c++)
+    for (unsigned int c = 115; c < 160; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = r;

--- a/src/Filtering/ImageStatistics/ComputePCAShapeFromSample/Code.cxx
+++ b/src/Filtering/ImageStatistics/ComputePCAShapeFromSample/Code.cxx
@@ -58,7 +58,7 @@ main(int argc, char * argv[])
     return 1;
   }
 
-  for (int i = 0; i < argc; i++)
+  for (int i = 0; i < argc; ++i)
   {
     std::cout << "id: " << i << " arg: " << argv[i] << std::endl;
   }
@@ -77,7 +77,7 @@ main(int argc, char * argv[])
   fileNamesCreator->SetSeriesFormat(argv[2]);
   const std::vector<std::string> & shapeModeFileNames = fileNamesCreator->GetFileNames();
 
-  for (unsigned int k = 0; k < nb_train; k++)
+  for (unsigned int k = 0; k < nb_train; ++k)
   {
     trainingImages[k] = itk::ReadImage<ImageType>(shapeModeFileNames[k]);
   }
@@ -87,7 +87,7 @@ main(int argc, char * argv[])
   filter->SetNumberOfTrainingImages(nb_train);
   filter->SetNumberOfPrincipalComponentsRequired(2);
 
-  for (unsigned int k = 0; k < nb_train; k++)
+  for (unsigned int k = 0; k < nb_train; ++k)
   {
     filter->SetInput(k, trainingImages[k]);
   }
@@ -107,7 +107,7 @@ main(int argc, char * argv[])
   my_Estimatortype::VectorOfDoubleType v = filter->GetEigenValues();
   double                               sv_mean = sqrt(v[0]);
 
-  for (unsigned int k = 0; k < nb_modes; k++)
+  for (unsigned int k = 0; k < nb_modes; ++k)
   {
     double sv = sqrt(v[k]);
     double sv_n = sv / sv_mean;

--- a/src/Filtering/LabelMap/ConvertImageToLabelMap/Code.cxx
+++ b/src/Filtering/LabelMap/ConvertImageToLabelMap/Code.cxx
@@ -69,9 +69,9 @@ CreateImage(ImageType::Pointer image)
   image->Allocate();
 
   // Make a square
-  for (unsigned int r = 20; r < 80; r++)
+  for (unsigned int r = 20; r < 80; ++r)
   {
-    for (unsigned int c = 30; c < 100; c++)
+    for (unsigned int c = 30; c < 100; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = r;
@@ -82,9 +82,9 @@ CreateImage(ImageType::Pointer image)
   }
 
   // Make another square
-  for (unsigned int r = 100; r < 130; r++)
+  for (unsigned int r = 100; r < 130; ++r)
   {
-    for (unsigned int c = 115; c < 160; c++)
+    for (unsigned int c = 115; c < 160; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = r;

--- a/src/Filtering/LabelMap/ConvertImageWithLabelsToShapeLabelMap/Code.cxx
+++ b/src/Filtering/LabelMap/ConvertImageWithLabelsToShapeLabelMap/Code.cxx
@@ -70,9 +70,9 @@ CreateImage(ImageType::Pointer image)
   image->Allocate();
 
   // Make a square
-  for (unsigned int r = 20; r < 80; r++)
+  for (unsigned int r = 20; r < 80; ++r)
   {
-    for (unsigned int c = 30; c < 100; c++)
+    for (unsigned int c = 30; c < 100; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = r;
@@ -83,9 +83,9 @@ CreateImage(ImageType::Pointer image)
   }
 
   // Make another square
-  for (unsigned int r = 100; r < 130; r++)
+  for (unsigned int r = 100; r < 130; ++r)
   {
-    for (unsigned int c = 115; c < 160; c++)
+    for (unsigned int c = 115; c < 160; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = r;

--- a/src/Filtering/LabelMap/ExtractGivenLabelObject/Code.cxx
+++ b/src/Filtering/LabelMap/ExtractGivenLabelObject/Code.cxx
@@ -62,7 +62,7 @@ main(int argc, char * argv[])
   selector->SetInput(labelMapConverter->GetOutput());
   selector->SetLabel(label);
 
-  for (int i = 0; i < 2; i++)
+  for (int i = 0; i < 2; ++i)
   {
     using LabelMapToLabelImageFilterType = itk::LabelMapToLabelImageFilter<LabelMapType, ImageType>;
     auto labelImageConverter = LabelMapToLabelImageFilterType::New();

--- a/src/Filtering/LabelMap/KeepBinaryRegionsThatMeetSpecific/Code.cxx
+++ b/src/Filtering/LabelMap/KeepBinaryRegionsThatMeetSpecific/Code.cxx
@@ -71,9 +71,9 @@ CreateImage(ImageType::Pointer image1, ImageType::Pointer image2)
   image2->FillBuffer(0);
 
   // Make a square
-  for (unsigned int r = 20; r < 80; r++)
+  for (unsigned int r = 20; r < 80; ++r)
   {
-    for (unsigned int c = 30; c < 100; c++)
+    for (unsigned int c = 30; c < 100; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = r;
@@ -85,9 +85,9 @@ CreateImage(ImageType::Pointer image1, ImageType::Pointer image2)
   }
 
   // Make another square
-  for (unsigned int r = 100; r < 130; r++)
+  for (unsigned int r = 100; r < 130; ++r)
   {
-    for (unsigned int c = 115; c < 160; c++)
+    for (unsigned int c = 115; c < 160; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = r;

--- a/src/Filtering/LabelMap/LabelBinaryRegionsAndGetProperties/Code.cxx
+++ b/src/Filtering/LabelMap/LabelBinaryRegionsAndGetProperties/Code.cxx
@@ -41,7 +41,7 @@ main()
             << std::endl;
 
   // Loop over all of the blobs
-  for (unsigned int i = 0; i < binaryImageToShapeLabelMapFilter->GetOutput()->GetNumberOfLabelObjects(); i++)
+  for (unsigned int i = 0; i < binaryImageToShapeLabelMapFilter->GetOutput()->GetNumberOfLabelObjects(); ++i)
   {
     BinaryImageToShapeLabelMapFilterType::OutputImageType::LabelObjectType * labelObject =
       binaryImageToShapeLabelMapFilter->GetOutput()->GetNthLabelObject(i);

--- a/src/Filtering/LabelMap/LabelBinaryRegionsInImage/Code.cxx
+++ b/src/Filtering/LabelMap/LabelBinaryRegionsInImage/Code.cxx
@@ -40,14 +40,14 @@ main()
             << std::endl;
 
   // Loop over each region
-  for (unsigned int i = 0; i < binaryImageToLabelMapFilter->GetOutput()->GetNumberOfLabelObjects(); i++)
+  for (unsigned int i = 0; i < binaryImageToLabelMapFilter->GetOutput()->GetNumberOfLabelObjects(); ++i)
   {
     // Get the ith region
     BinaryImageToLabelMapFilterType::OutputImageType::LabelObjectType * labelObject =
       binaryImageToLabelMapFilter->GetOutput()->GetNthLabelObject(i);
 
     // Output the pixels composing the region
-    for (unsigned int pixelId = 0; pixelId < labelObject->Size(); pixelId++)
+    for (unsigned int pixelId = 0; pixelId < labelObject->Size(); ++pixelId)
     {
       std::cout << "Object " << i << " contains pixel " << labelObject->GetIndex(pixelId) << std::endl;
     }

--- a/src/Filtering/LabelMap/MergeLabelMaps/Code.cxx
+++ b/src/Filtering/LabelMap/MergeLabelMaps/Code.cxx
@@ -34,7 +34,7 @@ main()
 
   int noObjects = 4;
 
-  for (int i = 1; i <= noObjects; i++)
+  for (int i = 1; i <= noObjects; ++i)
   {
     auto labelMap = LabelMapType::New();
     auto labelObject = LabelObjectType::New();

--- a/src/Filtering/LabelMap/RemoveLabelsFromLabelMap/Code.cxx
+++ b/src/Filtering/LabelMap/RemoveLabelsFromLabelMap/Code.cxx
@@ -45,7 +45,7 @@ main()
 
   // Note: do NOT remove the labels inside the loop! The IDs are stored such that they will change when one is deleted.
   // Instead, mark all of the labels to be removed first and then remove them all together.
-  for (unsigned int i = 0; i < binaryImageToLabelMapFilter->GetOutput()->GetNumberOfLabelObjects(); i++)
+  for (unsigned int i = 0; i < binaryImageToLabelMapFilter->GetOutput()->GetNumberOfLabelObjects(); ++i)
   {
     // Get the ith region
     BinaryImageToLabelMapFilterType::OutputImageType::LabelObjectType * labelObject =

--- a/src/Filtering/MathematicalMorphology/GenerateStructureElementsWithAccurateArea/Code.cxx
+++ b/src/Filtering/MathematicalMorphology/GenerateStructureElementsWithAccurateArea/Code.cxx
@@ -142,7 +142,7 @@ ComputeAreaError(SEType k, unsigned int thickness)
   {
     return EXIT_FAILURE;
   }
-  for (unsigned int i = 0; i < SEType::NeighborhoodDimension; i++)
+  for (unsigned int i = 0; i < SEType::NeighborhoodDimension; ++i)
   {
     expectedOuterForegroundArea *= k.GetRadius()[i];
     expectedInnerForegroundArea *= (k.GetRadius()[i] - thickness);

--- a/src/Filtering/MathematicalMorphology/RegionalMaximal/Code.cxx
+++ b/src/Filtering/MathematicalMorphology/RegionalMaximal/Code.cxx
@@ -65,9 +65,9 @@ CreateImage(ImageType::Pointer image)
   image->Allocate();
 
   // Make two intensity blobs
-  for (unsigned int r = 0; r < NumRows; r++)
+  for (unsigned int r = 0; r < NumRows; ++r)
   {
-    for (unsigned int c = 0; c < NumCols; c++)
+    for (unsigned int c = 0; c < NumCols; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = c;

--- a/src/Filtering/MathematicalMorphology/RegionalMinimal/Code.cxx
+++ b/src/Filtering/MathematicalMorphology/RegionalMinimal/Code.cxx
@@ -58,9 +58,9 @@ CreateImage(ImageType::Pointer image)
   image->Allocate();
 
   // Make two intensity blobs
-  for (unsigned int r = 0; r < size[1]; r++)
+  for (unsigned int r = 0; r < size[1]; ++r)
   {
-    for (unsigned int c = 0; c < size[0]; c++)
+    for (unsigned int c = 0; c < size[0]; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = c;

--- a/src/Filtering/MathematicalMorphology/ValuedRegionalMaximaImage/Code.cxx
+++ b/src/Filtering/MathematicalMorphology/ValuedRegionalMaximaImage/Code.cxx
@@ -65,9 +65,9 @@ CreateImage(ImageType::Pointer image)
   image->Allocate();
 
   // Make two intensity blobs
-  for (unsigned int r = 0; r < NumRows; r++)
+  for (unsigned int r = 0; r < NumRows; ++r)
   {
-    for (unsigned int c = 0; c < NumCols; c++)
+    for (unsigned int c = 0; c < NumCols; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = c;

--- a/src/Filtering/MathematicalMorphology/ValuedRegionalMinimalImage/Code.cxx
+++ b/src/Filtering/MathematicalMorphology/ValuedRegionalMinimalImage/Code.cxx
@@ -64,9 +64,9 @@ CreateImage(ImageType::Pointer image)
   image->Allocate();
 
   // Make two intensity blobs
-  for (unsigned int r = 0; r < NumRows; r++)
+  for (unsigned int r = 0; r < NumRows; ++r)
   {
-    for (unsigned int c = 0; c < NumCols; c++)
+    for (unsigned int c = 0; c < NumCols; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = c;

--- a/src/IO/GDCM/ResampleDICOMSeries/Code.cxx
+++ b/src/IO/GDCM/ResampleDICOMSeries/Code.cxx
@@ -141,7 +141,7 @@ main(int argc, char * argv[])
   outputSpacing[2] = std::stod(argv[5]);
 
   bool changeInSpacing = false;
-  for (unsigned int i = 0; i < 3; i++)
+  for (unsigned int i = 0; i < 3; ++i)
   {
     if (outputSpacing[i] == 0.0)
     {
@@ -195,7 +195,7 @@ main(int argc, char * argv[])
   itk::ExposeMetaData<std::string>(*inputDict, "0008|0016", sopClassUID);
   gdcmIO->KeepOriginalUIDOn();
 
-  for (unsigned int f = 0; f < outputSize[2]; f++)
+  for (unsigned int f = 0; f < outputSize[2]; ++f)
   {
     // Create a new dictionary for this slice
     auto dict = new ReaderType::DictionaryType;
@@ -247,7 +247,7 @@ main(int argc, char * argv[])
 
     // Derivation Description - How this image was derived
     value.str("");
-    for (int i = 0; i < argc; i++)
+    for (int i = 0; i < argc; ++i)
     {
       value << argv[i] << " ";
     }

--- a/src/IO/ImageBase/Create3DFromSeriesOf2D/Code.cxx
+++ b/src/IO/ImageBase/Create3DFromSeriesOf2D/Code.cxx
@@ -58,7 +58,7 @@ main(int argc, char * argv[])
   // List the files
   //
   std::vector<std::string>::iterator nit;
-  for (nit = names.begin(); nit != names.end(); nit++)
+  for (nit = names.begin(); nit != names.end(); ++nit)
   {
     std::cout << "File: " << (*nit).c_str() << std::endl;
   }

--- a/src/IO/ImageBase/ProcessImageChunks/Code.cxx
+++ b/src/IO/ImageBase/ProcessImageChunks/Code.cxx
@@ -69,19 +69,19 @@ main(int argc, char * argv[])
   // in order to create samples for a deep learning algorithm.
   // ImageRegionSplitterMultidimensional has a similar
   // functionality to what is implemented below.
-  for (int z = 0; z < zDiv; z++)
+  for (int z = 0; z < zDiv; ++z)
   {
     start[2] = fullSize[2] * double(z) / zDiv;
     end[2] = fullSize[2] * (z + 1.0) / zDiv;
     size[2] = end[2] - start[2];
 
-    for (int y = 0; y < yDiv; y++)
+    for (int y = 0; y < yDiv; ++y)
     {
       start[1] = fullSize[1] * double(y) / yDiv;
       end[1] = fullSize[1] * (y + 1.0) / yDiv;
       size[1] = end[1] - start[1];
 
-      for (int x = 0; x < xDiv; x++)
+      for (int x = 0; x < xDiv; ++x)
       {
         start[0] = fullSize[0] * double(x) / xDiv;
         end[0] = fullSize[0] * (x + 1.0) / xDiv;

--- a/src/ImageCompareCommand.cxx
+++ b/src/ImageCompareCommand.cxx
@@ -339,7 +339,7 @@ RegressionTestImage(const char * testImageFilename,
     region.SetIndex(index);
 
     size = rescale->GetOutput()->GetLargestPossibleRegion().GetSize();
-    for (unsigned int i = 2; i < ITK_TEST_DIMENSION_MAX; i++)
+    for (unsigned int i = 2; i < ITK_TEST_DIMENSION_MAX; ++i)
     {
       size[i] = 0;
     }

--- a/src/Nonunit/Review/GeometricPropertiesOfRegion/Code.cxx
+++ b/src/Nonunit/Review/GeometricPropertiesOfRegion/Code.cxx
@@ -117,7 +117,7 @@ main(int argc, char * argv[])
   std::cout << "Number of labels: " << labelGeometryImageFilter->GetNumberOfLabels() << std::endl;
   std::cout << std::endl;
 
-  for (allLabelsIt = allLabels.begin(); allLabelsIt != allLabels.end(); allLabelsIt++)
+  for (allLabelsIt = allLabels.begin(); allLabelsIt != allLabels.end(); ++allLabelsIt)
   {
     LabelGeometryImageFilterType::LabelPixelType labelValue = *allLabelsIt;
     std::cout << "\tLabel: " << (int)labelValue << std::endl;

--- a/src/Nonunit/Review/MultiphaseChanAndVeseSparseFieldLevelSetSegmentation/Code.cxx
+++ b/src/Nonunit/Review/MultiphaseChanAndVeseSparseFieldLevelSetSegmentation/Code.cxx
@@ -92,7 +92,7 @@ main(int argc, char ** argv)
   levelSetFilter->SetUseImageSpacing(1);
   levelSetFilter->SetInPlace(false);
 
-  for (unsigned int i = 0; i < 3; i++)
+  for (unsigned int i = 0; i < 3; ++i)
   {
     levelSetFilter->GetDifferenceFunction(i)->SetDomainFunction(domainFunction);
     levelSetFilter->GetDifferenceFunction(i)->SetCurvatureWeight(curvature_weight);

--- a/src/Numerics/Statistics/2DGaussianMixtureModelExpectMax/Code.cxx
+++ b/src/Numerics/Statistics/2DGaussianMixtureModelExpectMax/Code.cxx
@@ -83,7 +83,7 @@ main()
 
   // Create the components
   std::vector<ComponentType::Pointer> components;
-  for (unsigned int i = 0; i < numberOfClasses; i++)
+  for (unsigned int i = 0; i < numberOfClasses; ++i)
   {
     components.push_back(ComponentType::New());
     (components[i])->SetSample(sample);
@@ -102,7 +102,7 @@ main()
 
   estimator->SetInitialProportions(initialProportions);
 
-  for (unsigned int i = 0; i < numberOfClasses; i++)
+  for (unsigned int i = 0; i < numberOfClasses; ++i)
   {
     estimator->AddComponent((ComponentType::Superclass *)(components[i]).GetPointer());
   }
@@ -110,7 +110,7 @@ main()
   estimator->Update();
 
   // Output the results
-  for (unsigned int i = 0; i < numberOfClasses; i++)
+  for (unsigned int i = 0; i < numberOfClasses; ++i)
   {
     std::cout << "Cluster[" << i << "]" << std::endl;
     std::cout << "    Parameters:" << std::endl;

--- a/src/Numerics/Statistics/CreateHistogramFromListOfMeasurements/Code.cxx
+++ b/src/Numerics/Statistics/CreateHistogramFromListOfMeasurements/Code.cxx
@@ -47,7 +47,7 @@ main()
   std::cout << "Histogram vector size: " << histogram->GetMeasurementVectorSize() << std::endl;
 
 
-  for (unsigned int i = 0; i < histogram->GetSize()[0]; i++)
+  for (unsigned int i = 0; i < histogram->GetSize()[0]; ++i)
   {
     std::cout << "Frequency of " << i << " : (" << histogram->GetBinMin(0, i) << " to " << histogram->GetBinMax(0, i)
               << ") = " << histogram->GetFrequency(i) << std::endl;

--- a/src/Numerics/Statistics/DistributeSamplingUsingGMM/Code.cxx
+++ b/src/Numerics/Statistics/DistributeSamplingUsingGMM/Code.cxx
@@ -70,7 +70,7 @@ main()
   using ComponentType = itk::Statistics::GaussianMixtureModelComponent<SampleType>;
 
   std::vector<ComponentType::Pointer> components;
-  for (unsigned int i = 0; i < numberOfClasses; i++)
+  for (unsigned int i = 0; i < numberOfClasses; ++i)
   {
     components.push_back(ComponentType::New());
     components[i]->SetSample(sample);
@@ -89,14 +89,14 @@ main()
 
   estimator->SetInitialProportions(initialProportions);
 
-  for (unsigned int i = 0; i < numberOfClasses; i++)
+  for (unsigned int i = 0; i < numberOfClasses; ++i)
   {
     estimator->AddComponent((ComponentType::Superclass *)components[i].GetPointer());
   }
 
   estimator->Update();
 
-  for (unsigned int i = 0; i < numberOfClasses; i++)
+  for (unsigned int i = 0; i < numberOfClasses; ++i)
   {
     std::cout << "Cluster[" << i << "]" << std::endl;
     std::cout << "    Parameters:" << std::endl;

--- a/src/Numerics/Statistics/DistributionOfPixelsUsingGMM/Code.cxx
+++ b/src/Numerics/Statistics/DistributionOfPixelsUsingGMM/Code.cxx
@@ -62,14 +62,14 @@ main(int /*argc*/, char * /*argv*/[])
 
   // Create the first set (for the first cluster/model) of initial parameters
   std::vector<ParametersType> initialParameters(numberOfClasses);
-  for (unsigned int i = 0; i < 3; i++)
+  for (unsigned int i = 0; i < 3; ++i)
   {
     params[i] = 5.0; // mean of dimension i
   }
   unsigned int counter = 0;
-  for (unsigned int i = 0; i < 3; i++)
+  for (unsigned int i = 0; i < 3; ++i)
   {
-    for (unsigned int j = 0; j < 3; j++)
+    for (unsigned int j = 0; j < 3; ++j)
     {
       if (i == j)
       {
@@ -91,9 +91,9 @@ main(int /*argc*/, char * /*argv*/[])
   params[1] = 5.0;
   params[2] = 5.0;
   counter = 0;
-  for (unsigned int i = 0; i < 3; i++)
+  for (unsigned int i = 0; i < 3; ++i)
   {
-    for (unsigned int j = 0; j < 3; j++)
+    for (unsigned int j = 0; j < 3; ++j)
     {
       if (i == j)
       {
@@ -113,9 +113,9 @@ main(int /*argc*/, char * /*argv*/[])
   params[1] = 210.0;
   params[2] = 5.0;
   counter = 0;
-  for (unsigned int i = 0; i < 3; i++)
+  for (unsigned int i = 0; i < 3; ++i)
   {
-    for (unsigned int j = 0; j < 3; j++)
+    for (unsigned int j = 0; j < 3; ++j)
     {
       if (i == j)
       {
@@ -131,7 +131,7 @@ main(int /*argc*/, char * /*argv*/[])
   initialParameters[2] = params;
 
   std::cout << "Initial parameters: " << std::endl;
-  for (unsigned int i = 0; i < numberOfClasses; i++)
+  for (unsigned int i = 0; i < numberOfClasses; ++i)
   {
     std::cout << initialParameters[i] << std::endl;
   }
@@ -142,7 +142,7 @@ main(int /*argc*/, char * /*argv*/[])
 
   // Create the components
   std::vector<ComponentType::Pointer> components;
-  for (unsigned int i = 0; i < numberOfClasses; i++)
+  for (unsigned int i = 0; i < numberOfClasses; ++i)
   {
     components.push_back(ComponentType::New());
     (components[i])->SetSample(imageToListSampleFilter->GetOutput());
@@ -166,7 +166,7 @@ main(int /*argc*/, char * /*argv*/[])
 
   estimator->SetInitialProportions(initialProportions);
 
-  for (unsigned int i = 0; i < numberOfClasses; i++)
+  for (unsigned int i = 0; i < numberOfClasses; ++i)
   {
     estimator->AddComponent(components[i]);
   }
@@ -174,7 +174,7 @@ main(int /*argc*/, char * /*argv*/[])
   estimator->Update();
 
   // Output the results
-  for (unsigned int i = 0; i < numberOfClasses; i++)
+  for (unsigned int i = 0; i < numberOfClasses; ++i)
   {
     std::cout << "Cluster[" << i << "]" << std::endl;
     std::cout << "    Parameters:" << std::endl;

--- a/src/Registration/Common/MatchFeaturePoints/Code.cxx
+++ b/src/Registration/Common/MatchFeaturePoints/Code.cxx
@@ -91,9 +91,9 @@ CreateImage(ImageType::Pointer image, const unsigned int x)
   image->FillBuffer(0);
 
   // Make a white square
-  for (unsigned int r = x; r < x + 20; r++)
+  for (unsigned int r = x; r < x + 20; ++r)
   {
-    for (unsigned int c = 40; c < 60; c++)
+    for (unsigned int c = 40; c < 60; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = r;

--- a/src/Registration/Common/MultiresolutionPyramidFromImage/Code.cxx
+++ b/src/Registration/Common/MultiresolutionPyramidFromImage/Code.cxx
@@ -81,9 +81,9 @@ CreateImage(UnsignedCharImageType::Pointer image)
   image->FillBuffer(0);
 
   // Make a square
-  for (unsigned int r = 20; r < 80; r++)
+  for (unsigned int r = 20; r < 80; ++r)
   {
-    for (unsigned int c = 30; c < 100; c++)
+    for (unsigned int c = 30; c < 100; ++c)
     {
       UnsignedCharImageType::IndexType pixelIndex;
       pixelIndex[0] = r;

--- a/src/Registration/Metricsv4/RegisterTwoPointSets/Code.cxx
+++ b/src/Registration/Metricsv4/RegisterTwoPointSets/Code.cxx
@@ -111,7 +111,7 @@ main(int argc, char * argv[])
 
   // two circles with a small offset
   PointType offset;
-  for (unsigned int d = 0; d < Dimension; d++)
+  for (unsigned int d = 0; d < Dimension; ++d)
   {
     offset[d] = 2.0;
   }
@@ -195,7 +195,7 @@ main(int argc, char * argv[])
   PointType::ValueType                             tolerance = 1e-2;
   AffineTransformType::InverseTransformBasePointer movingInverse = metric->GetMovingTransform()->GetInverseTransform();
   AffineTransformType::InverseTransformBasePointer fixedInverse = metric->GetFixedTransform()->GetInverseTransform();
-  for (unsigned int n = 0; n < metric->GetNumberOfComponents(); n++)
+  for (unsigned int n = 0; n < metric->GetNumberOfComponents(); ++n)
   {
     // compare the points in virtual domain
     PointType transformedMovingPoint = movingInverse->TransformPoint(movingPoints->GetPoint(n));

--- a/src/Remote/WikiExamples/CustomUserMatrixToAlignImageWithDICOM/Code.cxx
+++ b/src/Remote/WikiExamples/CustomUserMatrixToAlignImageWithDICOM/Code.cxx
@@ -123,8 +123,8 @@ int main(int argc, char *argv[])
   // so that volume is in DICOM patient physical space
   VisualizingImageType::DirectionType d=image->GetDirection();
   vtkMatrix4x4 *mat=vtkMatrix4x4::New(); //start with identity matrix
-  for (int i=0; i<3; i++)
-      for (int k=0; k<3; k++)
+  for (int i=0; i<3; ++i)
+      for (int k=0; k<3; ++k)
           mat->SetElement(i,k, d(i,k));
 
   // Counteract the built-in translation by origin
@@ -132,7 +132,7 @@ int main(int argc, char *argv[])
   volume->SetPosition(-origin[0], -origin[1], -origin[2]);
 
   // Add translation to the user matrix
-  for (int i=0; i<3; i++)
+  for (int i=0; i<3; ++i)
     {
     mat->SetElement(i,3, origin[i]);
     }

--- a/src/Segmentation/Classifiers/KMeansClustering/Code.cxx
+++ b/src/Segmentation/Classifiers/KMeansClustering/Code.cxx
@@ -54,7 +54,7 @@ main(int argc, char * argv[])
   }
 
   std::vector<double> userMeans;
-  for (unsigned k = 0; k < numberOfInitialClasses; k++)
+  for (unsigned k = 0; k < numberOfInitialClasses; ++k)
   {
     const double userProvidedInitialMean = std::stod(argv[k + argoffset]);
     userMeans.push_back(userProvidedInitialMean);
@@ -82,7 +82,7 @@ main(int argc, char * argv[])
 
   // initialize using the user input means
 
-  for (unsigned k = 0; k < numberOfInitialClasses; k++)
+  for (unsigned k = 0; k < numberOfInitialClasses; ++k)
   {
     kmeansFilter->AddClassWithInitialMean(userMeans[k]);
   }

--- a/src/Segmentation/ConnectedComponents/LabelConnectComponentsInGrayscaleImage/Code.cxx
+++ b/src/Segmentation/ConnectedComponents/LabelConnectComponentsInGrayscaleImage/Code.cxx
@@ -130,9 +130,9 @@ CreateImage(TImage * const image)
   image->Allocate();
 
   // Make a square
-  for (typename TImage::IndexValueType r = 20; r < 80; r++)
+  for (typename TImage::IndexValueType r = 20; r < 80; ++r)
   {
-    for (typename TImage::IndexValueType c = 30; c < 100; c++)
+    for (typename TImage::IndexValueType c = 30; c < 100; ++c)
     {
       typename TImage::IndexType pixelIndex = { { r, c } };
 
@@ -141,9 +141,9 @@ CreateImage(TImage * const image)
   }
 
   // Make another square
-  for (typename TImage::IndexValueType r = 100; r < 130; r++)
+  for (typename TImage::IndexValueType r = 100; r < 130; ++r)
   {
-    for (typename TImage::IndexValueType c = 115; c < 160; c++)
+    for (typename TImage::IndexValueType c = 115; c < 160; ++c)
     {
       typename TImage::IndexType pixelIndex = { { r, c } };
 

--- a/src/Segmentation/KLMRegionGrowing/BasicRegionGrowing/Code.cxx
+++ b/src/Segmentation/KLMRegionGrowing/BasicRegionGrowing/Code.cxx
@@ -150,9 +150,9 @@ CreateImage(ImageType::Pointer image)
   image->Allocate();
 
   // Make a square
-  for (unsigned int r = 20; r < 80; r++)
+  for (unsigned int r = 20; r < 80; ++r)
   {
-    for (unsigned int c = 30; c < 100; c++)
+    for (unsigned int c = 30; c < 100; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = r;
@@ -163,9 +163,9 @@ CreateImage(ImageType::Pointer image)
   }
 
   // Make another square
-  for (unsigned int r = 100; r < 130; r++)
+  for (unsigned int r = 100; r < 130; ++r)
   {
-    for (unsigned int c = 115; c < 160; c++)
+    for (unsigned int c = 115; c < 160; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = r;

--- a/src/Segmentation/RegionGrowing/ConnectedComponentsInImage/Code.cxx
+++ b/src/Segmentation/RegionGrowing/ConnectedComponentsInImage/Code.cxx
@@ -160,9 +160,9 @@ CreateImage(ImageType::Pointer image)
   image->Allocate();
 
   // Make a square
-  for (unsigned int r = 20; r < 80; r++)
+  for (unsigned int r = 20; r < 80; ++r)
   {
-    for (unsigned int c = 30; c < 100; c++)
+    for (unsigned int c = 30; c < 100; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = r;
@@ -173,9 +173,9 @@ CreateImage(ImageType::Pointer image)
   }
 
   // Make another square
-  for (unsigned int r = 100; r < 130; r++)
+  for (unsigned int r = 100; r < 130; ++r)
   {
-    for (unsigned int c = 115; c < 160; c++)
+    for (unsigned int c = 115; c < 160; ++c)
     {
       ImageType::IndexType pixelIndex;
       pixelIndex[0] = r;

--- a/src/Segmentation/Voronoi/VoronoiDiagram/Code.cxx
+++ b/src/Segmentation/Voronoi/VoronoiDiagram/Code.cxx
@@ -77,7 +77,7 @@ main()
   voronoiGenerator->Update();
   voronoiDiagram = voronoiGenerator->GetOutput();
 
-  for (unsigned int i = 0; i < seeds.size(); i++)
+  for (unsigned int i = 0; i < seeds.size(); ++i)
   {
     PointType currP = voronoiDiagram->GetSeed(i);
     std::cout << "Seed No." << i << ": At (" << currP[0] << "," << currP[1] << ")" << std::endl;


### PR DESCRIPTION
Applied to the src directory, at the GNU bash prompt:

    find . -exec perl -pi -w -e 's/(\s+for \(.*;.*); (\w+)\+\+\)/$1; ++$2)/g;' {} \;

Follow-up to ITK pull request https://github.com/InsightSoftwareConsortium/ITK/pull/2505
commit https://github.com/InsightSoftwareConsortium/ITK/commit/878fa6f4356a428230b4a097f604347806376072
"STYLE: Replace postfix by prefix increment in `for` loops in Examples"

According to Herb Sutter, Andrei Alexandrescu - C++ Coding Standards:
101 Rules, Guidelines, and Best Practices: "Prefer the canonical form of
++ and --. Prefer calling the prefix forms"