### PR TITLE
DOC: Adjust title of `ImageBufferAndIndexRange` example

### DIFF
--- a/src/Core/Common/ImageBufferAndIndexRange/Documentation.rst
+++ b/src/Core/Common/ImageBufferAndIndexRange/Documentation.rst
@@ -1,7 +1,7 @@
 :name: ImageBufferAndIndexRange
 
-Image Buffer and Index Range
-============================
+Iterate Over an Image Buffer and an Index Range
+===============================================
 
 .. index::
    single: ImageBufferRange


### PR DESCRIPTION
Following the guideline on how the write a title, at
https://examples.itk.org/documentation/contribute/writeanewexample#title
which suggests filling out the dots ("...") of the question, "How do I ...?"