### PR TITLE
ENH: Add Python example on module loading printouts

### DIFF
--- a/src/Core/Common/PrintModuleLoadingPython/CMakeLists.txt
+++ b/src/Core/Common/PrintModuleLoadingPython/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.16.3)
+
+project(PrintModuleLoadingPython)
+
+find_package(ITK REQUIRED)
+include(${ITK_USE_FILE})
+
+install(FILES Code.py CMakeLists.txt
+  DESTINATION share/ITKSphinxExamples/Code/Core/Common/PrintModuleLoadingPython/
+  COMPONENT Code
+  )
+
+enable_testing()
+if(ITK_WRAP_PYTHON)
+  add_test(NAME PrintModuleLoadingPythonTest
+    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/Code.py)
+endif()

--- a/src/Core/Common/PrintModuleLoadingPython/Code.py
+++ b/src/Core/Common/PrintModuleLoadingPython/Code.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+# Copyright NumFOCUS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+### Print ITK Module Loading
+
+# It can be useful to see how ITK modules are being loaded in order
+# to understand module dependencies. `itk.auto_progress` can be used
+# to increase verbosity of module loading and filter printouts.
+
+import itk
+
+# Enable module loading printouts
+itk.auto_progress(2)
+
+# Load a filter from a module with several dependencies
+_ = itk.ForwardFFTImageFilter.values()[0].New()
+
+# Disable printouts
+itk.auto_progress(0)
+
+# Do work

--- a/src/Core/Common/PrintModuleLoadingPython/Documentation.rst
+++ b/src/Core/Common/PrintModuleLoadingPython/Documentation.rst
@@ -1,0 +1,34 @@
+:name: PrintModuleLoadingPython
+
+Print ITK Python Module Loading
+================================
+
+Synopsis
+--------
+
+Print how ITK Python module dependencies are lazily loaded.
+
+
+Results
+-------
+Output::
+
+  Loading ITKPyBase... done
+  Loading ITKCommon... done
+  Loading ITKStatistics... done
+  Loading ITKImageFilterBase... done
+  Loading ITKTransform... done
+  Loading ITKImageFunction... done
+  Loading ITKImageGrid... done
+  Loading ITKFFT... done
+  Loading ITKPyUtils... done
+
+Code
+----
+
+Python
+......
+
+.. literalinclude:: Code.py
+   :language: python
+   :lines: 1, 16-

--- a/src/Core/Common/index.rst
+++ b/src/Core/Common/index.rst
@@ -94,6 +94,7 @@ Common
   PassImageToFunction/Documentation.rst
   PermuteSequenceOfIndices/Documentation.rst
   PiConstant/Documentation.rst
+  PrintModuleLoadingPython/Documentation.rst
   ProduceImageProgrammatically/Documentation.rst
   RandomSelectOfPixelsFromRegion/Documentation.rst
   RandomSelectPixelFromRegionWithoutReplacee/Documentation.rst


### PR DESCRIPTION
Partially addresses #356 