### PR TITLE
STYLE: Use `${PROJECT_NAME}` as CMake target name of example projects

### DIFF
--- a/src/Bridge/VtkGlue/ConvertAnRGBitkImageTovtkImageData/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/ConvertAnRGBitkImageTovtkImageData/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ConvertAnRGBitkImageTovtkImageData Code.cxx)
-target_link_libraries(ConvertAnRGBitkImageTovtkImageData ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ConvertAnRGBitkImageTovtkImageData
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Bridge/VtkGlue
   COMPONENT Runtime
   )
@@ -25,6 +25,6 @@ enable_testing()
 set(input_image ${CMAKE_CURRENT_BINARY_DIR}/VisibleWomanEyeSlice.png)
 
 add_test(NAME ConvertAnRGBitkImageTovtkImageDataTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ConvertAnRGBitkImageTovtkImageData
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   ${input_image}
   )

--- a/src/Bridge/VtkGlue/ConvertAnitkImageTovtkImageData/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/ConvertAnitkImageTovtkImageData/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ConvertAnitkImageTovtkImageData Code.cxx)
-target_link_libraries(ConvertAnitkImageTovtkImageData ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ConvertAnitkImageTovtkImageData
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Bridge/VtkGlue
   COMPONENT Runtime
   )
@@ -25,6 +25,6 @@ enable_testing()
 set(input_image ${CMAKE_CURRENT_BINARY_DIR}/BrainProtonDensitySlice.png)
 
 add_test(NAME ConvertAnitkImageTovtkImageDataTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ConvertAnitkImageTovtkImageData
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
   )

--- a/src/Bridge/VtkGlue/ConvertRGBvtkImageDataToAnitkImage/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/ConvertRGBvtkImageDataToAnitkImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ConvertRGBvtkImageDataToAnitkImage Code.cxx)
-target_link_libraries(ConvertRGBvtkImageDataToAnitkImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ConvertRGBvtkImageDataToAnitkImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Bridge/VtkGlue
   COMPONENT Runtime
   )
@@ -25,6 +25,6 @@ enable_testing()
 set(input_image ${CMAKE_CURRENT_BINARY_DIR}/VisibleWomanEyeSlice.png)
 
 add_test(NAME ConvertRGBvtkImageDataToAnitkImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ConvertRGBvtkImageDataToAnitkImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
   )

--- a/src/Bridge/VtkGlue/ConvertvtkImageDataToAnitkImage/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/ConvertvtkImageDataToAnitkImage/CMakeLists.txt
@@ -14,8 +14,8 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
   include(${VTK_USE_FILE})
 endif()
 
-add_executable(ConvertvtkImageDataToAnitkImage Code.cxx)
-target_link_libraries(ConvertvtkImageDataToAnitkImage
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME}
   ${ITK_LIBRARIES}
   ${VTK_LIBRARIES}
   )
@@ -27,7 +27,7 @@ if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     )
 endif()
 
-install(TARGETS ConvertvtkImageDataToAnitkImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Bridge/VtkGlue
   COMPONENT Runtime
   )
@@ -43,6 +43,6 @@ enable_testing()
 set(input_image ${CMAKE_CURRENT_BINARY_DIR}/BrainProtonDensitySlice.png)
 
 add_test(NAME ConvertvtkImageDataToAnitkImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ConvertvtkImageDataToAnitkImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
   )

--- a/src/Bridge/VtkGlue/VTKImageToITKImage/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/VTKImageToITKImage/CMakeLists.txt
@@ -21,8 +21,8 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
   include(${VTK_USE_FILE})
 endif()
 
-add_executable(VTKImageToITKImage Code.cxx)
-target_link_libraries(VTKImageToITKImage ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(
@@ -31,7 +31,7 @@ if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     )
 endif()
 
-install(TARGETS VTKImageToITKImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Bridge/VtkGlue
   COMPONENT Runtime
   )
@@ -44,5 +44,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME VTKImageToITKImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/VTKImageToITKImage Gourds.png)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME} Gourds.png)
 

--- a/src/Bridge/VtkGlue/VisualizeEvolvingDense2DLevelSetAsElevationMap/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/VisualizeEvolvingDense2DLevelSetAsElevationMap/CMakeLists.txt
@@ -5,10 +5,10 @@ project(VisualizeEvolvingDense2DLevelSetAsElevationMap)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(VisualizeEvolvingDense2DLevelSetAsElevationMap Code.cxx)
-target_link_libraries(VisualizeEvolvingDense2DLevelSetAsElevationMap ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS VisualizeEvolvingDense2DLevelSetAsElevationMap
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Bridge/VtkGlue
   COMPONENT Runtime
   )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME VisualizeEvolvingDense2DLevelSetAsElevationMapTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/VisualizeEvolvingDense2DLevelSetAsElevationMap
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/cells.png
     100
   )

--- a/src/Bridge/VtkGlue/VisualizeEvolvingDense2DLevelSetZeroSet/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/VisualizeEvolvingDense2DLevelSetZeroSet/CMakeLists.txt
@@ -5,10 +5,10 @@ project(VisualizeEvolvingDense2DLevelSetZeroSet)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(VisualizeEvolvingDense2DLevelSetZeroSet Code.cxx)
-target_link_libraries(VisualizeEvolvingDense2DLevelSetZeroSet ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS VisualizeEvolvingDense2DLevelSetZeroSet
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Bridge/VtkGlue
   COMPONENT Runtime
   )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME VisualizeEvolvingDense2DLevelSetZeroSetTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/VisualizeEvolvingDense2DLevelSetZeroSet
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/cells.png
     100
   )

--- a/src/Bridge/VtkGlue/VisualizeStaticDense2DLevelSetAsElevationMap/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/VisualizeStaticDense2DLevelSetAsElevationMap/CMakeLists.txt
@@ -20,8 +20,8 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
   include(${VTK_USE_FILE})
 endif()
 
-add_executable(VisualizeStaticDense2DLevelSetAsElevationMap Code.cxx)
-target_link_libraries(VisualizeStaticDense2DLevelSetAsElevationMap ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(
@@ -30,7 +30,7 @@ if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     )
 endif()
 
-install(TARGETS VisualizeStaticDense2DLevelSetAsElevationMap
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Bridge/VtkGlue
   COMPONENT Runtime
   )
@@ -42,7 +42,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME VisualizeStaticDense2DLevelSetAsElevationMapTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/VisualizeStaticDense2DLevelSetAsElevationMap
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/cells.png
     0
   )

--- a/src/Bridge/VtkGlue/VisualizeStaticDense2DLevelSetZeroSet/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/VisualizeStaticDense2DLevelSetZeroSet/CMakeLists.txt
@@ -19,8 +19,8 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
   include(${VTK_USE_FILE})
 endif()
 
-add_executable(VisualizeStaticDense2DLevelSetZeroSet Code.cxx)
-target_link_libraries(VisualizeStaticDense2DLevelSetZeroSet ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(
@@ -29,7 +29,7 @@ if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     )
 endif()
 
-install(TARGETS VisualizeStaticDense2DLevelSetZeroSet
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Bridge/VtkGlue
   COMPONENT Runtime
   )
@@ -41,7 +41,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME VisualizeStaticDense2DLevelSetZeroSetTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/VisualizeStaticDense2DLevelSetZeroSet
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/cells.png
     0
   )

--- a/src/Bridge/VtkGlue/VisualizeStaticMalcolm2DLevelSetLayers/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/VisualizeStaticMalcolm2DLevelSetLayers/CMakeLists.txt
@@ -19,8 +19,8 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
   include(${VTK_USE_FILE})
 endif()
 
-add_executable(VisualizeStaticMalcolm2DLevelSetLayers Code.cxx)
-target_link_libraries(VisualizeStaticMalcolm2DLevelSetLayers ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(
@@ -29,7 +29,7 @@ if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     )
 endif()
 
-install(TARGETS VisualizeStaticMalcolm2DLevelSetLayers
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Bridge/VtkGlue
   COMPONENT Runtime
   )
@@ -41,7 +41,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME VisualizeStaticMalcolm2DLevelSetLayersTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/VisualizeStaticMalcolm2DLevelSetLayers
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/cells.png
     0
   )

--- a/src/Bridge/VtkGlue/VisualizeStaticShi2DLevelSetLayers/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/VisualizeStaticShi2DLevelSetLayers/CMakeLists.txt
@@ -19,8 +19,8 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
   include(${VTK_USE_FILE})
 endif()
 
-add_executable(VisualizeStaticShi2DLevelSetLayers Code.cxx)
-target_link_libraries(VisualizeStaticShi2DLevelSetLayers ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(
@@ -29,7 +29,7 @@ if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     )
 endif()
 
-install(TARGETS VisualizeStaticShi2DLevelSetLayers
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Bridge/VtkGlue
   COMPONENT Runtime
   )
@@ -41,7 +41,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME VisualizeStaticShi2DLevelSetLayersTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/VisualizeStaticShi2DLevelSetLayers
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/cells.png
     0
   )

--- a/src/Bridge/VtkGlue/VisualizeStaticWhitaker2DLevelSetLayers/CMakeLists.txt
+++ b/src/Bridge/VtkGlue/VisualizeStaticWhitaker2DLevelSetLayers/CMakeLists.txt
@@ -19,8 +19,8 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
   include(${VTK_USE_FILE})
 endif()
 
-add_executable(VisualizeStaticWhitaker2DLevelSetLayers Code.cxx)
-target_link_libraries(VisualizeStaticWhitaker2DLevelSetLayers ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(
@@ -29,7 +29,7 @@ if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     )
 endif()
 
-install(TARGETS VisualizeStaticWhitaker2DLevelSetLayers
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Bridge/VtkGlue
   COMPONENT Runtime
   )
@@ -41,7 +41,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME VisualizeStaticWhitaker2DLevelSetLayersTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/VisualizeStaticWhitaker2DLevelSetLayers
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/cells.png
     0
   )

--- a/src/Core/Common/AddNoiseToBinaryImage/CMakeLists.txt
+++ b/src/Core/Common/AddNoiseToBinaryImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(AddNoiseToBinaryImage Code.cxx)
-target_link_libraries(AddNoiseToBinaryImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS AddNoiseToBinaryImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,7 +22,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME AddNoiseToBinaryImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/AddNoiseToBinaryImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     Yinyang.png
     output.png
     50)

--- a/src/Core/Common/AddOffsetToIndex/CMakeLists.txt
+++ b/src/Core/Common/AddOffsetToIndex/CMakeLists.txt
@@ -5,10 +5,10 @@ project(AddOffsetToIndex)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(AddOffsetToIndex Code.cxx Code.py)
-target_link_libraries(AddOffsetToIndex ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx Code.py)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS AddOffsetToIndex
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -20,7 +20,7 @@ install(FILES Code.cxx Code.py CMakeLists.txt
 
 enable_testing()
 add_test(NAME AddOffsetToIndexTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/AddOffsetToIndex
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   )
 
 if(ITK_WRAP_PYTHON)

--- a/src/Core/Common/ApplyAFilterOnlyToASpecifiedRegionOfAnImage/CMakeLists.txt
+++ b/src/Core/Common/ApplyAFilterOnlyToASpecifiedRegionOfAnImage/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ApplyAFilterOnlyToASpecifiedRegionOfAnImage)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ApplyAFilterOnlyToASpecifiedRegionOfAnImage Code.cxx Code.py)
-target_link_libraries(ApplyAFilterOnlyToASpecifiedRegionOfAnImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx Code.py)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ApplyAFilterOnlyToASpecifiedRegionOfAnImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx Code.py CMakeLists.txt
 
 enable_testing()
 add_test(NAME ApplyAFilterOnlyToASpecifiedRegionOfAnImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ApplyAFilterOnlyToASpecifiedRegionOfAnImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 
 if(ITK_WRAP_PYTHON)
   add_test(NAME ApplyAFilterOnlyToASpecifiedRegionOfAnImageTestPython

--- a/src/Core/Common/ApplyCustomOperationToEachPixelInImage/CMakeLists.txt
+++ b/src/Core/Common/ApplyCustomOperationToEachPixelInImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(CustomOperationToEachPixelInImage Code.cxx)
-target_link_libraries(CustomOperationToEachPixelInImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CustomOperationToEachPixelInImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CustomOperationToEachPixelInImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CustomOperationToEachPixelInImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/BoundingBoxOfAPointSet/CMakeLists.txt
+++ b/src/Core/Common/BoundingBoxOfAPointSet/CMakeLists.txt
@@ -5,10 +5,10 @@ project(BoundingBoxOfAPointSet)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(BoundingBoxOfAPointSet Code.cxx Code.py)
-target_link_libraries(BoundingBoxOfAPointSet ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx Code.py)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS BoundingBoxOfAPointSet
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx Code.py CMakeLists.txt
 
 enable_testing()
 add_test(NAME BoundingBoxOfAPointSetTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/BoundingBoxOfAPointSet)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 
 if(ITK_WRAP_PYTHON)
   add_test(NAME BoundingBoxOfAPointSetTestPython

--- a/src/Core/Common/BresenhamLine/CMakeLists.txt
+++ b/src/Core/Common/BresenhamLine/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(BresenhamLine Code.cxx)
-target_link_libraries(BresenhamLine ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS BresenhamLine
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME BresenhamLineTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/BresenhamLine
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   )

--- a/src/Core/Common/BuildAHelloWorldProgram/CMakeLists.txt
+++ b/src/Core/Common/BuildAHelloWorldProgram/CMakeLists.txt
@@ -5,10 +5,10 @@ project(BuildAHelloWorldProgram)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(BuildAHelloWorldProgram Code.cxx Code.py)
-target_link_libraries(BuildAHelloWorldProgram ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx Code.py)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS BuildAHelloWorldProgram
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx Code.py CMakeLists.txt
 
 enable_testing()
 add_test(NAME BuildAHelloWorldProgramTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/BuildAHelloWorldProgram)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 
 if(ITK_WRAP_PYTHON)
   add_test(NAME BuildAHelloWorldProgramTestPython

--- a/src/Core/Common/CastVectorImageToAnotherType/CMakeLists.txt
+++ b/src/Core/Common/CastVectorImageToAnotherType/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(CastVectorImageToAnotherType Code.cxx)
-target_link_libraries(CastVectorImageToAnotherType ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CastVectorImageToAnotherType
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CastVectorImageToAnotherTypeTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CastVectorImageToAnotherType)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/CheckIfModuleIsPresent/CMakeLists.txt
+++ b/src/Core/Common/CheckIfModuleIsPresent/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(CheckIfModuleIsPresent Code.cxx)
-target_link_libraries(CheckIfModuleIsPresent ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CheckIfModuleIsPresent
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CheckIfModuleIsPresentTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CheckIfModuleIsPresent)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/ComputeTimeBetweenPoints/CMakeLists.txt
+++ b/src/Core/Common/ComputeTimeBetweenPoints/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ComputeTimeBetweenPoints)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ComputeTimeBetweenPoints Code.cxx)
-target_link_libraries(ComputeTimeBetweenPoints ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ComputeTimeBetweenPoints
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ComputeTimeBetweenPointsTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ComputeTimeBetweenPoints)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 
 if(ITK_WRAP_PYTHON)
   add_test(NAME ComputeTimeBetweenPointsTestPython

--- a/src/Core/Common/ConceptCheckingIsFloatingPoint/CMakeLists.txt
+++ b/src/Core/Common/ConceptCheckingIsFloatingPoint/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ConceptCheckingIsFloatingPoint)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ConceptCheckingIsFloatingPoint Code.cxx)
-target_link_libraries(ConceptCheckingIsFloatingPoint ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ConceptCheckingIsFloatingPoint
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -20,4 +20,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ConceptCheckingIsFloatingPointTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ConceptCheckingIsFloatingPoint)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/ConceptCheckingIsSameDimension/CMakeLists.txt
+++ b/src/Core/Common/ConceptCheckingIsSameDimension/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ConceptCheckingIsSameDimension)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ConceptCheckingIsSameDimension Code.cxx)
-target_link_libraries(ConceptCheckingIsSameDimension ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ConceptCheckingIsSameDimension
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -20,4 +20,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ConceptCheckingIsSameDimensionTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ConceptCheckingIsSameDimension)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/ConceptCheckingIsSameType/CMakeLists.txt
+++ b/src/Core/Common/ConceptCheckingIsSameType/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ConceptCheckingIsSameType)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ConceptCheckingIsSameType Code.cxx)
-target_link_libraries(ConceptCheckingIsSameType ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ConceptCheckingIsSameType
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -20,4 +20,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ConceptCheckingIsSameTypeTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ConceptCheckingIsSameType)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/ConvertArrayToImage/CMakeLists.txt
+++ b/src/Core/Common/ConvertArrayToImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ConvertArrayToImage Code.cxx)
-target_link_libraries(ConvertArrayToImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ConvertArrayToImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ConvertArrayToImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ConvertArrayToImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   )

--- a/src/Core/Common/CovariantVectorDotProduct/CMakeLists.txt
+++ b/src/Core/Common/CovariantVectorDotProduct/CMakeLists.txt
@@ -5,10 +5,10 @@ project(CovariantVectorDotProduct)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(CovariantVectorDotProduct Code.cxx)
-target_link_libraries(CovariantVectorDotProduct ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CovariantVectorDotProduct
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,4 +20,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CovariantVectorDotProductTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CovariantVectorDotProduct)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/CovariantVectorNorm/CMakeLists.txt
+++ b/src/Core/Common/CovariantVectorNorm/CMakeLists.txt
@@ -5,10 +5,10 @@ project(CovariantVectorNorm)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(CovariantVectorNorm Code.cxx)
-target_link_libraries(CovariantVectorNorm ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CovariantVectorNorm
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,4 +20,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CovariantVectorNormTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CovariantVectorNorm)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/CreateABackwardDifferenceOperator/CMakeLists.txt
+++ b/src/Core/Common/CreateABackwardDifferenceOperator/CMakeLists.txt
@@ -5,10 +5,10 @@ project(CreateABackwardDifferenceOperator)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(CreateABackwardDifferenceOperator Code.cxx)
-target_link_libraries(CreateABackwardDifferenceOperator ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateABackwardDifferenceOperator
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,4 +20,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CreateABackwardDifferenceOperatorTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateABackwardDifferenceOperator)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/CreateACovariantVector/CMakeLists.txt
+++ b/src/Core/Common/CreateACovariantVector/CMakeLists.txt
@@ -5,10 +5,10 @@ project(CreateACovariantVector)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(CreateACovariantVector Code.cxx Code.py)
-target_link_libraries(CreateACovariantVector ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx Code.py)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateACovariantVector
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx Code.py CMakeLists.txt
 
 enable_testing()
 add_test(NAME CreateACovariantVectorTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateACovariantVector)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 
 if(ITK_WRAP_PYTHON)
   add_test(NAME CreateACovariantVectorTestPython

--- a/src/Core/Common/CreateAFixedArray/CMakeLists.txt
+++ b/src/Core/Common/CreateAFixedArray/CMakeLists.txt
@@ -5,10 +5,10 @@ project(CreateAFixedArray)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(CreateAFixedArray Code.cxx Code.py)
-target_link_libraries(CreateAFixedArray ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx Code.py)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateAFixedArray
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx Code.py CMakeLists.txt
 
 enable_testing()
 add_test(NAME CreateAFixedArrayTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateAFixedArray)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 
 if(ITK_WRAP_PYTHON)
   add_test(NAME CreateAFixedArrayTestPython

--- a/src/Core/Common/CreateAIndex/CMakeLists.txt
+++ b/src/Core/Common/CreateAIndex/CMakeLists.txt
@@ -5,10 +5,10 @@ project(CreateAIndex)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(CreateAIndex Code.py Code.cxx)
-target_link_libraries(CreateAIndex ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateAIndex
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx Code.py CMakeLists.txt
 
 enable_testing()
 add_test(NAME CreateAIndexTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateAIndex)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 
 if(ITK_WRAP_PYTHON)
   add_test(NAME CreateAIndexTestPython

--- a/src/Core/Common/CreateAPointSet/CMakeLists.txt
+++ b/src/Core/Common/CreateAPointSet/CMakeLists.txt
@@ -5,10 +5,10 @@ project(CreateAPointSet)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(CreateAPointSet Code.py Code.cxx)
-target_link_libraries(CreateAPointSet ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateAPointSet
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx Code.py CMakeLists.txt
 
 enable_testing()
 add_test(NAME CreateAPointSetTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateAPointSet
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
 )
 
 if(ITK_WRAP_PYTHON)

--- a/src/Core/Common/CreateASize/CMakeLists.txt
+++ b/src/Core/Common/CreateASize/CMakeLists.txt
@@ -5,10 +5,10 @@ project(CreateASize)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(CreateASize Code.py Code.cxx)
-target_link_libraries(CreateASize ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateASize
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx Code.py CMakeLists.txt
 
 enable_testing()
 add_test(NAME CreateASizeTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateASize)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 
 if(ITK_WRAP_PYTHON)
   add_test(NAME CreateASizeTestPython

--- a/src/Core/Common/CreateAVector/CMakeLists.txt
+++ b/src/Core/Common/CreateAVector/CMakeLists.txt
@@ -5,10 +5,10 @@ project(CreateAVector)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(CreateAVector Code.py Code.cxx)
-target_link_libraries(CreateAVector ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateAVector
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx Code.py CMakeLists.txt
 
 enable_testing()
 add_test(NAME CreateAVectorTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateAVector)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 
 if(ITK_WRAP_PYTHON)
   add_test(NAME CreateAVectorTestPython

--- a/src/Core/Common/CreateAnImage/CMakeLists.txt
+++ b/src/Core/Common/CreateAnImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(CreateAnImage Code.cxx)
-target_link_libraries(CreateAnImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateAnImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -23,7 +23,7 @@ install(FILES Code.cxx CMakeLists.txt Code.py
 enable_testing()
 
 add_test(NAME CreateAnImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateAnImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   )
 
 if(ITK_WRAP_PYTHON)

--- a/src/Core/Common/CreateAnImageOfVectors/CMakeLists.txt
+++ b/src/Core/Common/CreateAnImageOfVectors/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(CreateAnImageOfVectors Code.cxx)
-target_link_libraries(CreateAnImageOfVectors ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateAnImageOfVectors
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -23,7 +23,7 @@ install(FILES Code.cxx CMakeLists.txt Code.py
 enable_testing()
 
 add_test(NAME CreateAnImageOfVectorsTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateAnImageOfVectors
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   )
 
 if(ITK_WRAP_PYTHON)

--- a/src/Core/Common/CreateAnImageRegion/CMakeLists.txt
+++ b/src/Core/Common/CreateAnImageRegion/CMakeLists.txt
@@ -5,10 +5,10 @@ project(CreateAnImageRegion)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(CreateAnImageRegion Code.cxx Code.py)
-target_link_libraries(CreateAnImageRegion ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx Code.py)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateAnImageRegion
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -21,7 +21,7 @@ install(FILES Code.cxx Code.py CMakeLists.txt
 enable_testing()
 set(testOutputRegex "ImageRegion")
 add_test(NAME CreateAnImageRegionTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateAnImageRegion)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 set_tests_properties(CreateAnImageRegionTest PROPERTIES
     PASS_REGULAR_EXPRESSION "${testOutputRegex}")
 

--- a/src/Core/Common/CreateAnRGBImage/CMakeLists.txt
+++ b/src/Core/Common/CreateAnRGBImage/CMakeLists.txt
@@ -4,10 +4,10 @@ project(CreateAnRGBImage)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(CreateAnRGBImage Code.cxx)
-target_link_libraries(CreateAnRGBImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateAnRGBImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -19,7 +19,7 @@ install(FILES Code.cxx CMakeLists.txt Code.py
 
 enable_testing()
 add_test(NAME CreateAnRGBImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateAnRGBImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 
 if(ITK_WRAP_PYTHON)
   add_test(NAME CreateAnRGBImageTestPython

--- a/src/Core/Common/CreateAnother/CMakeLists.txt
+++ b/src/Core/Common/CreateAnother/CMakeLists.txt
@@ -5,10 +5,10 @@ project(CreateAnother)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(CreateAnother Code.cxx)
-target_link_libraries(CreateAnother ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateAnother
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,4 +20,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CreateAnotherTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateAnother)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/CreateAnotherInstanceOfAnImage/CMakeLists.txt
+++ b/src/Core/Common/CreateAnotherInstanceOfAnImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(CreateAnotherInstanceOfAnImage Code.cxx)
-target_link_libraries(CreateAnotherInstanceOfAnImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateAnotherInstanceOfAnImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CreateAnotherInstanceOfAnImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateAnotherInstanceOfAnImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Core/Common/CreateDerivativeKernel/CMakeLists.txt
+++ b/src/Core/Common/CreateDerivativeKernel/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(CreateDerivativeKernel Code.cxx)
-target_link_libraries(CreateDerivativeKernel ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateDerivativeKernel
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,7 +22,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CreateDerivativeKernelTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateDerivativeKernel)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 
 if(ITK_WRAP_PYTHON)
   add_test(NAME CreateDerivativeKernelTestPython

--- a/src/Core/Common/CreateForwardDifferenceKernel/CMakeLists.txt
+++ b/src/Core/Common/CreateForwardDifferenceKernel/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(CreateForwardDifferenceKernel Code.cxx)
-target_link_libraries(CreateForwardDifferenceKernel ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateForwardDifferenceKernel
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,7 +22,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CreateForwardDifferenceKernelTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateForwardDifferenceKernel)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 
 if(ITK_WRAP_PYTHON)
   add_test(NAME CreateForwardDifferenceKernelTestPython

--- a/src/Core/Common/CreateGaussianDerivativeKernel/CMakeLists.txt
+++ b/src/Core/Common/CreateGaussianDerivativeKernel/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(CreateGaussianDerivativeKernel Code.cxx)
-target_link_libraries(CreateGaussianDerivativeKernel ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateGaussianDerivativeKernel
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,7 +22,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CreateGaussianDerivativeKernelTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateGaussianDerivativeKernel)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 
 if(ITK_WRAP_PYTHON)
   add_test(NAME CreateGaussianDerivativeKernelTestPython

--- a/src/Core/Common/CreateGaussianKernel/CMakeLists.txt
+++ b/src/Core/Common/CreateGaussianKernel/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(CreateGaussianKernel Code.cxx)
-target_link_libraries(CreateGaussianKernel ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateGaussianKernel
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,7 +22,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CreateGaussianKernelTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateGaussianKernel)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 
 if(ITK_WRAP_PYTHON)
   add_test(NAME CreateGaussianKernelTestPython

--- a/src/Core/Common/CreateLaplacianKernel/CMakeLists.txt
+++ b/src/Core/Common/CreateLaplacianKernel/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(CreateLaplacianKernel Code.cxx)
-target_link_libraries(CreateLaplacianKernel ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateLaplacianKernel
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,7 +22,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CreateLaplacianKernelTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateLaplacianKernel)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 
 if(ITK_WRAP_PYTHON)
   add_test(NAME CreateLaplacianKernelTestPython

--- a/src/Core/Common/CreateSobelKernel/CMakeLists.txt
+++ b/src/Core/Common/CreateSobelKernel/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(CreateSobelKernel Code.cxx)
-target_link_libraries(CreateSobelKernel ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateSobelKernel
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,7 +22,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CreateSobelKernelTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateSobelKernel)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 
 if(ITK_WRAP_PYTHON)
   add_test(NAME CreateSobelKernelTestPython

--- a/src/Core/Common/CreateVectorImage/CMakeLists.txt
+++ b/src/Core/Common/CreateVectorImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(CreateVectorImage Code.cxx)
-target_link_libraries(CreateVectorImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateVectorImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CreateVectorImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateVectorImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Core/Common/CropImageBySpecifyingRegion/CMakeLists.txt
+++ b/src/Core/Common/CropImageBySpecifyingRegion/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(CropImageBySpecifyingRegion Code.cxx)
-target_link_libraries(CropImageBySpecifyingRegion ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CropImageBySpecifyingRegion
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CropImageBySpecifyingRegionTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CropImageBySpecifyingRegion)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/DeepCopyImage/CMakeLists.txt
+++ b/src/Core/Common/DeepCopyImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(DeepCopyImage Code.cxx)
-target_link_libraries(DeepCopyImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS DeepCopyImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME DeepCopyImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/DeepCopyImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/DemonstrateAllOperators/CMakeLists.txt
+++ b/src/Core/Common/DemonstrateAllOperators/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(DemonstrateAllOperators Code.cxx)
-target_link_libraries(DemonstrateAllOperators ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS DemonstrateAllOperators
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME DemonstrateAllOperatorsTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/DemonstrateAllOperators)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/DirectWarningToFile/CMakeLists.txt
+++ b/src/Core/Common/DirectWarningToFile/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(DirectWarningToFile Code.cxx)
-target_link_libraries(DirectWarningToFile ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS DirectWarningToFile
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME DirectWarningToFileTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/DirectWarningToFile)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Core/Common/DisplayImage/CMakeLists.txt
+++ b/src/Core/Common/DisplayImage/CMakeLists.txt
@@ -15,8 +15,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(DisplayImage Code.cxx)
-  target_link_libraries(DisplayImage ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -25,11 +25,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(DisplayImage Code.cxx)
-  target_link_libraries(DisplayImage ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS DisplayImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -42,4 +42,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME DisplayImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/DisplayImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/DistanceBetweenIndices/CMakeLists.txt
+++ b/src/Core/Common/DistanceBetweenIndices/CMakeLists.txt
@@ -5,10 +5,10 @@ project(DistanceBetweenIndices)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(DistanceBetweenIndices Code.cxx)
-target_link_libraries(DistanceBetweenIndices ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS DistanceBetweenIndices
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,4 +20,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME DistanceBetweenIndicesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/DistanceBetweenIndices)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/DistanceBetweenPoints/CMakeLists.txt
+++ b/src/Core/Common/DistanceBetweenPoints/CMakeLists.txt
@@ -5,10 +5,10 @@ project(DistanceBetweenPoints)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(DistanceBetweenPoints Code.cxx)
-target_link_libraries(DistanceBetweenPoints ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS DistanceBetweenPoints
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,4 +20,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME DistanceBetweenPointsTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/DistanceBetweenPoints)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/DoDataParallelThreading/CMakeLists.txt
+++ b/src/Core/Common/DoDataParallelThreading/CMakeLists.txt
@@ -5,10 +5,10 @@ project(DoDataParallelThreading)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(DoDataParallelThreading Code.cxx)
-target_link_libraries(DoDataParallelThreading ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS DoDataParallelThreading
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,5 +20,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME DoDataParallelThreadingTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/DoDataParallelThreading
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
 )

--- a/src/Core/Common/DuplicateAnImage/CMakeLists.txt
+++ b/src/Core/Common/DuplicateAnImage/CMakeLists.txt
@@ -5,10 +5,10 @@ project(DuplicateAnImage)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(DuplicateAnImage Code.cxx)
-target_link_libraries(DuplicateAnImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS DuplicateAnImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME DuplicateAnImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/DuplicateAnImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 
 if(ITK_WRAP_PYTHON)
   add_test(NAME DuplicateAnImageTestPython

--- a/src/Core/Common/FilterAndParallelizeImageRegion/CMakeLists.txt
+++ b/src/Core/Common/FilterAndParallelizeImageRegion/CMakeLists.txt
@@ -5,10 +5,10 @@ project(FilterAndParallelizeImageRegion)
 find_package(ITK 5.0 REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(FilterAndParallelizeImageRegion Code.cxx)
-target_link_libraries(FilterAndParallelizeImageRegion ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS FilterAndParallelizeImageRegion
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,4 +20,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME FilterAndParallelizeImageRegionTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/FilterAndParallelizeImageRegion)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/FilterImage/CMakeLists.txt
+++ b/src/Core/Common/FilterImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(FilterImage Code.cxx)
-target_link_libraries(FilterImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS FilterImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME FilterImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/FilterImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/FilterImageUsingMultipleThreads/CMakeLists.txt
+++ b/src/Core/Common/FilterImageUsingMultipleThreads/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(FilterImageUsingMultipleThreads Code.cxx)
-target_link_libraries(FilterImageUsingMultipleThreads ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS FilterImageUsingMultipleThreads
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME FilterImageUsingMultipleThreadsTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/FilterImageUsingMultipleThreads)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Core/Common/FilterImageWithoutCopying/CMakeLists.txt
+++ b/src/Core/Common/FilterImageWithoutCopying/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(FilterImageWithoutCopying Code.cxx)
-target_link_libraries(FilterImageWithoutCopying ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS FilterImageWithoutCopying
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME FilterImageWithoutCopyingTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/FilterImageWithoutCopying)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Core/Common/FindMaxAndMinInImage/CMakeLists.txt
+++ b/src/Core/Common/FindMaxAndMinInImage/CMakeLists.txt
@@ -20,8 +20,8 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
   include(${VTK_USE_FILE})
 endif()
 
-add_executable(FindMaxAndMinInImage Code.cxx)
-target_link_libraries(FindMaxAndMinInImage ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(
@@ -30,7 +30,7 @@ if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     )
 endif()
 
-install(TARGETS FindMaxAndMinInImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -43,4 +43,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME FindMaxAndMinInImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/FindMaxAndMinInImage Yinyang.png)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME} Yinyang.png)

--- a/src/Core/Common/GetImageSize/CMakeLists.txt
+++ b/src/Core/Common/GetImageSize/CMakeLists.txt
@@ -5,10 +5,10 @@ project(GetImageSize)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(GetImageSize Code.cxx)
-target_link_libraries(GetImageSize ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS GetImageSize
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME GetImageSizeTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/GetImageSize
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/Yinyang.png
 )
 

--- a/src/Core/Common/GetNameOfClass/CMakeLists.txt
+++ b/src/Core/Common/GetNameOfClass/CMakeLists.txt
@@ -5,10 +5,10 @@ project(GetNameOfClass)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(GetNameOfClass Code.cxx)
-target_link_libraries(GetNameOfClass ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS GetNameOfClass
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,4 +20,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME GetNameOfClassTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/GetNameOfClass)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/GetOrSetMemberVariableOfITKClass/CMakeLists.txt
+++ b/src/Core/Common/GetOrSetMemberVariableOfITKClass/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(GetOrSetMemberVariableOfITKClass Code.cxx)
-target_link_libraries(GetOrSetMemberVariableOfITKClass ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS GetOrSetMemberVariableOfITKClass
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME GetOrSetMemberVariableOfITKClassTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/GetOrSetMemberVariableOfITKClass)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Core/Common/GetTypeBasicInformation/CMakeLists.txt
+++ b/src/Core/Common/GetTypeBasicInformation/CMakeLists.txt
@@ -5,10 +5,10 @@ project(GetTypeBasicInformation)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(GetTypeBasicInformation Code.cxx)
-target_link_libraries(GetTypeBasicInformation ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS GetTypeBasicInformation
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME GetTypeBasicInformationTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/GetTypeBasicInformation)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 
 if(ITK_WRAP_PYTHON)
   add_test(NAME GetTypeBasicInformationTestPython

--- a/src/Core/Common/ImageRegionIntersection/CMakeLists.txt
+++ b/src/Core/Common/ImageRegionIntersection/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ImageRegionIntersection)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ImageRegionIntersection Code.cxx)
-target_link_libraries(ImageRegionIntersection ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ImageRegionIntersection
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,4 +20,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ImageRegionIntersectionTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ImageRegionIntersection)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/ImageRegionOverlap/CMakeLists.txt
+++ b/src/Core/Common/ImageRegionOverlap/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ImageRegionOverlap)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ImageRegionOverlap Code.cxx)
-target_link_libraries(ImageRegionOverlap ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ImageRegionOverlap
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,6 +20,6 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ImageRegionOverlapTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ImageRegionOverlap
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/Output.png
   )

--- a/src/Core/Common/ImportPixelBufferIntoAnImage/CMakeLists.txt
+++ b/src/Core/Common/ImportPixelBufferIntoAnImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ImportPixelBufferIntoAnImage Code.cxx)
-target_link_libraries(ImportPixelBufferIntoAnImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ImportPixelBufferIntoAnImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -25,7 +25,7 @@ set(output_image Output.png)
 set(test_options)
 
 add_test(NAME ImportPixelBufferIntoAnImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ImportPixelBufferIntoAnImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${output_image}
     ${test_options}
   )

--- a/src/Core/Common/InPlaceFilterOfImage/CMakeLists.txt
+++ b/src/Core/Common/InPlaceFilterOfImage/CMakeLists.txt
@@ -20,8 +20,8 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
   include(${VTK_USE_FILE})
 endif()
 
-add_executable(InPlaceFilterOfImage Code.cxx)
-target_link_libraries(InPlaceFilterOfImage ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(
@@ -30,7 +30,7 @@ if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     )
 endif()
 
-install(TARGETS InPlaceFilterOfImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -43,4 +43,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME InPlaceFilterOfImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/InPlaceFilterOfImage Gourds.png)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME} Gourds.png)

--- a/src/Core/Common/IsPixelInsideRegion/CMakeLists.txt
+++ b/src/Core/Common/IsPixelInsideRegion/CMakeLists.txt
@@ -5,10 +5,10 @@ project(IsPixelInsideRegion)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(IsPixelInsideRegion Code.cxx)
-target_link_libraries(IsPixelInsideRegion ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS IsPixelInsideRegion
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx Code.py CMakeLists.txt
 
 enable_testing()
 add_test(NAME IsPixelInsideRegionTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/IsPixelInsideRegion)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 
 if(ITK_WRAP_PYTHON)
   add_test(NAME IsPixelInsideRegionPython

--- a/src/Core/Common/IterateImageStartingAtSeed/CMakeLists.txt
+++ b/src/Core/Common/IterateImageStartingAtSeed/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(IterateImageStartingAtSeed Code.cxx)
-target_link_libraries(IterateImageStartingAtSeed ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS IterateImageStartingAtSeed
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME IterateImageStartingAtSeedTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/IterateImageStartingAtSeed)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/IterateLineThroughImage/CMakeLists.txt
+++ b/src/Core/Common/IterateLineThroughImage/CMakeLists.txt
@@ -15,8 +15,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(IterateLineThroughImage Code.cxx)
-  target_link_libraries(IterateLineThroughImage ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -25,11 +25,11 @@ if(ENABLE_QUICKVIEW)
     )
   endif()
 else()
-  add_executable(IterateLineThroughImage Code.cxx)
-  target_link_libraries(IterateLineThroughImage ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS IterateLineThroughImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -42,5 +42,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME IterateLineThroughImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/IterateLineThroughImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Core/Common/IterateLineThroughImageWithoutWriteAccess/CMakeLists.txt
+++ b/src/Core/Common/IterateLineThroughImageWithoutWriteAccess/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(IterateLineThroughImageWithoutWriteAccess Code.cxx)
-target_link_libraries(IterateLineThroughImageWithoutWriteAccess ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS IterateLineThroughImageWithoutWriteAccess
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME IterateLineThroughImageWithoutWriteAccessTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/IterateLineThroughImageWithoutWriteAccess)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Core/Common/IterateOnAVectorContainer/CMakeLists.txt
+++ b/src/Core/Common/IterateOnAVectorContainer/CMakeLists.txt
@@ -5,10 +5,10 @@ project(IterateOnAVectorContainer)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(IterateOnAVectorContainer Code.cxx)
-target_link_libraries(IterateOnAVectorContainer ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS IterateOnAVectorContainer
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,4 +20,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME IterateOnAVectorContainerTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/IterateOnAVectorContainer)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/IterateOverARegionWithAShapedNeighborhoodIterator/CMakeLists.txt
+++ b/src/Core/Common/IterateOverARegionWithAShapedNeighborhoodIterator/CMakeLists.txt
@@ -5,10 +5,10 @@ project(IterateOverARegionWithAShapedNeighborhoodIterator)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(IterateOverARegionWithAShapedNeighborhoodIterator Code.cxx)
-target_link_libraries(IterateOverARegionWithAShapedNeighborhoodIterator ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS IterateOverARegionWithAShapedNeighborhoodIterator
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,4 +20,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME IterateOverARegionWithAShapedNeighborhoodIteratorTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/IterateOverARegionWithAShapedNeighborhoodIterator)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/IterateOverARegionWithAShapedNeighborhoodIteratorManual/CMakeLists.txt
+++ b/src/Core/Common/IterateOverARegionWithAShapedNeighborhoodIteratorManual/CMakeLists.txt
@@ -5,10 +5,10 @@ project(IterateOverARegionWithAShapedNeighborhoodIteratorManual)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(IterateOverARegionWithAShapedNeighborhoodIteratorManual Code.cxx)
-target_link_libraries(IterateOverARegionWithAShapedNeighborhoodIteratorManual ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS IterateOverARegionWithAShapedNeighborhoodIteratorManual
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,4 +20,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME IterateOverARegionWithAShapedNeighborhoodIteratorManualTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/IterateOverARegionWithAShapedNeighborhoodIteratorManual)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/IterateOverSpecificRegion/CMakeLists.txt
+++ b/src/Core/Common/IterateOverSpecificRegion/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(IterateOverSpecificRegion Code.cxx)
-target_link_libraries(IterateOverSpecificRegion ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS IterateOverSpecificRegion
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME IterateOverSpecificRegionTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/IterateOverSpecificRegion)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/IterateRegionWithAccessToIndexWithWriteAccess/CMakeLists.txt
+++ b/src/Core/Common/IterateRegionWithAccessToIndexWithWriteAccess/CMakeLists.txt
@@ -16,8 +16,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(IterateRegionWithAccessToIndexWithWriteAccess Code.cxx)
-  target_link_libraries(IterateRegionWithAccessToIndexWithWriteAccess ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -26,11 +26,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(IterateRegionWithAccessToIndexWithWriteAccess Code.cxx)
-  target_link_libraries(IterateRegionWithAccessToIndexWithWriteAccess ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS IterateRegionWithAccessToIndexWithWriteAccess
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -43,5 +43,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME IterateRegionWithAccessToIndexWithWriteAccessTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/IterateRegionWithAccessToIndexWithWriteAccess
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     Yinyang.png)

--- a/src/Core/Common/IterateRegionWithAccessToIndexWithoutWriteAccess/CMakeLists.txt
+++ b/src/Core/Common/IterateRegionWithAccessToIndexWithoutWriteAccess/CMakeLists.txt
@@ -15,8 +15,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(IterateRegionWithAccessToIndexWithoutWriteAccess Code.cxx)
-  target_link_libraries(IterateRegionWithAccessToIndexWithoutWriteAccess ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -25,11 +25,11 @@ if(ENABLE_QUICKVIEW)
     )
   endif()
 else()
-  add_executable(IterateRegionWithAccessToIndexWithoutWriteAccess Code.cxx)
-  target_link_libraries(IterateRegionWithAccessToIndexWithoutWriteAccess ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS IterateRegionWithAccessToIndexWithoutWriteAccess
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -42,6 +42,6 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME IterateRegionWithAccessToIndexWithoutWriteAccessTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/IterateRegionWithAccessToIndexWithoutWriteAccess
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     Yinyang.png)
 

--- a/src/Core/Common/IterateRegionWithNeighborhood/CMakeLists.txt
+++ b/src/Core/Common/IterateRegionWithNeighborhood/CMakeLists.txt
@@ -20,8 +20,8 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
   include(${VTK_USE_FILE})
 endif()
 
-add_executable(IterateRegionWithNeighborhood Code.cxx)
-target_link_libraries(IterateRegionWithNeighborhood ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(
@@ -30,7 +30,7 @@ if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     )
 endif()
 
-install(TARGETS IterateRegionWithNeighborhood
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -43,5 +43,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME IterateRegionWithNeighborhoodTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/IterateRegionWithNeighborhood Yinyang.png)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME} Yinyang.png)
 

--- a/src/Core/Common/IterateRegionWithWriteAccess/CMakeLists.txt
+++ b/src/Core/Common/IterateRegionWithWriteAccess/CMakeLists.txt
@@ -21,8 +21,8 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
   include(${VTK_USE_FILE})
 endif()
 
-add_executable(IterateRegionWithWriteAccess Code.cxx)
-target_link_libraries(IterateRegionWithWriteAccess ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(
@@ -31,7 +31,7 @@ if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     )
 endif()
 
-install(TARGETS IterateRegionWithWriteAccess
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -44,4 +44,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME IterateRegionWithWriteAccessTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/IterateRegionWithWriteAccess Yinyang.png)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME} Yinyang.png)

--- a/src/Core/Common/IterateRegionWithoutWriteAccess/CMakeLists.txt
+++ b/src/Core/Common/IterateRegionWithoutWriteAccess/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(IterateRegionWithoutWriteAccess Code.cxx)
-target_link_libraries(IterateRegionWithoutWriteAccess ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS IterateRegionWithoutWriteAccess
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME IterateRegionWithoutWriteAccessTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/IterateRegionWithoutWriteAccess
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     Yinyang.png)

--- a/src/Core/Common/IterateWithNeighborhoodWithoutAccess/CMakeLists.txt
+++ b/src/Core/Common/IterateWithNeighborhoodWithoutAccess/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(IterateWithNeighborhoodWithoutAccess Code.cxx)
-target_link_libraries(IterateWithNeighborhoodWithoutAccess ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS IterateWithNeighborhoodWithoutAccess
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -24,5 +24,5 @@ enable_testing()
 set(input_image Yinyang.png)
 
 add_test(NAME IterateWithNeighborhoodWithoutAccessTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/IterateWithNeighborhoodWithoutAccess
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image})

--- a/src/Core/Common/MakeOutOfBoundsPixelsReturnConstValue/CMakeLists.txt
+++ b/src/Core/Common/MakeOutOfBoundsPixelsReturnConstValue/CMakeLists.txt
@@ -22,8 +22,8 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
   include(${VTK_USE_FILE})
 endif()
 
-add_executable(MakeOutOfBoundsPixelsReturnConstValue Code.cxx)
-target_link_libraries(MakeOutOfBoundsPixelsReturnConstValue ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(
@@ -32,7 +32,7 @@ if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     )
 endif()
 
-install(TARGETS MakeOutOfBoundsPixelsReturnConstValue
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -45,5 +45,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME MakeOutOfBoundsPixelsReturnConstValueTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MakeOutOfBoundsPixelsReturnConstValue)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Core/Common/MakePartOfImageTransparent/CMakeLists.txt
+++ b/src/Core/Common/MakePartOfImageTransparent/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(MakePartOfImageTransparent Code.cxx)
-target_link_libraries(MakePartOfImageTransparent ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS MakePartOfImageTransparent
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME MakePartOfImageTransparentTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MakePartOfImageTransparent
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   )

--- a/src/Core/Common/Matrix/CMakeLists.txt
+++ b/src/Core/Common/Matrix/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(Matrix Code.cxx)
-target_link_libraries(Matrix ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS Matrix
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,6 +22,6 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME MatrixTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Matrix
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   )
 

--- a/src/Core/Common/MatrixInverse/CMakeLists.txt
+++ b/src/Core/Common/MatrixInverse/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(MatrixInverse Code.cxx)
-target_link_libraries(MatrixInverse ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS MatrixInverse
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME MatrixInverseTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MatrixInverse
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   )

--- a/src/Core/Common/MersenneTwisterRandomIntegerGenerator/CMakeLists.txt
+++ b/src/Core/Common/MersenneTwisterRandomIntegerGenerator/CMakeLists.txt
@@ -5,10 +5,10 @@ project(MersenneTwisterRandomIntegerGenerator)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(MersenneTwisterRandomIntegerGenerator Code.cxx)
-target_link_libraries(MersenneTwisterRandomIntegerGenerator ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS MersenneTwisterRandomIntegerGenerator
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,4 +20,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME MersenneTwisterRandomIntegerGeneratorTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MersenneTwisterRandomIntegerGenerator)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/MersenneTwisterRandomNumberGenerator/CMakeLists.txt
+++ b/src/Core/Common/MersenneTwisterRandomNumberGenerator/CMakeLists.txt
@@ -5,10 +5,10 @@ project(MersenneTwisterRandomNumberGenerator)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(MersenneTwisterRandomNumberGenerator Code.cxx)
-target_link_libraries(MersenneTwisterRandomNumberGenerator ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS MersenneTwisterRandomNumberGenerator
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,4 +20,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME MersenneTwisterRandomNumberGeneratorTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MersenneTwisterRandomNumberGenerator)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/MiniPipeline/CMakeLists.txt
+++ b/src/Core/Common/MiniPipeline/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(MiniPipeline Code.cxx)
-target_link_libraries(MiniPipeline ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS MiniPipeline
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME MiniPipelineTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MiniPipeline)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/MultiThreadOilPainting/CMakeLists.txt
+++ b/src/Core/Common/MultiThreadOilPainting/CMakeLists.txt
@@ -15,8 +15,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(MultiThreadOilPainting Code.cxx)
-  target_link_libraries(MultiThreadOilPainting ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -25,11 +25,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(MultiThreadOilPainting Code.cxx)
-  target_link_libraries(MultiThreadOilPainting ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS MultiThreadOilPainting
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -42,4 +42,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME MultiThreadOilPaintingTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MultiThreadOilPainting Yinyang.png 100 20)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME} Yinyang.png 100 20)

--- a/src/Core/Common/MultipleInputsOfDifferentType/CMakeLists.txt
+++ b/src/Core/Common/MultipleInputsOfDifferentType/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(MultipleInputsOfDifferentType Code.cxx)
-target_link_libraries(MultipleInputsOfDifferentType ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS MultipleInputsOfDifferentType
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME MultipleInputsOfDifferentTypeTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MultipleInputsOfDifferentType)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Core/Common/MultipleInputsOfSameType/CMakeLists.txt
+++ b/src/Core/Common/MultipleInputsOfSameType/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(MultipleInputsOfSameType Code.cxx)
-target_link_libraries(MultipleInputsOfSameType ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS MultipleInputsOfSameType
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME MultipleInputsOfSameTypeTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MultipleInputsOfSameType)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/MultipleOutputsOfDifferentType/CMakeLists.txt
+++ b/src/Core/Common/MultipleOutputsOfDifferentType/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(MultipleOutputsOfDifferentType Code.cxx)
-target_link_libraries(MultipleOutputsOfDifferentType ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS MultipleOutputsOfDifferentType
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME MultipleOutputsOfDifferentTypeTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MultipleOutputsOfDifferentType)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Core/Common/MultipleOutputsOfSameType/CMakeLists.txt
+++ b/src/Core/Common/MultipleOutputsOfSameType/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(MultipleOutputsOfSameType Code.cxx)
-target_link_libraries(MultipleOutputsOfSameType ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS MultipleOutputsOfSameType
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME MultipleOutputsOfSameTypeTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MultipleOutputsOfSameType)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/NeighborhoodIteratorOnVectorImage/CMakeLists.txt
+++ b/src/Core/Common/NeighborhoodIteratorOnVectorImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(NeighborhoodIteratorOnVectorImage Code.cxx)
-target_link_libraries(NeighborhoodIteratorOnVectorImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS NeighborhoodIteratorOnVectorImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME NeighborhoodIteratorOnVectorImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/NeighborhoodIteratorOnVectorImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Core/Common/ObserveAnEvent/CMakeLists.txt
+++ b/src/Core/Common/ObserveAnEvent/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ObserveAnEvent)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ObserveAnEvent Code.cxx)
-target_link_libraries(ObserveAnEvent ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ObserveAnEvent
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx Code.py CMakeLists.txt
 
 enable_testing()
 add_test(NAME ObserveAnEventTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ObserveAnEvent)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 
 if(ITK_WRAP_PYTHON)
   add_test(NAME ObserveAnEventTestPython

--- a/src/Core/Common/PassImageToFunction/CMakeLists.txt
+++ b/src/Core/Common/PassImageToFunction/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(PassImageToFunction Code.cxx)
-target_link_libraries(PassImageToFunction ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS PassImageToFunction
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME PassImageToFunctionTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/PassImageToFunction)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/PermuteSequenceOfIndices/CMakeLists.txt
+++ b/src/Core/Common/PermuteSequenceOfIndices/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(PermuteSequenceOfIndices Code.cxx)
-target_link_libraries(PermuteSequenceOfIndices ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS PermuteSequenceOfIndices
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME PermuteSequenceOfIndicesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/PermuteSequenceOfIndices)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Core/Common/PiConstant/CMakeLists.txt
+++ b/src/Core/Common/PiConstant/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(PiConstant Code.cxx)
-target_link_libraries(PiConstant ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS PiConstant
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME PiConstantTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/PiConstant)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Core/Common/ProduceImageProgrammatically/CMakeLists.txt
+++ b/src/Core/Common/ProduceImageProgrammatically/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ProduceImageProgrammatically Code.cxx)
-target_link_libraries(ProduceImageProgrammatically ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ProduceImageProgrammatically
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ProduceImageProgrammaticallyTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ProduceImageProgrammatically)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Core/Common/RandomSelectOfPixelsFromRegion/CMakeLists.txt
+++ b/src/Core/Common/RandomSelectOfPixelsFromRegion/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(RandomSelectOfPixelsFromRegion Code.cxx)
-target_link_libraries(RandomSelectOfPixelsFromRegion ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS RandomSelectOfPixelsFromRegion
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME RandomSelectOfPixelsFromRegionTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/RandomSelectOfPixelsFromRegion)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/RandomSelectPixelFromRegionWithoutReplacee/CMakeLists.txt
+++ b/src/Core/Common/RandomSelectPixelFromRegionWithoutReplacee/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(RandomSelectPixelFromRegionWithoutReplacee Code.cxx)
-target_link_libraries(RandomSelectPixelFromRegionWithoutReplacee ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS RandomSelectPixelFromRegionWithoutReplacee
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME RandomSelectPixelFromRegionWithoutReplaceeTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/RandomSelectPixelFromRegionWithoutReplacee)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/ReRunPipelineWithChangingLargestPossibleRegion/CMakeLists.txt
+++ b/src/Core/Common/ReRunPipelineWithChangingLargestPossibleRegion/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ReRunPipelineWithChangingLargestPossibleRegion)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ReRunPipelineWithChangingLargestPossibleRegion Code.cxx)
-target_link_libraries(ReRunPipelineWithChangingLargestPossibleRegion ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ReRunPipelineWithChangingLargestPossibleRegion
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -20,6 +20,6 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ReRunPipelineWithChangingLargestPossibleRegionTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ReRunPipelineWithChangingLargestPossibleRegion
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     "mri3D_%d.mha" 0 2
   )

--- a/src/Core/Common/ReadAPointSet/CMakeLists.txt
+++ b/src/Core/Common/ReadAPointSet/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ReadAPointSet)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ReadAPointSet Code.cxx)
-target_link_libraries(ReadAPointSet ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ReadAPointSet
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,5 +20,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ReadAPointSetTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ReadAPointSet
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
 )

--- a/src/Core/Common/ReadWriteVectorImage/CMakeLists.txt
+++ b/src/Core/Common/ReadWriteVectorImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ReadWriteVectorImage Code.cxx)
-target_link_libraries(ReadWriteVectorImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ReadWriteVectorImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -25,7 +25,7 @@ set(input_image ${CMAKE_CURRENT_BINARY_DIR}/mini-vector-fast.nrrd)
 set(output_image Output.nrrd)
 
 add_test(NAME ReadWriteVectorImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ReadWriteVectorImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
     ${output_image}
   )

--- a/src/Core/Common/ReturnObjectFromFunction/CMakeLists.txt
+++ b/src/Core/Common/ReturnObjectFromFunction/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ReturnObjectFromFunction Code.cxx)
-target_link_libraries(ReturnObjectFromFunction ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ReturnObjectFromFunction
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ReturnObjectFromFunctionTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ReturnObjectFromFunction)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Core/Common/SetDefaultNumberOfThreads/CMakeLists.txt
+++ b/src/Core/Common/SetDefaultNumberOfThreads/CMakeLists.txt
@@ -5,10 +5,10 @@ project(SetDefaultNumberOfThreads)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(SetDefaultNumberOfThreads Code.cxx)
-target_link_libraries(SetDefaultNumberOfThreads ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS SetDefaultNumberOfThreads
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -23,7 +23,7 @@ enable_testing()
 set(test_options 3)
 
 add_test(NAME SetDefaultNumberOfThreadsTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SetDefaultNumberOfThreads
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   ${test_options}
 )
 

--- a/src/Core/Common/SetPixelValueInOneImage/CMakeLists.txt
+++ b/src/Core/Common/SetPixelValueInOneImage/CMakeLists.txt
@@ -5,10 +5,10 @@ project(SetPixelValueInOneImage)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(SetPixelValueInOneImage Code.cxx)
-target_link_libraries(SetPixelValueInOneImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS SetPixelValueInOneImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME SetPixelValueInOneImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SetPixelValueInOneImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   ${CMAKE_CURRENT_BINARY_DIR}/Output.png
 )
 

--- a/src/Core/Common/SortITKIndex/CMakeLists.txt
+++ b/src/Core/Common/SortITKIndex/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(SortITKIndex Code.cxx)
-target_link_libraries(SortITKIndex ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS SortITKIndex
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME SortITKIndexTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SortITKIndex)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Core/Common/StoreNonPixelDataInImage/CMakeLists.txt
+++ b/src/Core/Common/StoreNonPixelDataInImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(StoreNonPixelDataInImage Code.cxx)
-target_link_libraries(StoreNonPixelDataInImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS StoreNonPixelDataInImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME StoreNonPixelDataInImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/StoreNonPixelDataInImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/StreamAPipeline/CMakeLists.txt
+++ b/src/Core/Common/StreamAPipeline/CMakeLists.txt
@@ -5,10 +5,10 @@ project(StreamAPipeline)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(StreamAPipeline Code.cxx)
-target_link_libraries(StreamAPipeline ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS StreamAPipeline
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -20,7 +20,7 @@ install(FILES Code.cxx Code.py CMakeLists.txt
 
 enable_testing()
 add_test(NAME StreamAPipelineTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/StreamAPipeline
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     3
   )
 

--- a/src/Core/Common/ThrowException/CMakeLists.txt
+++ b/src/Core/Common/ThrowException/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ThrowException Code.cxx)
-target_link_libraries(ThrowException ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ThrowException
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ThrowExceptionTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ThrowException)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/TraceMemoryBetweenPoints/CMakeLists.txt
+++ b/src/Core/Common/TraceMemoryBetweenPoints/CMakeLists.txt
@@ -5,10 +5,10 @@ project(TraceMemoryBetweenPoints)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(TraceMemoryBetweenPoints Code.cxx)
-target_link_libraries(TraceMemoryBetweenPoints ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS TraceMemoryBetweenPoints
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -20,4 +20,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME TraceMemoryBetweenPointsTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/TraceMemoryBetweenPoints 2048000)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME} 2048000)

--- a/src/Core/Common/TryCatchException/CMakeLists.txt
+++ b/src/Core/Common/TryCatchException/CMakeLists.txt
@@ -5,10 +5,10 @@ project(TryCatchException)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(TryCatchException Code.cxx)
-target_link_libraries(TryCatchException ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS TryCatchException
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,4 +20,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME TryCatchExceptionTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/TryCatchException)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/UseParallelizeImageRegion/CMakeLists.txt
+++ b/src/Core/Common/UseParallelizeImageRegion/CMakeLists.txt
@@ -5,10 +5,10 @@ project(UseParallelizeImageRegion)
 find_package(ITK 5.0 REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(UseParallelizeImageRegion Code.cxx)
-target_link_libraries(UseParallelizeImageRegion ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS UseParallelizeImageRegion
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME UseParallelizeImageRegionTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/UseParallelizeImageRegion
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   ${CMAKE_CURRENT_BINARY_DIR}/CellsFluorescence1.png
   CellsFluorescence1Out.png
   )

--- a/src/Core/Common/VariableLengthVector/CMakeLists.txt
+++ b/src/Core/Common/VariableLengthVector/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(VariableLengthVector Code.cxx)
-target_link_libraries(VariableLengthVector ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS VariableLengthVector
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME VariableLengthVectorTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/VariableLengthVector
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   )

--- a/src/Core/Common/VectorDotProduct/CMakeLists.txt
+++ b/src/Core/Common/VectorDotProduct/CMakeLists.txt
@@ -5,10 +5,10 @@ project(VectorDotProduct)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(VectorDotProduct Code.cxx Code.py)
-target_link_libraries(VectorDotProduct ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx Code.py)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS VectorDotProduct
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx Code.py CMakeLists.txt
 
 enable_testing()
 add_test(NAME VectorDotProductTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/VectorDotProduct)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 
 if(ITK_WRAP_PYTHON)
   add_test(NAME VectorDotProductTestPython

--- a/src/Core/Common/WatchAFilter/CMakeLists.txt
+++ b/src/Core/Common/WatchAFilter/CMakeLists.txt
@@ -5,10 +5,10 @@ project(WatchAFilter)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(WatchAFilter Code.cxx)
-target_link_libraries(WatchAFilter ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS WatchAFilter
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,4 +20,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME WatchAFilterTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/WatchAFilter)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Common/WriteAPointSet/CMakeLists.txt
+++ b/src/Core/Common/WriteAPointSet/CMakeLists.txt
@@ -5,10 +5,10 @@ project(WriteAPointSet)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(WriteAPointSet Code.cxx)
-target_link_libraries(WriteAPointSet ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS WriteAPointSet
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
 )
@@ -20,5 +20,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME WriteAPointSetTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ReadAPointSet
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
 )

--- a/src/Core/ImageAdaptors/AddConstantToPixelsWithoutDuplicatingImage/CMakeLists.txt
+++ b/src/Core/ImageAdaptors/AddConstantToPixelsWithoutDuplicatingImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(AddConstantToPixelsWithoutDuplicatingImage Code.cxx)
-target_link_libraries(AddConstantToPixelsWithoutDuplicatingImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS AddConstantToPixelsWithoutDuplicatingImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/ImageAdaptors
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME AddConstantToPixelsWithoutDuplicatingImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/AddConstantToPixelsWithoutDuplicatingImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Core/ImageAdaptors/ExtractChannelOfImageWithMultipleComponents/CMakeLists.txt
+++ b/src/Core/ImageAdaptors/ExtractChannelOfImageWithMultipleComponents/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ExtractChannelOfImageWithMultipleComponents Code.cxx)
-target_link_libraries(ExtractChannelOfImageWithMultipleComponents ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ExtractChannelOfImageWithMultipleComponents
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/ImageAdaptors
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ExtractChannelOfImageWithMultipleComponentsTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ExtractChannelOfImageWithMultipleComponents)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Core/ImageAdaptors/PresentImageAfterOperation/CMakeLists.txt
+++ b/src/Core/ImageAdaptors/PresentImageAfterOperation/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(PresentImageAfterOperation Code.cxx)
-target_link_libraries(PresentImageAfterOperation ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS PresentImageAfterOperation
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/ImageAdaptors
   COMPONENT Runtime
   )
@@ -21,5 +21,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME PresentImageAfterOperationTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/PresentImageAfterOperation)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Core/ImageAdaptors/ProcessNthComponentOfVectorImage/CMakeLists.txt
+++ b/src/Core/ImageAdaptors/ProcessNthComponentOfVectorImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ProcessNthComponentOfVectorImage Code.cxx)
-target_link_libraries(ProcessNthComponentOfVectorImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ProcessNthComponentOfVectorImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/ImageAdaptors
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ProcessNthComponentOfVectorImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ProcessNthComponentOfVectorImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/ImageAdaptors/ViewComponentVectorImageAsScaleImage/CMakeLists.txt
+++ b/src/Core/ImageAdaptors/ViewComponentVectorImageAsScaleImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ViewComponentVectorImageAsScaleImage Code.cxx)
-target_link_libraries(ViewComponentVectorImageAsScaleImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ViewComponentVectorImageAsScaleImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/ImageAdaptors
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ViewComponentVectorImageAsScaleImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ViewComponentVectorImageAsScaleImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Core/ImageFunction/ComputeMedianOfImageAtPixel/CMakeLists.txt
+++ b/src/Core/ImageFunction/ComputeMedianOfImageAtPixel/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ComputeMedianOfImageAtPixel Code.cxx)
-target_link_libraries(ComputeMedianOfImageAtPixel ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ComputeMedianOfImageAtPixel
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/ImageFunction
   COMPONENT Runtime
   )
@@ -22,6 +22,6 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ComputeMedianOfImageAtPixelTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ComputeMedianOfImageAtPixel
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
 
   )

--- a/src/Core/ImageFunction/LinearlyInterpolatePositionInImage/CMakeLists.txt
+++ b/src/Core/ImageFunction/LinearlyInterpolatePositionInImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(LinearlyInterpolatePositionInImage Code.cxx)
-target_link_libraries(LinearlyInterpolatePositionInImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS LinearlyInterpolatePositionInImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/ImageFunction
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME LinearlyInterpolatePositionInImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/LinearlyInterpolatePositionInImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/ImageFunction/MultiplyKernelWithAnImageAtLocation/CMakeLists.txt
+++ b/src/Core/ImageFunction/MultiplyKernelWithAnImageAtLocation/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(MultiplyKernelWithAnImageAtLocation Code.cxx)
-target_link_libraries(MultiplyKernelWithAnImageAtLocation ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS MultiplyKernelWithAnImageAtLocation
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/ImageFunction
   COMPONENT Runtime
   )
@@ -22,6 +22,6 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME MultiplyKernelWithAnImageAtLocationTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MultiplyKernelWithAnImageAtLocation
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   )
 

--- a/src/Core/ImageFunction/ResampleSegmentedImage/CMakeLists.txt
+++ b/src/Core/ImageFunction/ResampleSegmentedImage/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ResampleSegmentedImage)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ResampleSegmentedImage Code.cxx)
-target_link_libraries(ResampleSegmentedImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ResampleSegmentedImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/ImageFunction
   COMPONENT Runtime
   )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt Code.py
 
 enable_testing()
 add_test(NAME ResampleSegmentedImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ResampleSegmentedImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   ${CMAKE_CURRENT_BINARY_DIR}/2th_cthead1.png
   0.75
   0.6

--- a/src/Core/Mesh/AccessDataInCells/CMakeLists.txt
+++ b/src/Core/Mesh/AccessDataInCells/CMakeLists.txt
@@ -5,10 +5,10 @@ project(AccessDataInCells)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(AccessDataInCells Code.cxx)
-target_link_libraries(AccessDataInCells ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS AccessDataInCells
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Mesh
   COMPONENT Runtime
   )
@@ -21,7 +21,7 @@ install(FILES Code.cxx CMakeLists.txt Code.py
 enable_testing()
 
 add_test(NAME AccessDataInCellsTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/AccessDataInCells)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 
 if(ITK_WRAP_PYTHON)
   add_test(NAME AccessDataInCellsTestPython

--- a/src/Core/Mesh/AddPointsAndEdges/CMakeLists.txt
+++ b/src/Core/Mesh/AddPointsAndEdges/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(AddPointsAndEdges Code.cxx)
-target_link_libraries(AddPointsAndEdges ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS AddPointsAndEdges
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Mesh
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME AddPointsAndEdgesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/AddPointsAndEdges)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Mesh/CalculateAreaAndVolumeOfSimplexMesh/CMakeLists.txt
+++ b/src/Core/Mesh/CalculateAreaAndVolumeOfSimplexMesh/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(CalculateAreaAndVolumeOfSimplexMesh Code.cxx)
-target_link_libraries(CalculateAreaAndVolumeOfSimplexMesh ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CalculateAreaAndVolumeOfSimplexMesh
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Mesh
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CalculateAreaAndVolumeOfSimplexMeshTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CalculateAreaAndVolumeOfSimplexMesh)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Core/Mesh/ConvertMeshToUnstructeredGrid/CMakeLists.txt
+++ b/src/Core/Mesh/ConvertMeshToUnstructeredGrid/CMakeLists.txt
@@ -20,8 +20,8 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
   include(${VTK_USE_FILE})
 endif()
 
-add_executable(ConvertMeshToUnstructeredGrid Code.cxx)
-target_link_libraries(ConvertMeshToUnstructeredGrid ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(
@@ -30,7 +30,7 @@ if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     )
 endif()
 
-install(TARGETS ConvertMeshToUnstructeredGrid
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Mesh
   COMPONENT Runtime
   )
@@ -43,5 +43,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ConvertMeshToUnstructeredGridTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ConvertMeshToUnstructeredGrid)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Core/Mesh/ConvertTriangleMeshToBinaryImage/CMakeLists.txt
+++ b/src/Core/Mesh/ConvertTriangleMeshToBinaryImage/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ConvertTriangleMeshToBinaryImage)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ConvertTriangleMeshToBinaryImage Code.cxx)
-target_link_libraries(ConvertTriangleMeshToBinaryImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ConvertTriangleMeshToBinaryImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Mesh
   COMPONENT Runtime
   )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ConvertTriangleMeshToBinaryImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ConvertTriangleMeshToBinaryImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/HeadMRVolume.mha
     ${CMAKE_CURRENT_BINARY_DIR}/torus.vtk
     ${CMAKE_CURRENT_BINARY_DIR}/Output.mha

--- a/src/Core/Mesh/ExtractIsoSurface/CMakeLists.txt
+++ b/src/Core/Mesh/ExtractIsoSurface/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ExtractIsoSurface)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ExtractIsoSurface Code.cxx)
-target_link_libraries(ExtractIsoSurface ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ExtractIsoSurface
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Mesh
   COMPONENT Runtime
   )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ExtractIsoSurfaceTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ExtractIsoSurface
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/HeadMRVolume.mha
     ${CMAKE_CURRENT_BINARY_DIR}/Output.vtk
     64

--- a/src/Core/Mesh/TranslateOneMesh/CMakeLists.txt
+++ b/src/Core/Mesh/TranslateOneMesh/CMakeLists.txt
@@ -5,10 +5,10 @@ project(TranslateOneMesh)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(TranslateOneMesh Code.cxx)
-target_link_libraries(TranslateOneMesh ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS TranslateOneMesh
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Mesh
   COMPONENT Runtime
   )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME TranslateOneMeshTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/TranslateOneMesh
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/genusZeroSurface01.vtk
     ${CMAKE_CURRENT_BINARY_DIR}/Output.vtk
 

--- a/src/Core/Mesh/WorkingWithPointAndCellData/CMakeLists.txt
+++ b/src/Core/Mesh/WorkingWithPointAndCellData/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(WorkingWithPointAndCellData Code.cxx)
-target_link_libraries(WorkingWithPointAndCellData ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS WorkingWithPointAndCellData
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Mesh
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME WorkingWithPointAndCellDataTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/WorkingWithPointAndCellData)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Core/Mesh/WriteMeshToVTP/CMakeLists.txt
+++ b/src/Core/Mesh/WriteMeshToVTP/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(WriteMeshToVTP Code.cxx)
-target_link_libraries(WriteMeshToVTP ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS WriteMeshToVTP
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Mesh
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME WriteMeshToVTPTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/WriteMeshToVTP)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/QuadEdgeMesh/CreateTriangularQuadEdgeMesh/CMakeLists.txt
+++ b/src/Core/QuadEdgeMesh/CreateTriangularQuadEdgeMesh/CMakeLists.txt
@@ -5,10 +5,10 @@ project(CreateTriangularQuadEdgeMesh)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(CreateTriangularQuadEdgeMesh Code.cxx)
-target_link_libraries(CreateTriangularQuadEdgeMesh ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateTriangularQuadEdgeMesh
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/QuadEdgeMesh
   COMPONENT Runtime
   )
@@ -20,6 +20,6 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CreateTriangularQuadEdgeMeshTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateTriangularQuadEdgeMesh
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     Output.vtk
   )

--- a/src/Core/QuadEdgeMesh/CutMesh/CMakeLists.txt
+++ b/src/Core/QuadEdgeMesh/CutMesh/CMakeLists.txt
@@ -5,10 +5,10 @@ project(CutMesh)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(CutMesh Code.cxx)
-target_link_libraries(CutMesh ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CutMesh
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/QuadEdgeMesh
   COMPONENT Runtime
   )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CutMeshTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CutMesh
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/genusZeroSurface01.vtk
     CutMeshTestOutput.vtk
 )

--- a/src/Core/QuadEdgeMesh/ExtractVertexOnMeshBoundaries/CMakeLists.txt
+++ b/src/Core/QuadEdgeMesh/ExtractVertexOnMeshBoundaries/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ExtractVertexOnMeshBoundaries)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ExtractVertexOnMeshBoundaries Code.cxx)
-target_link_libraries(ExtractVertexOnMeshBoundaries ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ExtractVertexOnMeshBoundaries
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/QuadEdgeMesh
   COMPONENT Runtime
   )
@@ -20,6 +20,6 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ExtractVertexOnMeshBoundariesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ExtractVertexOnMeshBoundaries
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/wave.vtk
 )

--- a/src/Core/QuadEdgeMesh/GetListOfFacesAroundAGivenVertex/CMakeLists.txt
+++ b/src/Core/QuadEdgeMesh/GetListOfFacesAroundAGivenVertex/CMakeLists.txt
@@ -5,10 +5,10 @@ project(GetListOfFacesAroundAGivenVertex)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(GetListOfFacesAroundAGivenVertex Code.cxx)
-target_link_libraries(GetListOfFacesAroundAGivenVertex ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS GetListOfFacesAroundAGivenVertex
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/QuadEdgeMesh
   COMPONENT Runtime
   )
@@ -20,4 +20,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME GetListOfFacesAroundAGivenVertexTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/GetListOfFacesAroundAGivenVertex ${CMAKE_CURRENT_BINARY_DIR}/genusZeroSurface01.vtk 0)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR}/genusZeroSurface01.vtk 0)

--- a/src/Core/QuadEdgeMesh/PrintVertexNeighbors/CMakeLists.txt
+++ b/src/Core/QuadEdgeMesh/PrintVertexNeighbors/CMakeLists.txt
@@ -5,10 +5,10 @@ project(PrintVertexNeighbors)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(PrintVertexNeighbors Code.cxx)
-target_link_libraries(PrintVertexNeighbors ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS PrintVertexNeighbors
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/QuadEdgeMesh
   COMPONENT Runtime
   )
@@ -20,4 +20,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME PrintVertexNeighborsTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/PrintVertexNeighbors ${CMAKE_CURRENT_BINARY_DIR}/wave.vtk 50)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR}/wave.vtk 50)

--- a/src/Core/SpatialObjects/Blob/CMakeLists.txt
+++ b/src/Core/SpatialObjects/Blob/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(Blob Code.cxx)
-target_link_libraries(Blob ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS Blob
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/SpatialObjects
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME BlobTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Blob)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/SpatialObjects/ContourSpatialObject/CMakeLists.txt
+++ b/src/Core/SpatialObjects/ContourSpatialObject/CMakeLists.txt
@@ -15,8 +15,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(ContourSpatialObject Code.cxx)
-  target_link_libraries(ContourSpatialObject ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -25,11 +25,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(ContourSpatialObject Code.cxx)
-  target_link_libraries(ContourSpatialObject ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS ContourSpatialObject
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/SpatialObjects
   COMPONENT Runtime
   )
@@ -42,4 +42,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ContourSpatialObjectTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ContourSpatialObject)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/SpatialObjects/ConvertSpatialObjectToImage/CMakeLists.txt
+++ b/src/Core/SpatialObjects/ConvertSpatialObjectToImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ConvertSpatialObjectToImage Code.cxx)
-target_link_libraries(ConvertSpatialObjectToImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ConvertSpatialObjectToImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/SpatialObjects
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ConvertSpatialObjectToImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ConvertSpatialObjectToImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     output.png)

--- a/src/Core/SpatialObjects/CreateALineSpatialObject/CMakeLists.txt
+++ b/src/Core/SpatialObjects/CreateALineSpatialObject/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(CreateALineSpatialObject Code.cxx)
-target_link_libraries(CreateALineSpatialObject ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateALineSpatialObject
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/SpatialObjects
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CreateALineSpatialObjectTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateALineSpatialObject)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Core/SpatialObjects/Ellipse/CMakeLists.txt
+++ b/src/Core/SpatialObjects/Ellipse/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(Ellipse Code.cxx)
-target_link_libraries(Ellipse ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS Ellipse
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/SpatialObjects
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME EllipseTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Ellipse
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     output.png)

--- a/src/Core/TestKernel/GenerateRandomImage/CMakeLists.txt
+++ b/src/Core/TestKernel/GenerateRandomImage/CMakeLists.txt
@@ -5,10 +5,10 @@ project(GenerateRandomImage)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(GenerateRandomImage Code.cxx)
-target_link_libraries(GenerateRandomImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS GenerateRandomImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/TestKernel
   COMPONENT Runtime
 )
@@ -20,6 +20,6 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME GenerateRandomImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/GenerateRandomImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/Output.png
   )

--- a/src/Core/Transform/ApplyAffineTransformFromHomogeneousMatrixAndResample/CMakeLists.txt
+++ b/src/Core/Transform/ApplyAffineTransformFromHomogeneousMatrixAndResample/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ApplyAffineTransformFromHomogeneousMatrixAndResample)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ApplyAffineTransformFromHomogeneousMatrixAndResample Code.cxx)
-target_link_libraries(ApplyAffineTransformFromHomogeneousMatrixAndResample ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ApplyAffineTransformFromHomogeneousMatrixAndResample
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Transform
   COMPONENT Runtime
   )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ApplyAffineTransformFromHomogeneousMatrixAndResampleTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ApplyAffineTransformFromHomogeneousMatrixAndResample
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/Gourds.png
     Output.png
     0

--- a/src/Core/Transform/CartesianToAzimuthElevation/CMakeLists.txt
+++ b/src/Core/Transform/CartesianToAzimuthElevation/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(CartesianToAzimuthElevation Code.cxx)
-target_link_libraries(CartesianToAzimuthElevation ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CartesianToAzimuthElevation
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Transform
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CartesianToAzimuthElevationTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CartesianToAzimuthElevation)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Core/Transform/CopyACompositeTransform/CMakeLists.txt
+++ b/src/Core/Transform/CopyACompositeTransform/CMakeLists.txt
@@ -5,10 +5,10 @@ project(CopyACompositeTransform)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(CopyACompositeTransform Code.cxx)
-target_link_libraries(CopyACompositeTransform ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CopyACompositeTransform
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Transform
   COMPONENT Runtime
   )
@@ -20,4 +20,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CopyACompositeTransformTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CopyACompositeTransform)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Transform/CopyANonCompositeTransform/CMakeLists.txt
+++ b/src/Core/Transform/CopyANonCompositeTransform/CMakeLists.txt
@@ -5,10 +5,10 @@ project(CopyANonCompositeTransform)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(CopyANonCompositeTransform Code.cxx)
-target_link_libraries(CopyANonCompositeTransform ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CopyANonCompositeTransform
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Transform
   COMPONENT Runtime
   )
@@ -20,4 +20,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CopyANonCompositeTransformTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CopyANonCompositeTransform)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Transform/GlobalRegistrationTwoImagesAffine/CMakeLists.txt
+++ b/src/Core/Transform/GlobalRegistrationTwoImagesAffine/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(GlobalRegistrationTwoImagesAffine Code.cxx)
-target_link_libraries(GlobalRegistrationTwoImagesAffine ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS GlobalRegistrationTwoImagesAffine
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Transform
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME GlobalRegistrationTwoImagesAffineTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/GlobalRegistrationTwoImagesAffine)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Transform/GlobalRegistrationTwoImagesBSpline/CMakeLists.txt
+++ b/src/Core/Transform/GlobalRegistrationTwoImagesBSpline/CMakeLists.txt
@@ -15,8 +15,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(GlobalRegistrationTwoImagesBSpline Code.cxx)
-  target_link_libraries(GlobalRegistrationTwoImagesBSpline ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -25,11 +25,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(GlobalRegistrationTwoImagesBSpline Code.cxx)
-  target_link_libraries(GlobalRegistrationTwoImagesBSpline ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS GlobalRegistrationTwoImagesBSpline
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Transform
   COMPONENT Runtime
   )
@@ -42,4 +42,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME GlobalRegistrationTwoImagesBSplineTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/GlobalRegistrationTwoImagesBSpline)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Core/Transform/MutualInformationAffine/CMakeLists.txt
+++ b/src/Core/Transform/MutualInformationAffine/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(MutualInformationAffine Code.cxx)
-target_link_libraries(MutualInformationAffine ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS MutualInformationAffine
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Transform
   COMPONENT Runtime
   )
@@ -22,7 +22,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME MutualInformationAffineTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MutualInformationAffine
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   fixed.png
   moving.png
   Output.png)

--- a/src/Core/Transform/ScaleAnImage/CMakeLists.txt
+++ b/src/Core/Transform/ScaleAnImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ScaleAnImage Code.cxx)
-target_link_libraries(ScaleAnImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ScaleAnImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Transform
   COMPONENT Runtime
   )
@@ -23,7 +23,7 @@ install(FILES Code.cxx Code.py CMakeLists.txt
 enable_testing()
 
 add_test(NAME ScaleAnImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ScaleAnImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/ScaleAnImageInput.png
     ${CMAKE_CURRENT_BINARY_DIR}/ScaleAnImageOutput.png
   )

--- a/src/Core/Transform/TranslateAVectorImage/CMakeLists.txt
+++ b/src/Core/Transform/TranslateAVectorImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(TranslateAVectorImage Code.cxx)
-target_link_libraries(TranslateAVectorImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS TranslateAVectorImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Transform
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME TranslateAVectorImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/TranslateAVectorImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Core/Transform/TranslateImage/CMakeLists.txt
+++ b/src/Core/Transform/TranslateImage/CMakeLists.txt
@@ -5,10 +5,10 @@ project(TranslateImage)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(TranslateImage Code.cxx)
-target_link_libraries(TranslateImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS TranslateImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Transform
   COMPONENT Runtime
   )
@@ -20,4 +20,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME TranslateImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/TranslateImage ${CMAKE_CURRENT_BINARY_DIR}/Gourds.png Output.png 25. 50.)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME} ${CMAKE_CURRENT_BINARY_DIR}/Gourds.png Output.png 25. 50.)

--- a/src/Filtering/AnisotropicSmoothing/ComputeCurvatureAnisotropicDiffusion/CMakeLists.txt
+++ b/src/Filtering/AnisotropicSmoothing/ComputeCurvatureAnisotropicDiffusion/CMakeLists.txt
@@ -9,10 +9,10 @@ project(ComputeCurvatureAnisotropicDiffusion)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ComputeCurvatureAnisotropicDiffusion Code.cxx)
-target_link_libraries(ComputeCurvatureAnisotropicDiffusion ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ComputeCurvatureAnisotropicDiffusion
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/AnisotropicSmoothing
   COMPONENT Runtime
   )
@@ -24,7 +24,7 @@ install(FILES Code.cxx CMakeLists.txt Code.py
 
 enable_testing()
 add_test(NAME ComputeCurvatureAnisotropicDiffusionTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ComputeCurvatureAnisotropicDiffusion
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   ${input_image}
   ${output_image}
   ${test_options}

--- a/src/Filtering/AnisotropicSmoothing/ComputeCurvatureFlow/CMakeLists.txt
+++ b/src/Filtering/AnisotropicSmoothing/ComputeCurvatureFlow/CMakeLists.txt
@@ -9,10 +9,10 @@ project(ComputeCurvatureFlow)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ComputeCurvatureFlow Code.cxx)
-target_link_libraries(ComputeCurvatureFlow ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ComputeCurvatureFlow
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/AnisotropicSmoothing
   COMPONENT Runtime
   )
@@ -24,7 +24,7 @@ install(FILES Code.cxx CMakeLists.txt Code.py
 
 enable_testing()
 add_test(NAME ComputeCurvatureFlowTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ComputeCurvatureFlow
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   ${input_image}
   ${output_image}
   ${test_options}

--- a/src/Filtering/AnisotropicSmoothing/ComputeGradientAnisotropicDiffusion/CMakeLists.txt
+++ b/src/Filtering/AnisotropicSmoothing/ComputeGradientAnisotropicDiffusion/CMakeLists.txt
@@ -9,10 +9,10 @@ project(ComputeGradientAnisotropicDiffusion)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ComputeGradientAnisotropicDiffusion Code.cxx)
-target_link_libraries(ComputeGradientAnisotropicDiffusion ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ComputeGradientAnisotropicDiffusion
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/AnisotropicSmoothing
   COMPONENT Runtime
   )
@@ -24,7 +24,7 @@ install(FILES Code.cxx CMakeLists.txt Code.py
 
 enable_testing()
 add_test(NAME ComputeGradientAnisotropicDiffusionTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ComputeGradientAnisotropicDiffusion
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   ${input_image}
   ${output_image}
   ${test_options}

--- a/src/Filtering/AnisotropicSmoothing/ComputePeronaMalikAnisotropicDiffusion/CMakeLists.txt
+++ b/src/Filtering/AnisotropicSmoothing/ComputePeronaMalikAnisotropicDiffusion/CMakeLists.txt
@@ -16,10 +16,10 @@ find_package(ITK REQUIRED
   )
 include(${ITK_USE_FILE})
 
-add_executable(ComputePeronaMalikAnisotropicDiffusion Code.cxx)
-target_link_libraries(ComputePeronaMalikAnisotropicDiffusion ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ComputePeronaMalikAnisotropicDiffusion
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/AnisotropicSmoothing
   COMPONENT Runtime
 )
@@ -32,7 +32,7 @@ install(FILES Code.cxx CMakeLists.txt Code.py
 enable_testing()
 
 add_test(NAME ComputePeronaMalikAnisotropicDiffusionTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ComputePeronaMalikAnisotropicDiffusion
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   ${input_image}
   ${output_image}
   ${test_options}

--- a/src/Filtering/AnisotropicSmoothing/SmoothImageWhilePreservingEdges/CMakeLists.txt
+++ b/src/Filtering/AnisotropicSmoothing/SmoothImageWhilePreservingEdges/CMakeLists.txt
@@ -15,8 +15,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(SmoothImageWhilePreservingEdges Code.cxx)
-  target_link_libraries(SmoothImageWhilePreservingEdges ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -25,11 +25,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(SmoothImageWhilePreservingEdges Code.cxx)
-  target_link_libraries(SmoothImageWhilePreservingEdges ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS SmoothImageWhilePreservingEdges
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/AnisotropicSmoothing
   COMPONENT Runtime
   )
@@ -42,7 +42,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME SmoothImageWhilePreservingEdgesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SmoothImageWhilePreservingEdges
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     Yinyang.png
     4
     8)

--- a/src/Filtering/AnisotropicSmoothing/SmoothImageWhilePreservingEdges2/CMakeLists.txt
+++ b/src/Filtering/AnisotropicSmoothing/SmoothImageWhilePreservingEdges2/CMakeLists.txt
@@ -15,8 +15,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(SmoothImageWhilePreservingEdges2 Code.cxx)
-  target_link_libraries(SmoothImageWhilePreservingEdges2 ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -25,11 +25,11 @@ if(ENABLE_QUICKVIEW)
     )
   endif()
 else()
-  add_executable(SmoothImageWhilePreservingEdges2 Code.cxx)
-  target_link_libraries(SmoothImageWhilePreservingEdges2 ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS SmoothImageWhilePreservingEdges2
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/AnisotropicSmoothing
   COMPONENT Runtime
   )
@@ -42,7 +42,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME SmoothImageWhilePreservingEdges2Test
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SmoothImageWhilePreservingEdges2
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     Yinyang.png
     10
     30)

--- a/src/Filtering/AntiAlias/SmoothBinaryImageBeforeSurfaceExtraction/CMakeLists.txt
+++ b/src/Filtering/AntiAlias/SmoothBinaryImageBeforeSurfaceExtraction/CMakeLists.txt
@@ -9,10 +9,10 @@ project(SmoothBinaryImageBeforeSurfaceExtraction)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(SmoothBinaryImageBeforeSurfaceExtraction Code.cxx)
-target_link_libraries(SmoothBinaryImageBeforeSurfaceExtraction ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS SmoothBinaryImageBeforeSurfaceExtraction
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/AntiAlias
   COMPONENT Runtime
 )
@@ -24,7 +24,7 @@ install(FILES Code.cxx CMakeLists.txt Code.py
 
 enable_testing()
 add_test(NAME SmoothBinaryImageBeforeSurfaceExtractionTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SmoothBinaryImageBeforeSurfaceExtraction
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   ${input_image}
   ${output_image}
   ${test_options}

--- a/src/Filtering/BinaryMathematicalMorphology/ClosingBinaryImage/CMakeLists.txt
+++ b/src/Filtering/BinaryMathematicalMorphology/ClosingBinaryImage/CMakeLists.txt
@@ -15,8 +15,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(ClosingBinaryImage Code.cxx)
-  target_link_libraries(ClosingBinaryImage ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -25,11 +25,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(ClosingBinaryImage Code.cxx)
-  target_link_libraries(ClosingBinaryImage ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS ClosingBinaryImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/BinaryMathematicalMorphology
   COMPONENT Runtime
   )
@@ -42,5 +42,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ClosingBinaryImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ClosingBinaryImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/BinaryMathematicalMorphology/DilateABinaryImage/CMakeLists.txt
+++ b/src/Filtering/BinaryMathematicalMorphology/DilateABinaryImage/CMakeLists.txt
@@ -13,11 +13,11 @@ find_package(ITK REQUIRED
 include(${ITK_USE_FILE})
 
 
-add_executable(DilateABinaryImage Code.cxx)
-target_link_libraries(DilateABinaryImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
 
-install(TARGETS DilateABinaryImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/BinaryMathematicalMorphology/
   COMPONENT Runtime
   )
@@ -34,7 +34,7 @@ set(output_image Output.png)
 set(test_options 3)
 
 add_test(NAME DilateABinaryImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/DilateABinaryImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   ${input_image}
   ${output_image}
   ${test_options}

--- a/src/Filtering/BinaryMathematicalMorphology/ErodeABinaryImage/CMakeLists.txt
+++ b/src/Filtering/BinaryMathematicalMorphology/ErodeABinaryImage/CMakeLists.txt
@@ -16,10 +16,10 @@ find_package(ITK REQUIRED
   )
 include(${ITK_USE_FILE})
 
-add_executable(ErodeABinaryImage Code.cxx)
-target_link_libraries(ErodeABinaryImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ErodeABinaryImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/BinaryMathematicalMorphology/
   COMPONENT Runtime
 )
@@ -32,7 +32,7 @@ install(FILES Code.cxx CMakeLists.txt Code.py
 enable_testing()
 
 add_test(NAME ErodeABinaryImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ErodeABinaryImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   ${input_image}
   ${output_image}
   ${test_options}

--- a/src/Filtering/BinaryMathematicalMorphology/OpeningBinaryImage/CMakeLists.txt
+++ b/src/Filtering/BinaryMathematicalMorphology/OpeningBinaryImage/CMakeLists.txt
@@ -16,8 +16,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(OpeningBinaryImage Code.cxx)
-  target_link_libraries(OpeningBinaryImage ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -26,11 +26,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(OpeningBinaryImage Code.cxx)
-  target_link_libraries(OpeningBinaryImage ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS OpeningBinaryImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/BinaryMathematicalMorphology
   COMPONENT Runtime
   )
@@ -43,4 +43,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME OpeningBinaryImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/OpeningBinaryImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/BinaryMathematicalMorphology/PruneBinaryImage/CMakeLists.txt
+++ b/src/Filtering/BinaryMathematicalMorphology/PruneBinaryImage/CMakeLists.txt
@@ -15,8 +15,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(PruneBinaryImage Code.cxx)
-  target_link_libraries(PruneBinaryImage ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -25,11 +25,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(PruneBinaryImage Code.cxx)
-  target_link_libraries(PruneBinaryImage ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS PruneBinaryImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/BinaryMathematicalMorphology
   COMPONENT Runtime
   )
@@ -42,4 +42,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME PruneBinaryImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/PruneBinaryImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/BinaryMathematicalMorphology/ThinImage/CMakeLists.txt
+++ b/src/Filtering/BinaryMathematicalMorphology/ThinImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ThinImage Code.cxx)
-target_link_libraries(ThinImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ThinImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/BinaryMathematicalMorphology
   COMPONENT Runtime
   )
@@ -22,7 +22,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ThinImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ThinImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 
 if(ITK_WRAP_PYTHON)
 add_test(NAME ThinImageTestPython

--- a/src/Filtering/Colormap/ApplyAColormapToAnImage/CMakeLists.txt
+++ b/src/Filtering/Colormap/ApplyAColormapToAnImage/CMakeLists.txt
@@ -9,10 +9,10 @@ project(ApplyAColormapToAnImage)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ApplyAColormapToAnImage Code.cxx)
-target_link_libraries(ApplyAColormapToAnImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ApplyAColormapToAnImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Colormap
   COMPONENT Runtime
 )
@@ -24,7 +24,7 @@ install(FILES Code.cxx CMakeLists.txt Code.py
 
 enable_testing()
 add_test(NAME ApplyAColormapToAnImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ApplyAColormapToAnImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   ${input_image}
   ${output_image}
   ${test_options}

--- a/src/Filtering/Colormap/CreateACustomColormap/CMakeLists.txt
+++ b/src/Filtering/Colormap/CreateACustomColormap/CMakeLists.txt
@@ -9,10 +9,10 @@ project(CreateACustomColormap)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(CreateACustomColormap Code.cxx)
-target_link_libraries(CreateACustomColormap ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateACustomColormap
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Colormap
   COMPONENT Runtime
 )
@@ -24,7 +24,7 @@ install(FILES Code.cxx CMakeLists.txt Code.py
 
 enable_testing()
 add_test(NAME CreateACustomColormapTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateACustomColormap
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   ${input_image}
   ${output_image}
   ${test_options}

--- a/src/Filtering/Colormap/MapScalarsIntoJetColormap/CMakeLists.txt
+++ b/src/Filtering/Colormap/MapScalarsIntoJetColormap/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(MapScalarsIntoJetColormap Code.cxx)
-target_link_libraries(MapScalarsIntoJetColormap ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS MapScalarsIntoJetColormap
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Colormap
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME MapScalarsIntoJetColormapTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MapScalarsIntoJetColormap)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/Convolution/ColorNormalizedCorrelation/CMakeLists.txt
+++ b/src/Filtering/Convolution/ColorNormalizedCorrelation/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ColorNormalizedCorrelation Code.cxx)
-target_link_libraries(ColorNormalizedCorrelation ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ColorNormalizedCorrelation
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Convolution
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ColorNormalizedCorrelationTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ColorNormalizedCorrelation)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/Convolution/ConvolveImageWithKernel/CMakeLists.txt
+++ b/src/Filtering/Convolution/ConvolveImageWithKernel/CMakeLists.txt
@@ -16,8 +16,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(ConvolveImageWithKernel Code.cxx)
-  target_link_libraries(ConvolveImageWithKernel ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -26,11 +26,11 @@ if(ENABLE_QUICKVIEW)
     )
   endif()
 else()
-  add_executable(ConvolveImageWithKernel Code.cxx)
-  target_link_libraries(ConvolveImageWithKernel ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS ConvolveImageWithKernel
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Convolution
   COMPONENT Runtime
   )
@@ -43,6 +43,6 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ConvolveImageWithKernelTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ConvolveImageWithKernel
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     Yinyang.png
     10)

--- a/src/Filtering/Convolution/NormalizedCorrelation/CMakeLists.txt
+++ b/src/Filtering/Convolution/NormalizedCorrelation/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(NormalizedCorrelation Code.cxx)
-target_link_libraries(NormalizedCorrelation ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS NormalizedCorrelation
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Convolution
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME NormalizedCorrelationTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/NormalizedCorrelation)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/Convolution/NormalizedCorrelationOfMaskedImage/CMakeLists.txt
+++ b/src/Filtering/Convolution/NormalizedCorrelationOfMaskedImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(NormalizedCorrelationOfMaskedImage Code.cxx)
-target_link_libraries(NormalizedCorrelationOfMaskedImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS NormalizedCorrelationOfMaskedImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Convolution
   COMPONENT Runtime
   )
@@ -21,6 +21,6 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME NormalizedCorrelationOfMaskedImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/NormalizedCorrelationOfMaskedImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
 
   )

--- a/src/Filtering/Convolution/NormalizedCorrelationUsingFFT/CMakeLists.txt
+++ b/src/Filtering/Convolution/NormalizedCorrelationUsingFFT/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(NormalizedCorrelationUsingFFT Code.cxx)
-target_link_libraries(NormalizedCorrelationUsingFFT ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS NormalizedCorrelationUsingFFT
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Convolution
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME NormalizedCorrelationUsingFFTTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/NormalizedCorrelationUsingFFT)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/Convolution/NormalizedCorrelationUsingFFTWithMaskImages/CMakeLists.txt
+++ b/src/Filtering/Convolution/NormalizedCorrelationUsingFFTWithMaskImages/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(NormalizedCorrelationUsingFFTWithMaskImages Code.cxx)
-target_link_libraries(NormalizedCorrelationUsingFFTWithMaskImages ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS NormalizedCorrelationUsingFFTWithMaskImages
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Convolution
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME NormalizedCorrelationUsingFFTWithMaskImagesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/NormalizedCorrelationUsingFFTWithMaskImages)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/CurvatureFlow/BinaryMinMaxCurvatureFlow/CMakeLists.txt
+++ b/src/Filtering/CurvatureFlow/BinaryMinMaxCurvatureFlow/CMakeLists.txt
@@ -15,8 +15,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(BinaryMinMaxCurvatureFlow Code.cxx)
-  target_link_libraries(BinaryMinMaxCurvatureFlow ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -25,11 +25,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(BinaryMinMaxCurvatureFlow Code.cxx)
-  target_link_libraries(BinaryMinMaxCurvatureFlow ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS BinaryMinMaxCurvatureFlow
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/CurvatureFlow
   COMPONENT Runtime
   )
@@ -42,6 +42,6 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME BinaryMinMaxCurvatureFlowTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/BinaryMinMaxCurvatureFlow
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     Yinyang.png
     10)

--- a/src/Filtering/CurvatureFlow/SmoothImageUsingCurvatureFlow/CMakeLists.txt
+++ b/src/Filtering/CurvatureFlow/SmoothImageUsingCurvatureFlow/CMakeLists.txt
@@ -15,8 +15,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(SmoothImageUsingCurvatureFlow Code.cxx)
-  target_link_libraries(SmoothImageUsingCurvatureFlow ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -25,11 +25,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(SmoothImageUsingCurvatureFlow Code.cxx)
-  target_link_libraries(SmoothImageUsingCurvatureFlow ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS SmoothImageUsingCurvatureFlow
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/CurvatureFlow
   COMPONENT Runtime
   )
@@ -42,6 +42,6 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME SmoothImageUsingCurvatureFlowTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SmoothImageUsingCurvatureFlow
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     Yinyang.png
     10)

--- a/src/Filtering/CurvatureFlow/SmoothImageUsingMinMaxCurvatureFlow/CMakeLists.txt
+++ b/src/Filtering/CurvatureFlow/SmoothImageUsingMinMaxCurvatureFlow/CMakeLists.txt
@@ -15,8 +15,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(SmoothImageUsingMinMaxCurvatureFlow Code.cxx)
-  target_link_libraries(SmoothImageUsingMinMaxCurvatureFlow ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -25,11 +25,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(SmoothImageUsingMinMaxCurvatureFlow Code.cxx)
-  target_link_libraries(SmoothImageUsingMinMaxCurvatureFlow ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS SmoothImageUsingMinMaxCurvatureFlow
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/CurvatureFlow
   COMPONENT Runtime
   )
@@ -42,6 +42,6 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME SmoothImageUsingMinMaxCurvatureFlowTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SmoothImageUsingMinMaxCurvatureFlow
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
         Gourds.png
         5)

--- a/src/Filtering/CurvatureFlow/SmoothRGBImageUsingCurvatureFlow/CMakeLists.txt
+++ b/src/Filtering/CurvatureFlow/SmoothRGBImageUsingCurvatureFlow/CMakeLists.txt
@@ -15,8 +15,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(SmoothRGBImageUsingCurvatureFlow Code.cxx)
-  target_link_libraries(SmoothRGBImageUsingCurvatureFlow ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -25,11 +25,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(SmoothRGBImageUsingCurvatureFlow Code.cxx)
-  target_link_libraries(SmoothRGBImageUsingCurvatureFlow ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS SmoothRGBImageUsingCurvatureFlow
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/CurvatureFlow
   COMPONENT Runtime
   )
@@ -42,6 +42,6 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME SmoothRGBImageUsingCurvatureFlowTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SmoothRGBImageUsingCurvatureFlow
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     Gourds.png
     200)

--- a/src/Filtering/CurvatureFlow/SmoothRGBImageUsingMinMaxCurvatureFlow/CMakeLists.txt
+++ b/src/Filtering/CurvatureFlow/SmoothRGBImageUsingMinMaxCurvatureFlow/CMakeLists.txt
@@ -15,8 +15,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(SmoothRGBImageUsingMinMaxCurvatureFlow Code.cxx)
-  target_link_libraries(SmoothRGBImageUsingMinMaxCurvatureFlow ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -25,11 +25,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(SmoothRGBImageUsingMinMaxCurvatureFlow Code.cxx)
-  target_link_libraries(SmoothRGBImageUsingMinMaxCurvatureFlow ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS SmoothRGBImageUsingMinMaxCurvatureFlow
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/CurvatureFlow
   COMPONENT Runtime
   )
@@ -42,6 +42,6 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME SmoothRGBImageUsingMinMaxCurvatureFlowTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SmoothRGBImageUsingMinMaxCurvatureFlow
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
         Gourds.png
         50)

--- a/src/Filtering/DistanceMap/ApproxDistanceMapOfBinary/CMakeLists.txt
+++ b/src/Filtering/DistanceMap/ApproxDistanceMapOfBinary/CMakeLists.txt
@@ -15,8 +15,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(ApproxDistanceMapOfBinary Code.cxx)
-  target_link_libraries(ApproxDistanceMapOfBinary ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -25,11 +25,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(ApproxDistanceMapOfBinary Code.cxx)
-  target_link_libraries(ApproxDistanceMapOfBinary ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS ApproxDistanceMapOfBinary
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/DistanceMap
   COMPONENT Runtime
   )
@@ -42,4 +42,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ApproxDistanceMapOfBinaryTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ApproxDistanceMapOfBinary)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/DistanceMap/MaurerDistanceMapOfBinary/CMakeLists.txt
+++ b/src/Filtering/DistanceMap/MaurerDistanceMapOfBinary/CMakeLists.txt
@@ -17,8 +17,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(MaurerDistanceMapOfBinary Code.cxx)
-  target_link_libraries(MaurerDistanceMapOfBinary ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -27,11 +27,11 @@ if(ENABLE_QUICKVIEW)
       )
    endif()
 else()
-  add_executable(MaurerDistanceMapOfBinary Code.cxx)
-  target_link_libraries(MaurerDistanceMapOfBinary ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS MaurerDistanceMapOfBinary
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/DistanceMap
   COMPONENT Runtime
   )
@@ -44,5 +44,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME MaurerDistanceMapOfBinaryTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MaurerDistanceMapOfBinary)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/DistanceMap/MeanDistanceBetweenAllPointsOnTwoCurves/CMakeLists.txt
+++ b/src/Filtering/DistanceMap/MeanDistanceBetweenAllPointsOnTwoCurves/CMakeLists.txt
@@ -16,8 +16,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(MeanDistanceBetweenAllPointsOnTwoCurves Code.cxx)
-  target_link_libraries(MeanDistanceBetweenAllPointsOnTwoCurves ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -26,11 +26,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(MeanDistanceBetweenAllPointsOnTwoCurves Code.cxx)
-  target_link_libraries(MeanDistanceBetweenAllPointsOnTwoCurves ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS MeanDistanceBetweenAllPointsOnTwoCurves
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/DistanceMap
   COMPONENT Runtime
   )
@@ -43,4 +43,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME MeanDistanceBetweenAllPointsOnTwoCurvesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MeanDistanceBetweenAllPointsOnTwoCurves)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/DistanceMap/SignedDistanceMapOfBinary/CMakeLists.txt
+++ b/src/Filtering/DistanceMap/SignedDistanceMapOfBinary/CMakeLists.txt
@@ -17,8 +17,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(SignedDistanceMapOfBinary Code.cxx)
-  target_link_libraries(SignedDistanceMapOfBinary ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -27,11 +27,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(SignedDistanceMapOfBinary Code.cxx)
-  target_link_libraries(SignedDistanceMapOfBinary ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS SignedDistanceMapOfBinary
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/DistanceMap
   COMPONENT Runtime
   )
@@ -44,5 +44,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME SignedDistanceMapOfBinaryTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SignedDistanceMapOfBinary)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/FFT/ComputeForwardFFT/CMakeLists.txt
+++ b/src/Filtering/FFT/ComputeForwardFFT/CMakeLists.txt
@@ -5,11 +5,11 @@ project(ComputeForwardFFT)
 find_package(ITK REQUIRED)
 
 include(${ITK_USE_FILE})
-add_executable(ComputeForwardFFT
+add_executable(${PROJECT_NAME}
   Code.cxx)
-target_link_libraries(ComputeForwardFFT ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ComputeForwardFFT
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/FFT
   COMPONENT Runtime
   )
@@ -21,7 +21,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ComputeForwardFFTTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ComputeForwardFFT
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/HeadMRVolume.mha
     OutputReal.mha
     OutputComplex.mha

--- a/src/Filtering/FFT/ComputeImageSpectralDensity/CMakeLists.txt
+++ b/src/Filtering/FFT/ComputeImageSpectralDensity/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ComputeImageSpectralDensity)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ComputeImageSpectralDensity Code.cxx)
-target_link_libraries(ComputeImageSpectralDensity ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ComputeImageSpectralDensity
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
   )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ComputeImageSpectralDensityTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ComputeImageSpectralDensity
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/HeadMRVolume.mha
     Output.mha
   )

--- a/src/Filtering/FFT/ComputeInverseFFTOfImage/CMakeLists.txt
+++ b/src/Filtering/FFT/ComputeInverseFFTOfImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ComputeInverseFFTOfImage Code.cxx)
-target_link_libraries(ComputeInverseFFTOfImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ComputeInverseFFTOfImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/FFT
   COMPONENT Runtime
   )
@@ -22,7 +22,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ComputeInverseFFTOfImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ComputeInverseFFTOfImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 
 if(ITK_WRAP_PYTHON)
 add_test(NAME ComputeInverseFFTOfImageTestPython

--- a/src/Filtering/FFT/FilterImageInFourierDomain/CMakeLists.txt
+++ b/src/Filtering/FFT/FilterImageInFourierDomain/CMakeLists.txt
@@ -5,10 +5,10 @@ project(FilterImageInFourierDomain)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(FilterImageInFourierDomain Code.cxx)
-target_link_libraries(FilterImageInFourierDomain ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS FilterImageInFourierDomain
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/FFT
   COMPONENT Runtime
   )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME FilterImageInFourierDomainTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/FilterImageInFourierDomain
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/HeadMRVolume.mha
     Output.mha
   )

--- a/src/Filtering/FastMarching/ComputeGeodesicDistanceOnMesh/CMakeLists.txt
+++ b/src/Filtering/FastMarching/ComputeGeodesicDistanceOnMesh/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ComputeGeodesicDistanceOnMesh)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ComputeGeodesicDistanceOnMesh Code.cxx)
-target_link_libraries(ComputeGeodesicDistanceOnMesh ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ComputeGeodesicDistanceOnMesh
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/FastMarching
   COMPONENT Runtime
   )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ComputeGeodesicDistanceOnMeshTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ComputeGeodesicDistanceOnMesh
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     genusZeroSurface01.vtk
     ComputeGeodesicDistanceOnMeshOutput.vtk
 )

--- a/src/Filtering/FastMarching/CreateDistanceMapFromSeeds/CMakeLists.txt
+++ b/src/Filtering/FastMarching/CreateDistanceMapFromSeeds/CMakeLists.txt
@@ -5,10 +5,10 @@ project(CreateDistanceMapFromSeeds)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(CreateDistanceMapFromSeeds Code.cxx)
-target_link_libraries(CreateDistanceMapFromSeeds ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateDistanceMapFromSeeds
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/FastMarching
   COMPONENT Runtime
 )
@@ -20,6 +20,6 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CreateDistanceMapFromSeedsTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateDistanceMapFromSeeds
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/Output.mha
 )

--- a/src/Filtering/ImageCompare/AbsValueOfTwoImages/CMakeLists.txt
+++ b/src/Filtering/ImageCompare/AbsValueOfTwoImages/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(AbsValueOfTwoImages Code.cxx)
-target_link_libraries(AbsValueOfTwoImages ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS AbsValueOfTwoImages
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageCompare
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME AbsValueOfTwoImagesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/AbsValueOfTwoImages)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/ImageCompare/CombineTwoImagesWithCheckerBoardPattern/CMakeLists.txt
+++ b/src/Filtering/ImageCompare/CombineTwoImagesWithCheckerBoardPattern/CMakeLists.txt
@@ -5,10 +5,10 @@ project(CombineTwoImagesWithCheckerBoardPattern)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(CombineTwoImagesWithCheckerBoardPattern Code.cxx)
-target_link_libraries(CombineTwoImagesWithCheckerBoardPattern ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CombineTwoImagesWithCheckerBoardPattern
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageCompare
   COMPONENT Runtime
 )
@@ -23,7 +23,7 @@ enable_testing()
 set(output_image Output.png)
 
 add_test(NAME CombineTwoImagesWithCheckerBoardPatternTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CombineTwoImagesWithCheckerBoardPattern
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${output_image}
 )
 

--- a/src/Filtering/ImageCompare/SquaredDifferenceOfTwoImages/CMakeLists.txt
+++ b/src/Filtering/ImageCompare/SquaredDifferenceOfTwoImages/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(SquaredDifferenceOfTwoImages Code.cxx)
-target_link_libraries(SquaredDifferenceOfTwoImages ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS SquaredDifferenceOfTwoImages
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageCompare
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME SquaredDifferenceOfTwoImagesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SquaredDifferenceOfTwoImages)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/ImageCompose/ComposeVectorFromThreeScalarImages/CMakeLists.txt
+++ b/src/Filtering/ImageCompose/ComposeVectorFromThreeScalarImages/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ComposeVectorFromThreeScalarImages Code.cxx)
-target_link_libraries(ComposeVectorFromThreeScalarImages ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ComposeVectorFromThreeScalarImages
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageCompose
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ComposeVectorFromThreeScalarImagesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ComposeVectorFromThreeScalarImages)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/ImageCompose/ConvertRealAndImaginaryToComplexImage/CMakeLists.txt
+++ b/src/Filtering/ImageCompose/ConvertRealAndImaginaryToComplexImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ConvertRealAndImaginaryToComplexImage Code.cxx)
-target_link_libraries(ConvertRealAndImaginaryToComplexImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ConvertRealAndImaginaryToComplexImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageCompose
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ConvertRealAndImaginaryToComplexImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ConvertRealAndImaginaryToComplexImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/ImageCompose/CreateVectorImageFromScalarImages/CMakeLists.txt
+++ b/src/Filtering/ImageCompose/CreateVectorImageFromScalarImages/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(CreateVectorImageFromScalarImages Code.cxx)
-target_link_libraries(CreateVectorImageFromScalarImages ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateVectorImageFromScalarImages
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageCompose
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CreateVectorImageFromScalarImagesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateVectorImageFromScalarImages)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/ImageCompose/JoinImages/CMakeLists.txt
+++ b/src/Filtering/ImageCompose/JoinImages/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(JoinImages Code.cxx)
-target_link_libraries(JoinImages ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS JoinImages
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageCompose
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME JoinImagesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/JoinImages)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/ImageFeature/AdditiveGaussianNoiseImageFilter/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/AdditiveGaussianNoiseImageFilter/CMakeLists.txt
@@ -5,10 +5,10 @@ project(AdditiveGaussianNoiseImageFilter)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(AdditiveGaussianNoiseImageFilter Code.cxx)
-target_link_libraries(AdditiveGaussianNoiseImageFilter ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS AdditiveGaussianNoiseImageFilter
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFeature
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt Code.py
 
 enable_testing()
 add_test(NAME AdditiveGaussianNoiseImageFilterTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/AdditiveGaussianNoiseImageFilter
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   ${CMAKE_CURRENT_BINARY_DIR}/Gourds.png
   Output.png
   20

--- a/src/Filtering/ImageFeature/ApplyAFilterOnlyToASpecifiedImageRegion/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/ApplyAFilterOnlyToASpecifiedImageRegion/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ApplyAFilterOnlyToASpecifiedImageRegion Code.cxx)
-target_link_libraries(ApplyAFilterOnlyToASpecifiedImageRegion ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ApplyAFilterOnlyToASpecifiedImageRegion
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFeature
   COMPONENT Runtime
   )
@@ -26,7 +26,7 @@ set(output_image Output.png)
 set(test_options)
 
 add_test(NAME ApplyAFilterOnlyToASpecifiedImageRegionTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ApplyAFilterOnlyToASpecifiedImageRegion
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
     ${output_image}
     ${test_options}

--- a/src/Filtering/ImageFeature/ApplyAFilterToASpecifiedRegionOfAnImage/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/ApplyAFilterToASpecifiedRegionOfAnImage/CMakeLists.txt
@@ -17,8 +17,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(ApplyAFilterToASpecifiedRegionOfAnImage Code.cxx)
-  target_link_libraries(ApplyAFilterToASpecifiedRegionOfAnImage ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -27,11 +27,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(ApplyAFilterToASpecifiedRegionOfAnImage Code.cxx)
-  target_link_libraries(ApplyAFilterToASpecifiedRegionOfAnImage ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS ApplyAFilterToASpecifiedRegionOfAnImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFeature
   COMPONENT Runtime
   )
@@ -48,7 +48,7 @@ set(output_image Output.png)
 set(test_options)
 
 add_test(NAME ApplyAFilterOnlyToASpecifiedRegionOfAnImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ApplyAFilterOnlyToASpecifiedRegionOfAnImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
     ${output_image}
     ${test_options}

--- a/src/Filtering/ImageFeature/BilateralFilterAnImage/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/BilateralFilterAnImage/CMakeLists.txt
@@ -17,8 +17,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(BilateralFilterAnImage Code.cxx)
-  target_link_libraries(BilateralFilterAnImage ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -27,11 +27,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(BilateralFilterAnImage Code.cxx)
-  target_link_libraries(BilateralFilterAnImage ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS BilateralFilterAnImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFeature
   COMPONENT Runtime
   )
@@ -44,7 +44,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME BilateralFilterAnImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/BilateralFilterAnImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     Yinyang.png
     5
     10)

--- a/src/Filtering/ImageFeature/ComputeLaplacian/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/ComputeLaplacian/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ComputeLaplacian)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ComputeLaplacian Code.cxx)
-target_link_libraries(ComputeLaplacian ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ComputeLaplacian
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFeature
   COMPONENT Runtime
   )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ComputeLaplacianTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ComputeLaplacian
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/cthead1.png
     Output.png
   )

--- a/src/Filtering/ImageFeature/DetectEdgesWithCannyEdgeDetectionFilter/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/DetectEdgesWithCannyEdgeDetectionFilter/CMakeLists.txt
@@ -5,10 +5,10 @@ project(DetectEdgesWithCannyEdgeDetectionFilter)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(DetectEdgesWithCannyEdgeDetectionFilter Code.cxx)
-target_link_libraries(DetectEdgesWithCannyEdgeDetectionFilter ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS DetectEdgesWithCannyEdgeDetectionFilter
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFeature
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME DetectEdgesWithCannyEdgeDetectionFilterTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/DetectEdgesWithCannyEdgeDetectionFilter
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/cthead1.png
     Output.png
     1

--- a/src/Filtering/ImageFeature/ExtractContoursFromImage/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/ExtractContoursFromImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ExtractContoursFromImage Code.cxx)
-target_link_libraries(ExtractContoursFromImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ExtractContoursFromImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFeature
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ExtractContoursFromImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ExtractContoursFromImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/ImageFeature/FindZeroCrossingsInSignedImage/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/FindZeroCrossingsInSignedImage/CMakeLists.txt
@@ -17,8 +17,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(FindZeroCrossingsInSignedImage Code.cxx)
-  target_link_libraries(FindZeroCrossingsInSignedImage ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -27,11 +27,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(FindZeroCrossingsInSignedImage Code.cxx)
-  target_link_libraries(FindZeroCrossingsInSignedImage ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS FindZeroCrossingsInSignedImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFeature
   COMPONENT Runtime
   )
@@ -44,4 +44,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME FindZeroCrossingsInSignedImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/FindZeroCrossingsInSignedImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/ImageFeature/LaplacianRecursiveGaussianImageFilter/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/LaplacianRecursiveGaussianImageFilter/CMakeLists.txt
@@ -5,10 +5,10 @@ project(LaplacianRecursiveGaussianImageFilter)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(LaplacianRecursiveGaussianImageFilter Code.cxx)
-target_link_libraries(LaplacianRecursiveGaussianImageFilter ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS LaplacianRecursiveGaussianImageFilter
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFeature
   COMPONENT Runtime
 )
@@ -24,7 +24,7 @@ set(input_image ${CMAKE_CURRENT_BINARY_DIR}/cthead1.png)
 set(output_image Output.mha)
 
 add_test(NAME LaplacianRecursiveGaussianImageFilterTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/LaplacianRecursiveGaussianImageFilter
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
     ${output_image}
   )

--- a/src/Filtering/ImageFeature/SegmentBloodVessels/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/SegmentBloodVessels/CMakeLists.txt
@@ -6,11 +6,11 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(SegmentBloodVessels Code.cxx)
-target_link_libraries(SegmentBloodVessels ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
 
-install(TARGETS SegmentBloodVessels
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFeature
   COMPONENT Runtime
   )
@@ -27,7 +27,7 @@ set(output_image Output.mha)
 set(sigma 2.0)
 
 add_test(NAME SegmentBloodVesselsTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SegmentBloodVessels
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
     ${output_image}
     ${sigma}

--- a/src/Filtering/ImageFeature/SharpenImage/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/SharpenImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(SharpenImage Code.cxx)
-target_link_libraries(SharpenImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS SharpenImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFeature
   COMPONENT Runtime
   )
@@ -21,5 +21,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME SharpenImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SharpenImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/ImageFeature/SobelEdgeDetectionImageFilter/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/SobelEdgeDetectionImageFilter/CMakeLists.txt
@@ -5,10 +5,10 @@ project(SobelEdgeDetectionImageFilter)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(SobelEdgeDetectionImageFilter Code.cxx)
-target_link_libraries(SobelEdgeDetectionImageFilter ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS SobelEdgeDetectionImageFilter
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFeature
   COMPONENT Runtime
 )
@@ -24,7 +24,7 @@ set(input_image ${CMAKE_CURRENT_BINARY_DIR}/Gourds.png)
 set(output_image Output.mha)
 
 add_test(NAME SobelEdgeDetectionImageFilterTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SobelEdgeDetectionImageFilter
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
     ${output_image}
 )

--- a/src/Filtering/ImageFeature/ZeroCrossingBasedEdgeDecor/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/ZeroCrossingBasedEdgeDecor/CMakeLists.txt
@@ -17,8 +17,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(ZeroCrossingBasedEdgeDecor Code.cxx)
-  target_link_libraries(ZeroCrossingBasedEdgeDecor ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -27,11 +27,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(ZeroCrossingBasedEdgeDecor Code.cxx)
-  target_link_libraries(ZeroCrossingBasedEdgeDecor ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS ZeroCrossingBasedEdgeDecor
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFeature
   COMPONENT Runtime
   )
@@ -44,5 +44,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ZeroCrossingBasedEdgeDecorTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ZeroCrossingBasedEdgeDecor
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     Yinyang.png)

--- a/src/Filtering/ImageFilterBase/ApplyKernelToEveryPixel/CMakeLists.txt
+++ b/src/Filtering/ImageFilterBase/ApplyKernelToEveryPixel/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ApplyKernelToEveryPixel Code.cxx)
-target_link_libraries(ApplyKernelToEveryPixel ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ApplyKernelToEveryPixel
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFilterBase
   COMPONENT Runtime
   )
@@ -22,7 +22,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ApplyKernelToEveryPixelTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ApplyKernelToEveryPixel)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 
 if(ITK_WRAP_PYTHON)
   add_test(NAME ApplyKernelToEveryPixelTestPython

--- a/src/Filtering/ImageFilterBase/ApplyKernelToEveryPixelInNonZeroImage/CMakeLists.txt
+++ b/src/Filtering/ImageFilterBase/ApplyKernelToEveryPixelInNonZeroImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ApplyKernelToEveryPixelInNonZeroImage Code.cxx)
-target_link_libraries(ApplyKernelToEveryPixelInNonZeroImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ApplyKernelToEveryPixelInNonZeroImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFilterBase
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ApplyKernelToEveryPixelInNonZeroImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ApplyKernelToEveryPixelInNonZeroImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/ImageFilterBase/CastAnImageToAnotherType/CMakeLists.txt
+++ b/src/Filtering/ImageFilterBase/CastAnImageToAnotherType/CMakeLists.txt
@@ -5,10 +5,10 @@ project(CastAnImageToAnotherType)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(CastAnImageToAnotherType Code.cxx)
-target_link_libraries(CastAnImageToAnotherType ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CastAnImageToAnotherType
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFilterBase
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CastAnImageToAnotherTypeTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CastAnImageToAnotherType
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/CorpusCallosumMeanShape.mha
     Output.png
   )

--- a/src/Filtering/ImageFilterBase/ComputeLocalNoise/CMakeLists.txt
+++ b/src/Filtering/ImageFilterBase/ComputeLocalNoise/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ComputeLocalNoise Code.cxx)
-target_link_libraries(ComputeLocalNoise ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ComputeLocalNoise
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFilterBase
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ComputeLocalNoiseTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ComputeLocalNoise)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/ImageFilterBase/CustomOperationToCorrespondingPixelsInTwoImages/CMakeLists.txt
+++ b/src/Filtering/ImageFilterBase/CustomOperationToCorrespondingPixelsInTwoImages/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(CustomOperationToCorrespondingPixelsInTwoImages Code.cxx)
-target_link_libraries(CustomOperationToCorrespondingPixelsInTwoImages ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CustomOperationToCorrespondingPixelsInTwoImages
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFilterBase
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CustomOperationToCorrespondingPixelsInTwoImagesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CustomOperationToCorrespondingPixelsInTwoImages)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/ImageFilterBase/PredefinedOperationToCorrespondingPixelsInTwoImages/CMakeLists.txt
+++ b/src/Filtering/ImageFilterBase/PredefinedOperationToCorrespondingPixelsInTwoImages/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(PredefinedOperationToCorrespondingPixelsInTwoImages Code.cxx)
-target_link_libraries(PredefinedOperationToCorrespondingPixelsInTwoImages ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS PredefinedOperationToCorrespondingPixelsInTwoImages
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFilterBase
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME PredefinedOperationToCorrespondingPixelsInTwoImagesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/PredefinedOperationToCorrespondingPixelsInTwoImages)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/ImageFusion/ColorBoundariesOfRegions/CMakeLists.txt
+++ b/src/Filtering/ImageFusion/ColorBoundariesOfRegions/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ColorBoundariesOfRegions Code.cxx)
-target_link_libraries(ColorBoundariesOfRegions ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ColorBoundariesOfRegions
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFusion
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ColorBoundariesOfRegionsTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ColorBoundariesOfRegions)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/ImageFusion/ColorLabeledRegions/CMakeLists.txt
+++ b/src/Filtering/ImageFusion/ColorLabeledRegions/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ColorLabeledRegions Code.cxx)
-target_link_libraries(ColorLabeledRegions ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ColorLabeledRegions
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFusion
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ColorLabeledRegionsTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ColorLabeledRegions)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/ImageFusion/OverlayLabelMapOnImage/CMakeLists.txt
+++ b/src/Filtering/ImageFusion/OverlayLabelMapOnImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(OverlayLabelMapOnImage Code.cxx)
-target_link_libraries(OverlayLabelMapOnImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS OverlayLabelMapOnImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFusion
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME OverlayLabelMapOnImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/OverlayLabelMapOnImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/ImageFusion/OverlayLabelMapOnTopOfAnImage/CMakeLists.txt
+++ b/src/Filtering/ImageFusion/OverlayLabelMapOnTopOfAnImage/CMakeLists.txt
@@ -4,10 +4,10 @@ project(OverlayLabelMapOnTopOfAnImage)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(OverlayLabelMapOnTopOfAnImage Code.cxx)
-target_link_libraries(OverlayLabelMapOnTopOfAnImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS OverlayLabelMapOnTopOfAnImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageFusion
   COMPONENT Runtime
   )
@@ -27,7 +27,7 @@ set(input_images
 set(output_image Output.png)
 
 add_test(NAME OverlayLabelMapOnTopOfAnImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/OverlayLabelMapOnTopOfAnImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_images}
     ${output_image}
   )

--- a/src/Filtering/ImageGradient/ApplyGradientRecursiveGaussian/CMakeLists.txt
+++ b/src/Filtering/ImageGradient/ApplyGradientRecursiveGaussian/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ApplyGradientRecursiveGaussian)
 find_package(ITK 4.7.0 REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ApplyGradientRecursiveGaussian Code.cxx)
-target_link_libraries(ApplyGradientRecursiveGaussian ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ApplyGradientRecursiveGaussian
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGradient/
   COMPONENT Runtime
   )
@@ -25,7 +25,7 @@ set(input_image ${CMAKE_CURRENT_BINARY_DIR}/Gourds.png)
 set(output_image OutputX.png OutputY.png OutputMagnitude.png)
 
 add_test(NAME ApplyGradientRecursiveGaussianTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ApplyGradientRecursiveGaussian
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   ${input_image}
   ${output_image}
   )

--- a/src/Filtering/ImageGradient/ApplyGradientRecursiveGaussianWithVectorInput/CMakeLists.txt
+++ b/src/Filtering/ImageGradient/ApplyGradientRecursiveGaussianWithVectorInput/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ApplyGradientRecursiveGaussianWithVectorInput)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ApplyGradientRecursiveGaussianWithVectorInput Code.cxx)
-target_link_libraries(ApplyGradientRecursiveGaussianWithVectorInput ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ApplyGradientRecursiveGaussianWithVectorInput
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGradient/
   COMPONENT Runtime
 )
@@ -24,7 +24,7 @@ set(input_image ${CMAKE_CURRENT_BINARY_DIR}/Gourds.png)
 set(output_image Output1X.png Output1Y.png Output2X.png Output2Y.png)
 
 add_test(NAME ApplyGradientRecursiveGaussianWithVectorInputTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ApplyGradientRecursiveGaussianWithVectorInput
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
     ${output_image}
   )

--- a/src/Filtering/ImageGradient/ComputeAndDisplayGradient/CMakeLists.txt
+++ b/src/Filtering/ImageGradient/ComputeAndDisplayGradient/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ComputeAndDisplayGradient Code.cxx)
-target_link_libraries(ComputeAndDisplayGradient ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ComputeAndDisplayGradient
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGradient
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ComputeAndDisplayGradientTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ComputeAndDisplayGradient)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/ImageGradient/ComputeGradientMagnitude/CMakeLists.txt
+++ b/src/Filtering/ImageGradient/ComputeGradientMagnitude/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ComputeGradientMagnitude)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ComputeGradientMagnitude Code.cxx)
-target_link_libraries(ComputeGradientMagnitude ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ComputeGradientMagnitude
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGradient
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ComputeGradientMagnitudeTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ComputeGradientMagnitude
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/Gourds.png
     ComputeGradientMagnitudeTestOutput.mha
     )

--- a/src/Filtering/ImageGradient/ComputeGradientMagnitudeRecursiveGaussian/CMakeLists.txt
+++ b/src/Filtering/ImageGradient/ComputeGradientMagnitudeRecursiveGaussian/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ComputeGradientMagnitudeRecursiveGaussian)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ComputeGradientMagnitudeRecursiveGaussian Code.cxx)
-target_link_libraries(ComputeGradientMagnitudeRecursiveGaussian ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ComputeGradientMagnitudeRecursiveGaussian
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGradient
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ComputeGradientMagnitudeRecursiveGaussianTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ComputeGradientMagnitudeRecursiveGaussian
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/Gourds.png
     ComputeGradientMagnitudeRecursiveGaussianTestOutput.mha
     2.

--- a/src/Filtering/ImageGradient/GradientOfVectorImage/CMakeLists.txt
+++ b/src/Filtering/ImageGradient/GradientOfVectorImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(GradientOfVectorImage Code.cxx)
-target_link_libraries(GradientOfVectorImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS GradientOfVectorImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGradient
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME GradientOfVectorImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/GradientOfVectorImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/ImageGradient/ImplementationOfSnakes/CMakeLists.txt
+++ b/src/Filtering/ImageGradient/ImplementationOfSnakes/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ImplementationOfSnakes Code.cxx)
-target_link_libraries(ImplementationOfSnakes ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ImplementationOfSnakes
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGradient
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ImplementationOfSnakesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ImplementationOfSnakes)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/ImageGrid/AppendTwo3DVolumes/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/AppendTwo3DVolumes/CMakeLists.txt
@@ -5,10 +5,10 @@ project(AppendTwo3DVolumes)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(AppendTwo3DVolumes Code.cxx)
-target_link_libraries(AppendTwo3DVolumes ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS AppendTwo3DVolumes
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid
   COMPONENT Runtime
   )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME AppendTwo3DVolumesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/AppendTwo3DVolumes
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/HeadMRVolume.mha
     ${CMAKE_CURRENT_BINARY_DIR}/HeadMRVolume.mha
     Output.mha

--- a/src/Filtering/ImageGrid/ChangeImageOriginSpacingOrDirection/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/ChangeImageOriginSpacingOrDirection/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ChangeImageOriginSpacingOrDirection)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ChangeImageOriginSpacingOrDirection Code.cxx)
-target_link_libraries(ChangeImageOriginSpacingOrDirection ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ChangeImageOriginSpacingOrDirection
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid
   COMPONENT Runtime
   )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ChangeImageOriginSpacingOrDirectionTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ChangeImageOriginSpacingOrDirection
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   ${CMAKE_CURRENT_BINARY_DIR}/HeadMRVolume.mha
   0.7
   8.4

--- a/src/Filtering/ImageGrid/Create3DVolume/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/Create3DVolume/CMakeLists.txt
@@ -5,11 +5,11 @@ project(Create3DVolume)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(Create3DVolume
+add_executable(${PROJECT_NAME}
   Code.cxx)
-target_link_libraries(Create3DVolume ${ITK_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS Create3DVolume
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid
   COMPONENT Runtime
   )
@@ -21,7 +21,7 @@ install(FILES Code.cxx CMakeLists.txt Code.py
 
 enable_testing()
 add_test(NAME Create3DVolumeTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Create3DVolume
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/mri3D_0.mha
     ${CMAKE_CURRENT_BINARY_DIR}/mri3D_1.mha
     ${CMAKE_CURRENT_BINARY_DIR}/mri3D_2.mha

--- a/src/Filtering/ImageGrid/CropImageBySpecifyingRegion2/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/CropImageBySpecifyingRegion2/CMakeLists.txt
@@ -17,8 +17,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(CropImageBySpecifyingRegion2 Code.cxx)
-  target_link_libraries(CropImageBySpecifyingRegion2 ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -27,11 +27,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(CropImageBySpecifyingRegion2 Code.cxx)
-  target_link_libraries(CropImageBySpecifyingRegion2 ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS CropImageBySpecifyingRegion2
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid
   COMPONENT Runtime
   )
@@ -44,4 +44,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CropImageBySpecifyingRegion2Test
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CropImageBySpecifyingRegion2)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/ImageGrid/ExtractRegionOfInterestInOneImage/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/ExtractRegionOfInterestInOneImage/CMakeLists.txt
@@ -4,10 +4,10 @@ project(ExtractRegionOfInterestInOneImage)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ExtractRegionOfInterestInOneImage Code.cxx)
-target_link_libraries(ExtractRegionOfInterestInOneImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ExtractRegionOfInterestInOneImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid
   COMPONENT Runtime
   )
@@ -19,7 +19,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ExtractRegionOfInterestInOneImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ExtractRegionOfInterestInOneImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/Gourds.png
     Output.png
     50 150

--- a/src/Filtering/ImageGrid/FitSplineIntoPointSet/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/FitSplineIntoPointSet/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(FitSplineIntoPointSet Code.cxx)
-target_link_libraries(FitSplineIntoPointSet ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS FitSplineIntoPointSet
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME FitSplineIntoPointSetTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/FitSplineIntoPointSet)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/ImageGrid/FlipAnImageOverSpecifiedAxes/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/FlipAnImageOverSpecifiedAxes/CMakeLists.txt
@@ -5,10 +5,10 @@ project(FlipAnImageOverSpecifiedAxes)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(FlipAnImageOverSpecifiedAxes Code.cxx)
-target_link_libraries(FlipAnImageOverSpecifiedAxes ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS FlipAnImageOverSpecifiedAxes
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid
   COMPONENT Runtime
 )
@@ -24,7 +24,7 @@ set(input_image ${CMAKE_CURRENT_BINARY_DIR}/Yinyang.png)
 set(output_image Output.png)
 
 add_test(NAME FlipAnImageOverSpecifiedAxesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/FlipAnImageOverSpecifiedAxes
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
     ${output_image}
     0

--- a/src/Filtering/ImageGrid/PadAnImageByMirroring/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/PadAnImageByMirroring/CMakeLists.txt
@@ -5,10 +5,10 @@ project(PadAnImageByMirroring)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(PadAnImageByMirroring Code.cxx)
-target_link_libraries(PadAnImageByMirroring ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS PadAnImageByMirroring
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME PadAnImageByMirroringTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/PadAnImageByMirroring
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/Gourds.png
     Output.png
 )

--- a/src/Filtering/ImageGrid/PadAnImageWithAConstant/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/PadAnImageWithAConstant/CMakeLists.txt
@@ -5,10 +5,10 @@ project(PadAnImageWithAConstant)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(PadAnImageWithAConstant Code.cxx)
-target_link_libraries(PadAnImageWithAConstant ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS PadAnImageWithAConstant
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME PadAnImageWithAConstantTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/PadAnImageWithAConstant
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/Gourds.png
     Output.png
     10

--- a/src/Filtering/ImageGrid/PadImageByWrapping/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/PadImageByWrapping/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(PadImageByWrapping Code.cxx)
-target_link_libraries(PadImageByWrapping ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS PadImageByWrapping
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME PadImageByWrappingTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/PadImageByWrapping)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/ImageGrid/PasteImageIntoAnotherOne/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/PasteImageIntoAnotherOne/CMakeLists.txt
@@ -5,10 +5,10 @@ project(PasteImageIntoAnotherOne)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(PasteImageIntoAnotherOne Code.cxx)
-target_link_libraries(PasteImageIntoAnotherOne ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS PasteImageIntoAnotherOne
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid
   COMPONENT Runtime
   )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME PasteImageIntoAnotherOneTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/PasteImageIntoAnotherOne
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/Yinyang.png
     ${CMAKE_CURRENT_BINARY_DIR}/Gourds.png
     Output.png

--- a/src/Filtering/ImageGrid/PermuteAxesOfAnImage/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/PermuteAxesOfAnImage/CMakeLists.txt
@@ -5,10 +5,10 @@ project(PermuteAxesOfAnImage)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(PermuteAxesOfAnImage Code.cxx)
-target_link_libraries(PermuteAxesOfAnImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS PermuteAxesOfAnImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid
   COMPONENT Runtime
   )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME PermuteAxesOfAnImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/PermuteAxesOfAnImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/Gourds.png
     Output.png
 )

--- a/src/Filtering/ImageGrid/ProcessA2DSliceOfA3DImage/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/ProcessA2DSliceOfA3DImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ProcessA2DSliceOfA3DImage Code.cxx)
-target_link_libraries(ProcessA2DSliceOfA3DImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ProcessA2DSliceOfA3DImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Core/Common
   COMPONENT Runtime
   )
@@ -26,7 +26,7 @@ set(output_image Output.mha)
 set(test_options 232) # slice number
 
 add_test(NAME ProcessA2DSliceOfA3DImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ProcessA2DSliceOfA3DImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
     ${output_image}
     ${test_options}

--- a/src/Filtering/ImageGrid/ResampleAScalarImage/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/ResampleAScalarImage/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ResampleAScalarImage)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ResampleAScalarImage Code.cxx)
-target_link_libraries(ResampleAScalarImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ResampleAScalarImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid
   COMPONENT Runtime
   )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt Code.py
 
 enable_testing()
 add_test(NAME ResampleAScalarImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ResampleAScalarImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/Gourds.png
     Output.png
     160

--- a/src/Filtering/ImageGrid/ResampleAVectorImage/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/ResampleAVectorImage/CMakeLists.txt
@@ -8,10 +8,10 @@ project(ResampleAVectorImage)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ResampleAVectorImage Code.cxx)
-target_link_libraries(ResampleAVectorImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ResampleAVectorImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid/
   COMPONENT Runtime
   )
@@ -24,7 +24,7 @@ install(FILES Code.cxx CMakeLists.txt Code.py
 enable_testing()
 
 add_test(NAME ResampleAVectorImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ResampleAVectorImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   ${input_image}
   ${output_image}
   )

--- a/src/Filtering/ImageGrid/ResampleAnImage/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/ResampleAnImage/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ResampleAnImage)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ResampleAnImage Code.cxx)
-target_link_libraries(ResampleAnImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ResampleAnImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid
   COMPONENT Runtime
   )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ResampleAnImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ResampleAnImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/BrainProtonDensitySlice.png
     Output.png
     2

--- a/src/Filtering/ImageGrid/RunImageFilterOnRegionOfImage/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/RunImageFilterOnRegionOfImage/CMakeLists.txt
@@ -16,8 +16,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(RunImageFilterOnRegionOfImage Code.cxx)
-  target_link_libraries(RunImageFilterOnRegionOfImage ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -26,11 +26,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(RunImageFilterOnRegionOfImage Code.cxx)
-  target_link_libraries(RunImageFilterOnRegionOfImage ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS RunImageFilterOnRegionOfImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid
   COMPONENT Runtime
   )
@@ -43,6 +43,6 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME RunImageFilterOnRegionOfImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/RunImageFilterOnRegionOfImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
         Yinyang.png
         10)

--- a/src/Filtering/ImageGrid/ShrinkImage/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/ShrinkImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ShrinkImage Code.cxx)
-target_link_libraries(ShrinkImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ShrinkImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ShrinkImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ShrinkImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/ImageGrid/Stack2DImagesInto3DImage/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/Stack2DImagesInto3DImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(Stack2DImagesInto3DImage Code.cxx)
-target_link_libraries(Stack2DImagesInto3DImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS Stack2DImagesInto3DImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 # TODO Implement input in test when Code.cxx is updated
 enable_testing()
 add_test(NAME Stack2DImagesInto3DImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Stack2DImagesInto3DImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/ImageGrid/TileImagesSideBySide/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/TileImagesSideBySide/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(TileImagesSideBySide Code.cxx)
-target_link_libraries(TileImagesSideBySide ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS TileImagesSideBySide
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid
   COMPONENT Runtime
   )
@@ -22,7 +22,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME TileImagesSideBySideTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/TileImagesSideBySide
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     Gourds.png
     Gourds.png
     output.png

--- a/src/Filtering/ImageGrid/UpsampleAnImage/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/UpsampleAnImage/CMakeLists.txt
@@ -5,10 +5,10 @@ project(UpsampleAnImage)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(UpsampleAnImage Code.cxx)
-target_link_libraries(UpsampleAnImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS UpsampleAnImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid
   COMPONENT Runtime
   )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME UpsampleAnImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/UpsampleAnImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/BrainProtonDensitySlice.png
     Output.png
     2

--- a/src/Filtering/ImageGrid/WarpAnImageUsingADeformationField/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/WarpAnImageUsingADeformationField/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(WarpAnImageUsingADeformationField Code.cxx)
-target_link_libraries(WarpAnImageUsingADeformationField ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS WarpAnImageUsingADeformationField
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageGrid
   COMPONENT Runtime
   )
@@ -27,7 +27,7 @@ set(output_image Output.png)
 set(test_options)
 
 add_test(NAME WarpAnImageUsingADeformationFieldTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/WarpAnImageUsingADeformationField
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
     ${displacement_field_image}
     ${output_image}

--- a/src/Filtering/ImageIntensity/AbsValueOfImage/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/AbsValueOfImage/CMakeLists.txt
@@ -17,8 +17,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(AbsValueOfImage Code.cxx)
-  target_link_libraries(AbsValueOfImage ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -27,11 +27,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(AbsValueOfImage Code.cxx)
-  target_link_libraries(AbsValueOfImage ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS AbsValueOfImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
   )
@@ -44,5 +44,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME AbsValueOfImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/AbsValueOfImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/ImageIntensity/AddConstantToEveryPixel/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/AddConstantToEveryPixel/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(AddConstantToEveryPixel Code.cxx)
-target_link_libraries(AddConstantToEveryPixel ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS AddConstantToEveryPixel
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME AddConstantToEveryPixelTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/AddConstantToEveryPixel)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/ImageIntensity/AddTwoImages/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/AddTwoImages/CMakeLists.txt
@@ -21,8 +21,8 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
   include(${VTK_USE_FILE})
 endif()
 
-add_executable(AddTwoImages Code.cxx)
-target_link_libraries(AddTwoImages ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(
@@ -31,7 +31,7 @@ if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     )
 endif()
 
-install(TARGETS AddTwoImages
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
   )
@@ -44,4 +44,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME AddTwoImagesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/AddTwoImages)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/ImageIntensity/ApplyAtanImageFilter/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/ApplyAtanImageFilter/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ApplyAtanImageFilter)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ApplyAtanImageFilter Code.cxx)
-target_link_libraries(ApplyAtanImageFilter ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ApplyAtanImageFilter
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
 )
@@ -20,6 +20,6 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ApplyAtanImageFilterTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ApplyAtanImageFilter
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     Output.mha
 )

--- a/src/Filtering/ImageIntensity/ApplyCosImageFilter/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/ApplyCosImageFilter/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ApplyCosImageFilter)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ApplyCosImageFilter Code.cxx)
-target_link_libraries(ApplyCosImageFilter ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ApplyCosImageFilter
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ApplyCosImageFilterTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ApplyCosImageFilter
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/Input.mha
     Output.mha
 )

--- a/src/Filtering/ImageIntensity/ApplyExpNegativeImageFilter/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/ApplyExpNegativeImageFilter/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ApplyExpNegativeImageFilter)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ApplyExpNegativeImageFilter Code.cxx)
-target_link_libraries(ApplyExpNegativeImageFilter ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ApplyExpNegativeImageFilter
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
   )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ApplyExpNegativeImageFilterTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ApplyExpNegativeImageFilter
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/Gourds.png
     Output.mha
     0.001

--- a/src/Filtering/ImageIntensity/ApplySinImageFilter/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/ApplySinImageFilter/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ApplySinImageFilter)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ApplySinImageFilter Code.cxx)
-target_link_libraries(ApplySinImageFilter ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ApplySinImageFilter
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ApplySinImageFilterTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ApplySinImageFilter
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/Input.mha
     Output.mha
 )

--- a/src/Filtering/ImageIntensity/BinaryANDTwoImages/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/BinaryANDTwoImages/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(BinaryANDTwoImages Code.cxx)
-target_link_libraries(BinaryANDTwoImages ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS BinaryANDTwoImages
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME BinaryANDTwoImagesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/BinaryANDTwoImages)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/ImageIntensity/BinaryORTwoImages/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/BinaryORTwoImages/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(BinaryORTwoImages Code.cxx)
-target_link_libraries(BinaryORTwoImages ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS BinaryORTwoImages
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME BinaryORTwoImagesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/BinaryORTwoImages)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/ImageIntensity/BinaryXORTwoImages/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/BinaryXORTwoImages/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(BinaryXORTwoImages Code.cxx)
-target_link_libraries(BinaryXORTwoImages ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS BinaryXORTwoImages
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME BinaryXORTwoImagesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/BinaryXORTwoImages)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/ImageIntensity/CastImageToAnotherTypeButClampToOutput/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/CastImageToAnotherTypeButClampToOutput/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(CastImageToAnotherTypeButClampToOutput Code.cxx)
-target_link_libraries(CastImageToAnotherTypeButClampToOutput ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CastImageToAnotherTypeButClampToOutput
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CastImageToAnotherTypeButClampToOutputTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CastImageToAnotherTypeButClampToOutput)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/ImageIntensity/CompareTwoImagesAndSetOutputPixelToMax/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/CompareTwoImagesAndSetOutputPixelToMax/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(CompareTwoImagesAndSetOutputPixelToMax Code.cxx)
-target_link_libraries(CompareTwoImagesAndSetOutputPixelToMax ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CompareTwoImagesAndSetOutputPixelToMax
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CompareTwoImagesAndSetOutputPixelToMaxTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CompareTwoImagesAndSetOutputPixelToMax)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/ImageIntensity/CompareTwoImagesAndSetOutputPixelToMin/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/CompareTwoImagesAndSetOutputPixelToMin/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(CompareTwoImagesAndSetOutputPixelToMin Code.cxx)
-target_link_libraries(CompareTwoImagesAndSetOutputPixelToMin ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CompareTwoImagesAndSetOutputPixelToMin
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CompareTwoImagesAndSetOutputPixelToMinTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CompareTwoImagesAndSetOutputPixelToMin)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/ImageIntensity/ComputeEdgePotential/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/ComputeEdgePotential/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ComputeEdgePotential Code.cxx)
-target_link_libraries(ComputeEdgePotential ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ComputeEdgePotential
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ComputeEdgePotentialTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ComputeEdgePotential)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/ImageIntensity/ComputeSigmoid/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/ComputeSigmoid/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ComputeSigmoid)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ComputeSigmoid Code.cxx)
-target_link_libraries(ComputeSigmoid ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ComputeSigmoid
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
   )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ComputeSigmoidTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ComputeSigmoid
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/BrainProtonDensitySlice.png
     Output.png
     10 240 10 170

--- a/src/Filtering/ImageIntensity/ComputerMagInVectorImageToMakeMagImage/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/ComputerMagInVectorImageToMakeMagImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ComputerMagInVectorImageToMakeMagImage Code.cxx)
-target_link_libraries(ComputerMagInVectorImageToMakeMagImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ComputerMagInVectorImageToMakeMagImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
   )
@@ -22,6 +22,6 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ComputerMagInVectorImageToMakeMagImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ComputerMagInVectorImageToMakeMagImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     Yinyang.png
     output.png)

--- a/src/Filtering/ImageIntensity/ConvertRGBImageToGrayscaleImage/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/ConvertRGBImageToGrayscaleImage/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ConvertRGBImageToGrayscaleImage)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ConvertRGBImageToGrayscaleImage Code.cxx)
-target_link_libraries(ConvertRGBImageToGrayscaleImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ConvertRGBImageToGrayscaleImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
 )
@@ -23,7 +23,7 @@ set(input_image ${CMAKE_CURRENT_BINARY_DIR}/itk_eg_logo.png)
 set(output_image Output.png)
 
 add_test(NAME ConvertRGBImageToGrayscaleImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ConvertRGBImageToGrayscaleImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
     ${output_image}
 )

--- a/src/Filtering/ImageIntensity/ExtractComponentOfVectorImage/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/ExtractComponentOfVectorImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ExtractComponentOfVectorImage Code.cxx)
-target_link_libraries(ExtractComponentOfVectorImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ExtractComponentOfVectorImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ExtractComponentOfVectorImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ExtractComponentOfVectorImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/ImageIntensity/IntensityWindowing/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/IntensityWindowing/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(IntensityWindowing Code.cxx)
-target_link_libraries(IntensityWindowing ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS IntensityWindowing
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME IntensityWindowingTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/IntensityWindowing)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/ImageIntensity/InverseOfMaskToImage/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/InverseOfMaskToImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(InverseOfMaskToImage Code.cxx)
-target_link_libraries(InverseOfMaskToImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS InverseOfMaskToImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME InverseOfMaskToImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/InverseOfMaskToImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/ImageIntensity/InvertImage/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/InvertImage/CMakeLists.txt
@@ -17,8 +17,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(InvertImage Code.cxx)
-  target_link_libraries(InvertImage ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -27,11 +27,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(InvertImage Code.cxx)
-  target_link_libraries(InvertImage ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS InvertImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
   )
@@ -44,5 +44,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME InvertImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/InvertImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/ImageIntensity/MaskImage/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/MaskImage/CMakeLists.txt
@@ -17,8 +17,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(MaskImage Code.cxx)
-  target_link_libraries(MaskImage ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -27,11 +27,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(MaskImage Code.cxx)
-  target_link_libraries(MaskImage ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS MaskImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
   )
@@ -44,6 +44,6 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME MaskImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MaskImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     Yinyang.png
     )

--- a/src/Filtering/ImageIntensity/MultiplyImageByScalar/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/MultiplyImageByScalar/CMakeLists.txt
@@ -5,10 +5,10 @@ project(MultiplyImageByScalar)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(MultiplyImageByScalar Code.cxx)
-target_link_libraries(MultiplyImageByScalar ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS MultiplyImageByScalar
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
   )
@@ -20,6 +20,6 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME MultiplyImageByScalarTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MultiplyImageByScalar
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/Gourds.png 2.5 Output.mha
 )

--- a/src/Filtering/ImageIntensity/MultiplyTwoImages/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/MultiplyTwoImages/CMakeLists.txt
@@ -5,10 +5,10 @@ project(MultiplyTwoImages)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(MultiplyTwoImages Code.cxx)
-target_link_libraries(MultiplyTwoImages ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS MultiplyTwoImages
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
   )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME MultiplyTwoImagesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MultiplyTwoImages
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/Gourds.png
     ${CMAKE_CURRENT_BINARY_DIR}/mask.png
     Output.mha

--- a/src/Filtering/ImageIntensity/NormalizeImage/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/NormalizeImage/CMakeLists.txt
@@ -17,8 +17,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(NormalizeImage Code.cxx)
-  target_link_libraries(NormalizeImage ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -27,11 +27,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(NormalizeImage Code.cxx)
-  target_link_libraries(NormalizeImage ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS NormalizeImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
   )
@@ -44,5 +44,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME NormalizeImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/NormalizeImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     Yinyang.png)

--- a/src/Filtering/ImageIntensity/PixelDivisionOfTwoImages/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/PixelDivisionOfTwoImages/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(PixelDivisionOfTwoImages Code.cxx)
-target_link_libraries(PixelDivisionOfTwoImages ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS PixelDivisionOfTwoImages
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME PixelDivisionOfTwoImagesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/PixelDivisionOfTwoImages)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/ImageIntensity/RescaleIntensity/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/RescaleIntensity/CMakeLists.txt
@@ -5,10 +5,10 @@ project(RescaleIntensity)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(RescaleIntensity Code.cxx)
-target_link_libraries(RescaleIntensity ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS RescaleIntensity
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
 )
@@ -24,7 +24,7 @@ set(input_image ${CMAKE_CURRENT_BINARY_DIR}/Gourds.png)
 set(output_image Output.png)
 
 add_test(NAME RescaleIntensityTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/RescaleIntensity
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
     ${output_image}
     0

--- a/src/Filtering/ImageIntensity/ScalePixelSumToConstant/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/ScalePixelSumToConstant/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ScalePixelSumToConstant Code.cxx)
-target_link_libraries(ScalePixelSumToConstant ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ScalePixelSumToConstant
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
   )
@@ -24,4 +24,4 @@ enable_testing()
 
 
 add_test(NAME ScalePixelSumToConstantTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ScalePixelSumToConstant)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/ImageIntensity/SquareEveryPixel/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/SquareEveryPixel/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(SquareEveryPixel Code.cxx)
-target_link_libraries(SquareEveryPixel ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS SquareEveryPixel
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME SquareEveryPixelTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SquareEveryPixel)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/ImageIntensity/SubtractConstantFromEveryPixel/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/SubtractConstantFromEveryPixel/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(SubtractConstantFromEveryPixel Code.cxx)
-target_link_libraries(SubtractConstantFromEveryPixel ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS SubtractConstantFromEveryPixel
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME SubtractConstantFromEveryPixelTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SubtractConstantFromEveryPixel)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/ImageIntensity/SubtractTwoImages/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/SubtractTwoImages/CMakeLists.txt
@@ -20,8 +20,8 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
   include(${VTK_USE_FILE})
 endif()
 
-add_executable(SubtractTwoImages Code.cxx)
-target_link_libraries(SubtractTwoImages ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(
@@ -30,7 +30,7 @@ if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     )
 endif()
 
-install(TARGETS SubtractTwoImages
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
   )
@@ -43,5 +43,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME SubtractTwoImagesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SubtractTwoImages)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/ImageIntensity/TransformVectorValuedImagePixels/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/TransformVectorValuedImagePixels/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(TransformVectorValuedImagePixels Code.cxx)
-target_link_libraries(TransformVectorValuedImagePixels ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS TransformVectorValuedImagePixels
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageIntensity
   COMPONENT Runtime
   )
@@ -22,7 +22,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME TransformVectorValuedImagePixelsTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/TransformVectorValuedImagePixels
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     Gourds.png
     output.png
   )

--- a/src/Filtering/ImageLabel/ExtractBoundariesOfConnectedRegionsInBinaryImage/CMakeLists.txt
+++ b/src/Filtering/ImageLabel/ExtractBoundariesOfConnectedRegionsInBinaryImage/CMakeLists.txt
@@ -17,8 +17,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(ExtractBoundariesOfConnectedRegionsInBinaryImage Code.cxx)
-  target_link_libraries(ExtractBoundariesOfConnectedRegionsInBinaryImage ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -27,11 +27,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(ExtractBoundariesOfConnectedRegionsInBinaryImage Code.cxx)
-  target_link_libraries(ExtractBoundariesOfConnectedRegionsInBinaryImage ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS ExtractBoundariesOfConnectedRegionsInBinaryImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageLabel
   COMPONENT Runtime
   )
@@ -44,4 +44,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ExtractBoundariesOfConnectedRegionsInBinaryImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ExtractBoundariesOfConnectedRegionsInBinaryImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/ImageLabel/ExtractInnerAndOuterBoundariesOfBlobsInBinaryImage/CMakeLists.txt
+++ b/src/Filtering/ImageLabel/ExtractInnerAndOuterBoundariesOfBlobsInBinaryImage/CMakeLists.txt
@@ -17,8 +17,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(ExtractInnerAndOuterBoundariesOfBlobsInBinaryImage Code.cxx)
-  target_link_libraries(ExtractInnerAndOuterBoundariesOfBlobsInBinaryImage ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -27,11 +27,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(ExtractInnerAndOuterBoundariesOfBlobsInBinaryImage Code.cxx)
-  target_link_libraries(ExtractInnerAndOuterBoundariesOfBlobsInBinaryImage ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS ExtractInnerAndOuterBoundariesOfBlobsInBinaryImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageLabel
   COMPONENT Runtime
   )
@@ -44,5 +44,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ExtractInnerAndOuterBoundariesOfBlobsInBinaryImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ExtractInnerAndOuterBoundariesOfBlobsInBinaryImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/ImageLabel/LabelContoursOfConnectComponent/CMakeLists.txt
+++ b/src/Filtering/ImageLabel/LabelContoursOfConnectComponent/CMakeLists.txt
@@ -17,8 +17,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(LabelContoursOfConnectComponent Code.cxx)
-  target_link_libraries(LabelContoursOfConnectComponent ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -27,11 +27,11 @@ if(ENABLE_QUICKVIEW)
        )
   endif()
 else()
-  add_executable(LabelContoursOfConnectComponent Code.cxx)
-  target_link_libraries(LabelContoursOfConnectComponent ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS LabelContoursOfConnectComponent
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageLabel
   COMPONENT Runtime
   )
@@ -44,4 +44,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME LabelContoursOfConnectComponentTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/LabelContoursOfConnectComponent)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/ImageStatistics/AdaptiveHistogramEqualizationImageFilter/CMakeLists.txt
+++ b/src/Filtering/ImageStatistics/AdaptiveHistogramEqualizationImageFilter/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(AdaptiveHistogramEqualizationImageFilter Code.cxx)
-target_link_libraries(AdaptiveHistogramEqualizationImageFilter ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS AdaptiveHistogramEqualizationImageFilter
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Statistics
   COMPONENT Runtime
   )
@@ -39,7 +39,7 @@ set(radius04 10)
 
 
 add_test(NAME AdaptiveHistogramEqualizationImageFilterTest01
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/AdaptiveHistogramEqualizationImageFilter
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
     AdaptiveHistogramEqualizationImageFilterTest01.png
     ${alpha01}
@@ -47,7 +47,7 @@ add_test(NAME AdaptiveHistogramEqualizationImageFilterTest01
     ${radius01}
   )
 add_test(NAME AdaptiveHistogramEqualizationImageFilterTest02
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/AdaptiveHistogramEqualizationImageFilter
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
     AdaptiveHistogramEqualizationImageFilterTest02.png
     ${alpha02}
@@ -55,7 +55,7 @@ add_test(NAME AdaptiveHistogramEqualizationImageFilterTest02
     ${radius02}
   )
 add_test(NAME AdaptiveHistogramEqualizationImageFilterTest03
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/AdaptiveHistogramEqualizationImageFilter
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
     AdaptiveHistogramEqualizationImageFilterTest03.png
     ${alpha03}
@@ -63,7 +63,7 @@ add_test(NAME AdaptiveHistogramEqualizationImageFilterTest03
     ${radius03}
   )
 add_test(NAME AdaptiveHistogramEqualizationImageFilterTest04
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/AdaptiveHistogramEqualizationImageFilter
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
     AdaptiveHistogramEqualizationImageFilterTest04.png
     ${alpha04}
@@ -71,7 +71,7 @@ add_test(NAME AdaptiveHistogramEqualizationImageFilterTest04
     ${radius01}
   )
  add_test(NAME AdaptiveHistogramEqualizationImageFilterTest05
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/AdaptiveHistogramEqualizationImageFilter
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
     AdaptiveHistogramEqualizationImageFilterTest05.png
     ${alpha05}
@@ -79,7 +79,7 @@ add_test(NAME AdaptiveHistogramEqualizationImageFilterTest04
     ${radius02}
   )
   add_test(NAME AdaptiveHistogramEqualizationImageFilterTest06
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/AdaptiveHistogramEqualizationImageFilter
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
     AdaptiveHistogramEqualizationImageFilterTest06.png
     ${alpha05}

--- a/src/Filtering/ImageStatistics/ApplyAccumulateImageFilter/CMakeLists.txt
+++ b/src/Filtering/ImageStatistics/ApplyAccumulateImageFilter/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ApplyAccumulateImageFilter)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ApplyAccumulateImageFilter Code.cxx)
-target_link_libraries(ApplyAccumulateImageFilter ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ApplyAccumulateImageFilter
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageStatistics
   COMPONENT Runtime
   )
@@ -22,7 +22,7 @@ enable_testing()
 
 foreach(i RANGE 0 2)
   add_test(NAME ApplyAccumulateImageFilterTest${i}
-    COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ApplyAccumulateImageFilter
+    COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
       ${CMAKE_CURRENT_BINARY_DIR}/HeadMRVolume.mha
       ${CMAKE_CURRENT_BINARY_DIR}/ApplyAccumulateImageFilterTestOutput${i}.mha
       ${i}

--- a/src/Filtering/ImageStatistics/CalculateImageMoments/CMakeLists.txt
+++ b/src/Filtering/ImageStatistics/CalculateImageMoments/CMakeLists.txt
@@ -5,10 +5,10 @@ project(CalculateImageMoments)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(CalculateImageMoments Code.cxx)
-target_link_libraries(CalculateImageMoments ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CalculateImageMoments
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKExamples/Filtering/ImageStatistics
   COMPONENT Runtime
 )
@@ -23,7 +23,7 @@ enable_testing()
 set(input_image ${CMAKE_CURRENT_BINARY_DIR}/ellipse.mha)
 
 add_test(NAME CalculateImageMomentsTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CalculateImageMoments
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   ${input_image}
 )
 

--- a/src/Filtering/ImageStatistics/ComputeMinMaxVarianceMeanOfImage/CMakeLists.txt
+++ b/src/Filtering/ImageStatistics/ComputeMinMaxVarianceMeanOfImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ComputeMinMaxVarianceMeanOfImage Code.cxx)
-target_link_libraries(ComputeMinMaxVarianceMeanOfImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ComputeMinMaxVarianceMeanOfImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageStatistics
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ComputeMinMaxVarianceMeanOfImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ComputeMinMaxVarianceMeanOfImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/ImageStatistics/ComputePCAShapeFromSample/CMakeLists.txt
+++ b/src/Filtering/ImageStatistics/ComputePCAShapeFromSample/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ComputePCAShapeFromSample Code.cxx)
-target_link_libraries(ComputePCAShapeFromSample ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ComputePCAShapeFromSample
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageStatistics
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ComputePCAShapeFromSampleTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ComputePCAShapeFromSample)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/ImageStatistics/StatisticalPropertiesOfRegions/CMakeLists.txt
+++ b/src/Filtering/ImageStatistics/StatisticalPropertiesOfRegions/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(StatisticalPropertiesOfRegions Code.cxx)
-target_link_libraries(StatisticalPropertiesOfRegions ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS StatisticalPropertiesOfRegions
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/ImageStatistics
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME StatisticalPropertiesOfRegionsTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/StatisticalPropertiesOfRegions)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/LabelMap/ApplyMorphologicalClosingOnAllLabelObjects/CMakeLists.txt
+++ b/src/Filtering/LabelMap/ApplyMorphologicalClosingOnAllLabelObjects/CMakeLists.txt
@@ -4,10 +4,10 @@ project(ApplyMorphologicalClosingOnAllLabelObjects)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ApplyMorphologicalClosingOnAllLabelObjects Code.cxx)
-target_link_libraries(ApplyMorphologicalClosingOnAllLabelObjects ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ApplyMorphologicalClosingOnAllLabelObjects
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap
   COMPONENT Runtime
   )
@@ -19,7 +19,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ApplyMorphologicalClosingOnAllLabelObjectsTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ApplyMorphologicalClosingOnAllLabelObjects
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/2th_cthead1.png
     Output.png
     1

--- a/src/Filtering/LabelMap/ApplyMorphologicalClosingOnSpecificLabelObject/CMakeLists.txt
+++ b/src/Filtering/LabelMap/ApplyMorphologicalClosingOnSpecificLabelObject/CMakeLists.txt
@@ -4,10 +4,10 @@ project(ApplyMorphologicalClosingOnSpecificLabelObject)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ApplyMorphologicalClosingOnSpecificLabelObject Code.cxx)
-target_link_libraries(ApplyMorphologicalClosingOnSpecificLabelObject ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ApplyMorphologicalClosingOnSpecificLabelObject
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap
   COMPONENT Runtime
   )
@@ -19,7 +19,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ApplyMorphologicalClosingOnSpecificLabelObjectTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ApplyMorphologicalClosingOnSpecificLabelObject
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/2th_cthead1.png
     Output.png
     100

--- a/src/Filtering/LabelMap/ConvertImageToLabelMap/CMakeLists.txt
+++ b/src/Filtering/LabelMap/ConvertImageToLabelMap/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ConvertImageToLabelMap Code.cxx)
-target_link_libraries(ConvertImageToLabelMap ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ConvertImageToLabelMap
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ConvertImageToLabelMapTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ConvertImageToLabelMap)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/LabelMap/ConvertImageWithLabelsToShapeLabelMap/CMakeLists.txt
+++ b/src/Filtering/LabelMap/ConvertImageWithLabelsToShapeLabelMap/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ConvertImageWithLabelsToShapeLabelMap Code.cxx)
-target_link_libraries(ConvertImageWithLabelsToShapeLabelMap ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ConvertImageWithLabelsToShapeLabelMap
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ConvertImageWithLabelsToShapeLabelMapTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ConvertImageWithLabelsToShapeLabelMap)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/LabelMap/ConvertLabelMapToImage/CMakeLists.txt
+++ b/src/Filtering/LabelMap/ConvertLabelMapToImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ConvertLabelMapToImage Code.cxx)
-target_link_libraries(ConvertLabelMapToImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ConvertLabelMapToImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ConvertLabelMapToImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ConvertLabelMapToImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/LabelMap/ExtractGivenLabelObject/CMakeLists.txt
+++ b/src/Filtering/LabelMap/ExtractGivenLabelObject/CMakeLists.txt
@@ -4,10 +4,10 @@ project(ExtractGivenLabelObject)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ExtractGivenLabelObject Code.cxx)
-target_link_libraries(ExtractGivenLabelObject ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ExtractGivenLabelObject
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap
   COMPONENT Runtime
   )
@@ -19,7 +19,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ExtractGivenLabelObjectTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ExtractGivenLabelObject
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/2th_cthead1.png
     Output1.png
     Output2.png

--- a/src/Filtering/LabelMap/InvertImageUsingBinaryNot/CMakeLists.txt
+++ b/src/Filtering/LabelMap/InvertImageUsingBinaryNot/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(InvertImageUsingBinaryNot Code.cxx)
-target_link_libraries(InvertImageUsingBinaryNot ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS InvertImageUsingBinaryNot
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME InvertImageUsingBinaryNotTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/InvertImageUsingBinaryNot)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/LabelMap/KeepBinaryRegionsThatMeetSpecific/CMakeLists.txt
+++ b/src/Filtering/LabelMap/KeepBinaryRegionsThatMeetSpecific/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(KeepBinaryRegionsThatMeetSpecific Code.cxx)
-target_link_libraries(KeepBinaryRegionsThatMeetSpecific ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS KeepBinaryRegionsThatMeetSpecific
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap
   COMPONENT Runtime
   )
@@ -22,6 +22,6 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME KeepBinaryRegionsThatMeetSpecificTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/KeepBinaryRegionsThatMeetSpecific
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   )
 

--- a/src/Filtering/LabelMap/KeepRegionsAboveLevel/CMakeLists.txt
+++ b/src/Filtering/LabelMap/KeepRegionsAboveLevel/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(KeepRegionsAboveLevel Code.cxx)
-target_link_libraries(KeepRegionsAboveLevel ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS KeepRegionsAboveLevel
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME KeepRegionsAboveLevelTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/KeepRegionsAboveLevel
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   )

--- a/src/Filtering/LabelMap/KeepRegionsThatMeetSpecific/CMakeLists.txt
+++ b/src/Filtering/LabelMap/KeepRegionsThatMeetSpecific/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(KeepRegionsThatMeetSpecific Code.cxx)
-target_link_libraries(KeepRegionsThatMeetSpecific ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS KeepRegionsThatMeetSpecific
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME KeepRegionsThatMeetSpecificTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/KeepRegionsThatMeetSpecific
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   )

--- a/src/Filtering/LabelMap/LabelBinaryRegionsAndGetProperties/CMakeLists.txt
+++ b/src/Filtering/LabelMap/LabelBinaryRegionsAndGetProperties/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(LabelBinaryRegionsAndGetProperties Code.cxx)
-target_link_libraries(LabelBinaryRegionsAndGetProperties ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS LabelBinaryRegionsAndGetProperties
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME LabelBinaryRegionsAndGetPropertiesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/LabelBinaryRegionsAndGetProperties)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/LabelMap/LabelBinaryRegionsInImage/CMakeLists.txt
+++ b/src/Filtering/LabelMap/LabelBinaryRegionsInImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(LabelBinaryRegionsInImage Code.cxx)
-target_link_libraries(LabelBinaryRegionsInImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS LabelBinaryRegionsInImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME LabelBinaryRegionsInImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/LabelBinaryRegionsInImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/LabelMap/MaskOneImageGivenLabelMap/CMakeLists.txt
+++ b/src/Filtering/LabelMap/MaskOneImageGivenLabelMap/CMakeLists.txt
@@ -5,10 +5,10 @@ project(MaskOneImageGivenLabelMap)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(MaskOneImageGivenLabelMap Code.cxx)
-target_link_libraries(MaskOneImageGivenLabelMap ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS MaskOneImageGivenLabelMap
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap
   COMPONENT Runtime
   )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME MaskOneImageGivenLabelMapTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MaskOneImageGivenLabelMap
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/cthead1.png
     ${CMAKE_CURRENT_BINARY_DIR}/2th_cthead1.png
     ${CMAKE_CURRENT_BINARY_DIR}/Output1.png
@@ -28,7 +28,7 @@ add_test(NAME MaskOneImageGivenLabelMapTest
     0
 )
 add_test(NAME MaskOneImageGivenLabelMapTestNegateCrop
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MaskOneImageGivenLabelMap
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/cthead1.png
     ${CMAKE_CURRENT_BINARY_DIR}/2th_cthead1.png
     ${CMAKE_CURRENT_BINARY_DIR}/Output2.png

--- a/src/Filtering/LabelMap/MergeLabelMaps/CMakeLists.txt
+++ b/src/Filtering/LabelMap/MergeLabelMaps/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(MergeLabelMaps Code.cxx)
-target_link_libraries(MergeLabelMaps ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS MergeLabelMaps
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME MergeLabelMapsTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MergeLabelMaps)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/LabelMap/RemoveHolesNotConnectedToImageBoundaries/CMakeLists.txt
+++ b/src/Filtering/LabelMap/RemoveHolesNotConnectedToImageBoundaries/CMakeLists.txt
@@ -8,10 +8,10 @@ project(RemoveHolesNotConnectedToImageBoundaries)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(RemoveHolesNotConnectedToImageBoundaries Code.cxx)
-target_link_libraries(RemoveHolesNotConnectedToImageBoundaries ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS RemoveHolesNotConnectedToImageBoundaries
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap/
   COMPONENT Runtime
   )
@@ -23,7 +23,7 @@ install(FILES Code.cxx CMakeLists.txt Code.py
 
 enable_testing()
 add_test(NAME RemoveHolesNotConnectedToImageBoundariesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/RemoveHolesNotConnectedToImageBoundaries
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   ${input_image}
   ${output_image}
 )

--- a/src/Filtering/LabelMap/RemoveLabelsFromLabelMap/CMakeLists.txt
+++ b/src/Filtering/LabelMap/RemoveLabelsFromLabelMap/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(RemoveLabelsFromLabelMap Code.cxx)
-target_link_libraries(RemoveLabelsFromLabelMap ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS RemoveLabelsFromLabelMap
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME RemoveLabelsFromLabelMapTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/RemoveLabelsFromLabelMap
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   )

--- a/src/Filtering/LabelMap/ShapeAttributesForBinaryImage/CMakeLists.txt
+++ b/src/Filtering/LabelMap/ShapeAttributesForBinaryImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ShapeAttributesForBinaryImage Code.cxx)
-target_link_libraries(ShapeAttributesForBinaryImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ShapeAttributesForBinaryImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/LabelMap
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ShapeAttributesForBinaryImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ShapeAttributesForBinaryImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/MathematicalMorphology/CreateABinaryBallStructuringElement/CMakeLists.txt
+++ b/src/Filtering/MathematicalMorphology/CreateABinaryBallStructuringElement/CMakeLists.txt
@@ -5,10 +5,10 @@ project(CreateABinaryBallStructuringElement)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(CreateABinaryBallStructuringElement Code.cxx)
-target_link_libraries(CreateABinaryBallStructuringElement ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateABinaryBallStructuringElement
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/MathematicalMorphology
   COMPONENT Runtime
 )
@@ -20,4 +20,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CreateABinaryBallStructuringElementTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateABinaryBallStructuringElement)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/MathematicalMorphology/DilateAGrayscaleImage/CMakeLists.txt
+++ b/src/Filtering/MathematicalMorphology/DilateAGrayscaleImage/CMakeLists.txt
@@ -11,10 +11,10 @@ find_package(ITK REQUIRED
   )
 include(${ITK_USE_FILE})
 
-add_executable(DilateAGrayscaleImage Code.cxx)
-target_link_libraries(DilateAGrayscaleImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS DilateAGrayscaleImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/MathematicalMorphology
   COMPONENT Runtime
 )
@@ -26,7 +26,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME DilateAGrayscaleImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/DilateAGrayscaleImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/cthead1.png
     Output.png
     5

--- a/src/Filtering/MathematicalMorphology/ErodeAGrayscaleImage/CMakeLists.txt
+++ b/src/Filtering/MathematicalMorphology/ErodeAGrayscaleImage/CMakeLists.txt
@@ -11,10 +11,10 @@ find_package(ITK REQUIRED
   )
 include(${ITK_USE_FILE})
 
-add_executable(ErodeAGrayscaleImage Code.cxx)
-target_link_libraries(ErodeAGrayscaleImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ErodeAGrayscaleImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/MathematicalMorphology
   COMPONENT Runtime
 )
@@ -26,7 +26,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ErodeAGrayscaleImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ErodeAGrayscaleImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/cthead1.png
     Output.png
     5

--- a/src/Filtering/MathematicalMorphology/ErodeBinaryImageUsingFlatStruct/CMakeLists.txt
+++ b/src/Filtering/MathematicalMorphology/ErodeBinaryImageUsingFlatStruct/CMakeLists.txt
@@ -17,8 +17,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(ErodeBinaryImageUsingFlatStruct Code.cxx)
-  target_link_libraries(ErodeBinaryImageUsingFlatStruct ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -27,11 +27,11 @@ if(ENABLE_QUICKVIEW)
       )
    endif()
 else()
-  add_executable(ErodeBinaryImageUsingFlatStruct Code.cxx)
-  target_link_libraries(ErodeBinaryImageUsingFlatStruct ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS ErodeBinaryImageUsingFlatStruct
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/MathematicalMorphology
   COMPONENT Runtime
   )
@@ -44,6 +44,6 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ErodeBinaryImageUsingFlatStructTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ErodeBinaryImageUsingFlatStruct
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     Yinyang.png
     7)

--- a/src/Filtering/MathematicalMorphology/GenerateStructureElementsWithAccurateArea/CMakeLists.txt
+++ b/src/Filtering/MathematicalMorphology/GenerateStructureElementsWithAccurateArea/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(GenerateStructureElementsWithAccurateArea Code.cxx)
-target_link_libraries(GenerateStructureElementsWithAccurateArea ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS GenerateStructureElementsWithAccurateArea
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/MathematicalMorphology
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME GenerateStructureElementsWithAccurateAreaTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/GenerateStructureElementsWithAccurateArea)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/MathematicalMorphology/RegionalMaximal/CMakeLists.txt
+++ b/src/Filtering/MathematicalMorphology/RegionalMaximal/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(RegionalMaximal Code.cxx)
-target_link_libraries(RegionalMaximal ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS RegionalMaximal
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/MathematicalMorphology
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME RegionalMaximalTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/RegionalMaximal)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/MathematicalMorphology/RegionalMinimal/CMakeLists.txt
+++ b/src/Filtering/MathematicalMorphology/RegionalMinimal/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(RegionalMinimal Code.cxx)
-target_link_libraries(RegionalMinimal ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS RegionalMinimal
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/MathematicalMorphology
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME RegionalMinimalTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/RegionalMinimal)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/MathematicalMorphology/ValuedRegionalMaximaImage/CMakeLists.txt
+++ b/src/Filtering/MathematicalMorphology/ValuedRegionalMaximaImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ValuedRegionalMaximaImage Code.cxx)
-target_link_libraries(ValuedRegionalMaximaImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ValuedRegionalMaximaImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/MathematicalMorphology
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ValuedRegionalMaximaImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ValuedRegionalMaximaImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/MathematicalMorphology/ValuedRegionalMinimalImage/CMakeLists.txt
+++ b/src/Filtering/MathematicalMorphology/ValuedRegionalMinimalImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ValuedRegionalMinimalImage Code.cxx)
-target_link_libraries(ValuedRegionalMinimalImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ValuedRegionalMinimalImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/MathematicalMorphology
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ValuedRegionalMinimalImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ValuedRegionalMinimalImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/Path/DataStructureForPieceWiseLinearCurve/CMakeLists.txt
+++ b/src/Filtering/Path/DataStructureForPieceWiseLinearCurve/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(DataStructureForPieceWiseLinearCurve Code.cxx)
-target_link_libraries(DataStructureForPieceWiseLinearCurve ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS DataStructureForPieceWiseLinearCurve
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Path
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME DataStructureForPieceWiseLinearCurveTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/DataStructureForPieceWiseLinearCurve)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/Path/ExtractContoursFromImage/CMakeLists.txt
+++ b/src/Filtering/Path/ExtractContoursFromImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ExtractContoursFromImage Code.cxx)
-target_link_libraries(ExtractContoursFromImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ExtractContoursFromImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Path
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ExtractContoursFromImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ExtractContoursFromImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/QuadEdgeMeshFiltering/CleanQuadEdgeMesh/CMakeLists.txt
+++ b/src/Filtering/QuadEdgeMeshFiltering/CleanQuadEdgeMesh/CMakeLists.txt
@@ -5,10 +5,10 @@ project(CleanQuadEdgeMesh)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(CleanQuadEdgeMesh Code.cxx)
-target_link_libraries(CleanQuadEdgeMesh ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CleanQuadEdgeMesh
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/QuadEdgeMeshFiltering
   COMPONENT Runtime
 )
@@ -20,4 +20,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CleanQuadEdgeMeshTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CleanQuadEdgeMesh)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Filtering/QuadEdgeMeshFiltering/ComputeNormalsOfAMesh/CMakeLists.txt
+++ b/src/Filtering/QuadEdgeMeshFiltering/ComputeNormalsOfAMesh/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ComputeNormalsOfAMesh)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ComputeNormalsOfAMesh Code.cxx)
-target_link_libraries(ComputeNormalsOfAMesh ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ComputeNormalsOfAMesh
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/QuadEdgeMeshFiltering
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ComputeNormalsOfAMeshTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ComputeNormalsOfAMesh
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/genusZeroSurface01.vtk
     0
 )

--- a/src/Filtering/QuadEdgeMeshFiltering/ComputePlanarParameterizationOfAMesh/CMakeLists.txt
+++ b/src/Filtering/QuadEdgeMeshFiltering/ComputePlanarParameterizationOfAMesh/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ComputePlanarParameterizationOfAMesh)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ComputePlanarParameterizationOfAMesh Code.cxx)
-target_link_libraries(ComputePlanarParameterizationOfAMesh ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ComputePlanarParameterizationOfAMesh
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/QuadEdgeMeshFiltering
   COMPONENT Runtime
   )

--- a/src/Filtering/QuadEdgeMeshFiltering/DelaunayConformEdgeFlipping/CMakeLists.txt
+++ b/src/Filtering/QuadEdgeMeshFiltering/DelaunayConformEdgeFlipping/CMakeLists.txt
@@ -5,10 +5,10 @@ project(DelaunayConformEdgeFlipping)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(DelaunayConformEdgeFlipping Code.cxx)
-target_link_libraries(DelaunayConformEdgeFlipping ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS DelaunayConformEdgeFlipping
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/QuadEdgeMeshFiltering
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME DelaunayConformEdgeFlippingTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/DelaunayConformEdgeFlipping
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   mushroom.vtk
   Output.vtk
 )

--- a/src/Filtering/Smoothing/BlurringAnImageUsingABinomialKernel/CMakeLists.txt
+++ b/src/Filtering/Smoothing/BlurringAnImageUsingABinomialKernel/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(BlurringAnImageUsingABinomialKernel Code.cxx)
-target_link_libraries(BlurringAnImageUsingABinomialKernel ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS BlurringAnImageUsingABinomialKernel
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Smoothing
   COMPONENT Runtime
   )
@@ -26,7 +26,7 @@ set(output_image Output.png)
 set(test_options 5)
 
 add_test(NAME BlurringAnImageUsingABinomialKernelTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/BlurringAnImageUsingABinomialKernel
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
     ${output_image}
     ${test_options}

--- a/src/Filtering/Smoothing/ComputesSmoothingWithGaussianKernel/CMakeLists.txt
+++ b/src/Filtering/Smoothing/ComputesSmoothingWithGaussianKernel/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ComputesSmoothingWithGaussianKernel)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ComputesSmoothingWithGaussianKernel Code.cxx)
-target_link_libraries(ComputesSmoothingWithGaussianKernel ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ComputesSmoothingWithGaussianKernel
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Smoothing
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ComputesSmoothingWithGaussianKernelTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ComputesSmoothingWithGaussianKernel
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/BrainProtonDensitySlice.png
     Output.png
     3

--- a/src/Filtering/Smoothing/FindHigherDerivativesOfImage/CMakeLists.txt
+++ b/src/Filtering/Smoothing/FindHigherDerivativesOfImage/CMakeLists.txt
@@ -17,8 +17,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(FindHigherDerivativesOfImage Code.cxx)
-  target_link_libraries(FindHigherDerivativesOfImage ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -27,11 +27,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(FindHigherDerivativesOfImage Code.cxx)
-  target_link_libraries(FindHigherDerivativesOfImage ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS FindHigherDerivativesOfImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Smoothing
   COMPONENT Runtime
   )
@@ -44,5 +44,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME FindHigherDerivativesOfImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/FindHigherDerivativesOfImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     Yinyang.png)

--- a/src/Filtering/Smoothing/MeanFilteringOfAnImage/CMakeLists.txt
+++ b/src/Filtering/Smoothing/MeanFilteringOfAnImage/CMakeLists.txt
@@ -5,10 +5,10 @@ project(MeanFilteringOfAnImage)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(MeanFilteringOfAnImage Code.cxx)
-target_link_libraries(MeanFilteringOfAnImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS MeanFilteringOfAnImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Smoothing
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME MeanFilteringOfAnImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MeanFilteringOfAnImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/Gourds.png
     Output.png
     2

--- a/src/Filtering/Smoothing/MedianFilteringOfAnImage/CMakeLists.txt
+++ b/src/Filtering/Smoothing/MedianFilteringOfAnImage/CMakeLists.txt
@@ -5,10 +5,10 @@ project(MedianFilteringOfAnImage)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(MedianFilteringOfAnImage Code.cxx)
-target_link_libraries(MedianFilteringOfAnImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS MedianFilteringOfAnImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Smoothing
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME MedianFilteringOfAnImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MedianFilteringOfAnImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/Gourds.png
     Output.png
     2

--- a/src/Filtering/Smoothing/MedianFilteringOfAnRGBImage/CMakeLists.txt
+++ b/src/Filtering/Smoothing/MedianFilteringOfAnRGBImage/CMakeLists.txt
@@ -5,10 +5,10 @@ project(MedianFilteringOfAnRGBImage)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(MedianFilteringOfAnRGBImage Code.cxx)
-target_link_libraries(MedianFilteringOfAnRGBImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS MedianFilteringOfAnRGBImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Smoothing
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME MedianFilteringOfAnRGBImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MedianFilteringOfAnRGBImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/GourdsRGB.png
     Output.png
     2

--- a/src/Filtering/Smoothing/SmoothImageWithDiscreteGaussianFilter/CMakeLists.txt
+++ b/src/Filtering/Smoothing/SmoothImageWithDiscreteGaussianFilter/CMakeLists.txt
@@ -17,8 +17,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(SmoothImageWithDiscreteGaussianFilter Code.cxx)
-  target_link_libraries(SmoothImageWithDiscreteGaussianFilter ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -27,11 +27,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(SmoothImageWithDiscreteGaussianFilter Code.cxx)
-  target_link_libraries(SmoothImageWithDiscreteGaussianFilter ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS SmoothImageWithDiscreteGaussianFilter
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Smoothing
   COMPONENT Runtime
   )
@@ -44,6 +44,6 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME SmoothImageWithDiscreteGaussianFilterTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SmoothImageWithDiscreteGaussianFilter
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     Yinyang.png
     8)

--- a/src/Filtering/Thresholding/DemonstrateThresholdAlgorithms/CMakeLists.txt
+++ b/src/Filtering/Thresholding/DemonstrateThresholdAlgorithms/CMakeLists.txt
@@ -17,8 +17,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(DemonstrateThresholdAlgorithms Code.cxx)
-  target_link_libraries(DemonstrateThresholdAlgorithms ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -27,11 +27,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(DemonstrateThresholdAlgorithms Code.cxx)
-  target_link_libraries(DemonstrateThresholdAlgorithms ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS DemonstrateThresholdAlgorithms
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Thresholding
   COMPONENT Runtime
   )
@@ -44,5 +44,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME DemonstrateThresholdAlgorithmsTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/DemonstrateThresholdAlgorithms
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     Yinyang.png)

--- a/src/Filtering/Thresholding/SeparateGroundUsingOtsu/CMakeLists.txt
+++ b/src/Filtering/Thresholding/SeparateGroundUsingOtsu/CMakeLists.txt
@@ -17,8 +17,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(SeparateGroundUsingOtsu Code.cxx)
-  target_link_libraries(SeparateGroundUsingOtsu ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -27,11 +27,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(SeparateGroundUsingOtsu Code.cxx)
-  target_link_libraries(SeparateGroundUsingOtsu ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS SeparateGroundUsingOtsu
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Thresholding
   COMPONENT Runtime
   )
@@ -44,5 +44,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME SeparateGroundUsingOtsuTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SeparateGroundUsingOtsu)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Filtering/Thresholding/ThresholdAnImage/CMakeLists.txt
+++ b/src/Filtering/Thresholding/ThresholdAnImage/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ThresholdAnImage)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ThresholdAnImage Code.cxx)
-target_link_libraries(ThresholdAnImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ThresholdAnImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Thresholding
   COMPONENT Runtime
   )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ThresholdAnImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ThresholdAnImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/Gourds.png
     ${CMAKE_CURRENT_BINARY_DIR}/Output.png
     64

--- a/src/Filtering/Thresholding/ThresholdAnImageUsingBinary/CMakeLists.txt
+++ b/src/Filtering/Thresholding/ThresholdAnImageUsingBinary/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ThresholdAnImageUsingBinary)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ThresholdAnImageUsingBinary Code.cxx)
-target_link_libraries(ThresholdAnImageUsingBinary ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ThresholdAnImageUsingBinary
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Thresholding
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ThresholdAnImageUsingBinaryTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ThresholdAnImageUsingBinary
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/cthead1.png
     Output.png
     50

--- a/src/Filtering/Thresholding/ThresholdAnImageUsingOtsu/CMakeLists.txt
+++ b/src/Filtering/Thresholding/ThresholdAnImageUsingOtsu/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ThresholdAnImageUsingOtsu)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ThresholdAnImageUsingOtsu Code.cxx)
-target_link_libraries(ThresholdAnImageUsingOtsu ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ThresholdAnImageUsingOtsu
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/Thresholding
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ThresholdAnImageUsingOtsuTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ThresholdAnImageUsingOtsu
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/Gourds.png
     Output.png
     64

--- a/src/IO/GDCM/ReadAndPrintDICOMTags/CMakeLists.txt
+++ b/src/IO/GDCM/ReadAndPrintDICOMTags/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ReadAndPrintDICOMTags)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ReadAndPrintDICOMTags Code.cxx)
-target_link_libraries(ReadAndPrintDICOMTags ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ReadAndPrintDICOMTags
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/GDCM
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt Code.py
 
 enable_testing()
 add_test(NAME ReadAndPrintDICOMTagsTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ReadAndPrintDICOMTags
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   "${CMAKE_CURRENT_BINARY_DIR}"
 )
 

--- a/src/IO/GDCM/ReadDICOMSeriesAndWrite3DImage/CMakeLists.txt
+++ b/src/IO/GDCM/ReadDICOMSeriesAndWrite3DImage/CMakeLists.txt
@@ -4,10 +4,10 @@ project(ReadDICOMSeriesAndWrite3DImage)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ReadDICOMSeriesAndWrite3DImage Code.cxx)
-target_link_libraries(ReadDICOMSeriesAndWrite3DImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ReadDICOMSeriesAndWrite3DImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/GDCM
   COMPONENT Runtime
   )
@@ -19,7 +19,7 @@ install(FILES Code.cxx CMakeLists.txt Code.py
 
 enable_testing()
 add_test(NAME ReadDICOMSeriesAndWrite3DImage
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ReadDICOMSeriesAndWrite3DImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     "${CMAKE_CURRENT_BINARY_DIR}"
     "${CMAKE_CURRENT_BINARY_DIR}/Image3D.nrrd"
     )

--- a/src/IO/GDCM/ResampleDICOMSeries/CMakeLists.txt
+++ b/src/IO/GDCM/ResampleDICOMSeries/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ResampleDICOMSeries Code.cxx)
-target_link_libraries(ResampleDICOMSeries ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ResampleDICOMSeries
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/GDCM
   COMPONENT Runtime
   )
@@ -22,6 +22,6 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ResampleDICOMSeriesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ResampleDICOMSeries
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
 
   )

--- a/src/IO/ImageBase/ConvertFileFormats/CMakeLists.txt
+++ b/src/IO/ImageBase/ConvertFileFormats/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ConvertFileFormats)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ConvertFileFormats Code.cxx)
-target_link_libraries(ConvertFileFormats ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ConvertFileFormats
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/ImageBase
   COMPONENT Runtime
   )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ConvertFileFormatsTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ConvertFileFormats
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/Gourds.png
     ${CMAKE_CURRENT_BINARY_DIR}/Output.jpg
   )

--- a/src/IO/ImageBase/ConvertImageToAnotherType/CMakeLists.txt
+++ b/src/IO/ImageBase/ConvertImageToAnotherType/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ConvertImageToAnotherType Code.cxx)
-target_link_libraries(ConvertImageToAnotherType ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ConvertImageToAnotherType
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/ImageBase
   COMPONENT Runtime
   )
@@ -21,6 +21,6 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ConvertImageToAnotherTypeTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ConvertImageToAnotherType
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   )
 

--- a/src/IO/ImageBase/Create3DFromSeriesOf2D/CMakeLists.txt
+++ b/src/IO/ImageBase/Create3DFromSeriesOf2D/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(Create3DFromSeriesOf2D Code.cxx)
-target_link_libraries(Create3DFromSeriesOf2D ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS Create3DFromSeriesOf2D
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/ImageBase
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME Create3DFromSeriesOf2DTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Create3DFromSeriesOf2D)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/IO/ImageBase/CreateAListOfFileNames/CMakeLists.txt
+++ b/src/IO/ImageBase/CreateAListOfFileNames/CMakeLists.txt
@@ -5,10 +5,10 @@ project(CreateAListOfFileNames)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(CreateAListOfFileNames Code.cxx)
-target_link_libraries(CreateAListOfFileNames ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateAListOfFileNames
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/ImageBase
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CreateAListOfFileNamesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateAListOfFileNames)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 
 if(ITK_WRAP_PYTHON)
 add_test(NAME CreateAListOfFileNamesTestPython

--- a/src/IO/ImageBase/GenerateSlicesFromVolume/CMakeLists.txt
+++ b/src/IO/ImageBase/GenerateSlicesFromVolume/CMakeLists.txt
@@ -15,10 +15,10 @@ find_package(ITK REQUIRED
   )
 include(${ITK_USE_FILE})
 
-add_executable(GenerateSlicesFromVolume Code.cxx)
-target_link_libraries(GenerateSlicesFromVolume ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS GenerateSlicesFromVolume
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/ImageBase/
   COMPONENT Runtime
   )
@@ -31,7 +31,7 @@ install(FILES Code.cxx CMakeLists.txt Code.py
 enable_testing()
 
 add_test(NAME GenerateSlicesFromVolumeTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/GenerateSlicesFromVolume
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
     ${output_image}
 )

--- a/src/IO/ImageBase/ProcessImageChunks/CMakeLists.txt
+++ b/src/IO/ImageBase/ProcessImageChunks/CMakeLists.txt
@@ -12,10 +12,10 @@ find_package(ITK REQUIRED
   )
 include(${ITK_USE_FILE})
 
-add_executable(ProcessImageChunks Code.cxx)
-target_link_libraries(ProcessImageChunks ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ProcessImageChunks
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/ImageBase/
   COMPONENT Runtime
   )
@@ -28,7 +28,7 @@ install(FILES Code.cxx CMakeLists.txt Code.py
 enable_testing()
 
 add_test(NAME ProcessImageChunksTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ProcessImageChunks
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/Gourds.png
     Output.mha
 )

--- a/src/IO/ImageBase/ReadAnImage/CMakeLists.txt
+++ b/src/IO/ImageBase/ReadAnImage/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ReadAnImage)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ReadAnImage Code.cxx)
-target_link_libraries(ReadAnImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ReadAnImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/ImageBase/
   COMPONENT Runtime
   )
@@ -22,7 +22,7 @@ set(input_image ${CMAKE_CURRENT_BINARY_DIR}/Yinyang.png)
 
 enable_testing()
 add_test(NAME ReadAnImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ReadAnImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
   )
 

--- a/src/IO/ImageBase/ReadUnknownImageType/CMakeLists.txt
+++ b/src/IO/ImageBase/ReadUnknownImageType/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ReadUnknownImageType)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ReadUnknownImageType Code.cxx)
-target_link_libraries(ReadUnknownImageType ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ReadUnknownImageType
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/ImageBase
   COMPONENT Runtime
   )
@@ -20,11 +20,11 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ReadUnknownImageTypeTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ReadUnknownImageType
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/Gourds.png
   )
 
 add_test(NAME ReadUnknownImageTypeTest1
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ReadUnknownImageType
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/HeadMRVolume.mha
   )

--- a/src/IO/ImageBase/RegisterIOFactories/CMakeLists.txt
+++ b/src/IO/ImageBase/RegisterIOFactories/CMakeLists.txt
@@ -9,10 +9,10 @@ find_package(ITK REQUIRED)
 set(ITK_NO_IMAGEIO_FACTORY_REGISTER_MANAGER 1)
 include(${ITK_USE_FILE})
 
-add_executable(RegisterIOFactories Code.cxx)
-target_link_libraries(RegisterIOFactories ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS RegisterIOFactories
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/ImageBase
   COMPONENT Runtime
   )
@@ -24,7 +24,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME RegisterIOFactoriesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/RegisterIOFactories
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/HeadMRVolume.mha
     ${CMAKE_CURRENT_BINARY_DIR}/Yinyang.png
   )

--- a/src/IO/ImageBase/WriteAnImage/CMakeLists.txt
+++ b/src/IO/ImageBase/WriteAnImage/CMakeLists.txt
@@ -5,10 +5,10 @@ project(WriteAnImage)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(WriteAnImage Code.cxx)
-target_link_libraries(WriteAnImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS WriteAnImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Base/
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME WriteAnImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/WriteAnImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 
 if(ITK_WRAP_PYTHON)
   add_test(NAME WriteAnImageTestPython

--- a/src/IO/Mesh/ReadMesh/CMakeLists.txt
+++ b/src/IO/Mesh/ReadMesh/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ReadMesh)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ReadMesh Code.cxx)
-target_link_libraries(ReadMesh ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ReadMesh
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/Mesh
   COMPONENT Runtime
   )
@@ -21,6 +21,6 @@ install(FILES Code.cxx CMakeLists.txt
 enable_testing()
 
 add_test(NAME ReadMeshTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ReadMesh
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/genusZeroSurface01.vtk 0 25
 )

--- a/src/IO/TIFF/WriteATIFFImage/CMakeLists.txt
+++ b/src/IO/TIFF/WriteATIFFImage/CMakeLists.txt
@@ -5,10 +5,10 @@ project(WriteATIFFImage)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(WriteATIFFImage Code.cxx)
-target_link_libraries(WriteATIFFImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS WriteATIFFImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/TIFF/
   COMPONENT Runtime
 )
@@ -20,5 +20,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME WriteATIFFImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/WriteATIFFImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/Output.tif)

--- a/src/IO/TransformBase/ReadTransformFromFile/CMakeLists.txt
+++ b/src/IO/TransformBase/ReadTransformFromFile/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ReadTransformFromFile Code.cxx)
-target_link_libraries(ReadTransformFromFile ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ReadTransformFromFile
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/TransformBase
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ReadTransformFromFileTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ReadTransformFromFile)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/IO/TransformBase/WriteTransformToFile/CMakeLists.txt
+++ b/src/IO/TransformBase/WriteTransformToFile/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(WriteTransfromFromFile Code.cxx)
-target_link_libraries(WriteTransfromFromFile ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS WriteTransfromFromFile
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/TransformBase
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME WriteTransfromFromFileTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/WriteTransfromFromFile
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   )

--- a/src/IO/TransformFactory/RegisterTransformWithTransformFactory/CMakeLists.txt
+++ b/src/IO/TransformFactory/RegisterTransformWithTransformFactory/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(RegisterTransformWithTransformFactory Code.cxx)
-target_link_libraries(RegisterTransformWithTransformFactory ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS RegisterTransformWithTransformFactory
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/IO/TransformFactory
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt Code.py
 
 enable_testing()
 add_test(NAME RegisterTransformWithTransformFactoryTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/RegisterTransformWithTransformFactory)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Nonunit/Review/GeometricPropertiesOfRegion/CMakeLists.txt
+++ b/src/Nonunit/Review/GeometricPropertiesOfRegion/CMakeLists.txt
@@ -17,8 +17,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(GeometricPropertiesOfRegion Code.cxx)
-  target_link_libraries(GeometricPropertiesOfRegion ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -27,11 +27,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(GeometricPropertiesOfRegion Code.cxx)
-  target_link_libraries(GeometricPropertiesOfRegion ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS GeometricPropertiesOfRegion
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Nonunit/Review
   COMPONENT Runtime
   )
@@ -44,5 +44,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME GeometricPropertiesOfRegionTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/GeometricPropertiesOfRegion)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Nonunit/Review/MultiphaseChanAndVeseSparseFieldLevelSetSegmentation/CMakeLists.txt
+++ b/src/Nonunit/Review/MultiphaseChanAndVeseSparseFieldLevelSetSegmentation/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(MultiphaseChanAndVeseSparseFieldLevelSetSegmentation Code.cxx)
-target_link_libraries(MultiphaseChanAndVeseSparseFieldLevelSetSegmentation ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS MultiphaseChanAndVeseSparseFieldLevelSetSegmentation
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Nonunit/Review
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME MultiphaseChanAndVeseSparseFieldLevelSetSegmentationTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MultiphaseChanAndVeseSparseFieldLevelSetSegmentation)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Nonunit/Review/SegmentBloodVesselsWithMultiScaleHessianBasedMeasure/CMakeLists.txt
+++ b/src/Nonunit/Review/SegmentBloodVesselsWithMultiScaleHessianBasedMeasure/CMakeLists.txt
@@ -5,10 +5,10 @@ project(SegmentBloodVesselsWithMultiScaleHessianBasedMeasure)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(SegmentBloodVesselsWithMultiScaleHessianBasedMeasure Code.cxx)
-target_link_libraries(SegmentBloodVesselsWithMultiScaleHessianBasedMeasure ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS SegmentBloodVesselsWithMultiScaleHessianBasedMeasure
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Nonunit/Review
   COMPONENT Runtime
   )
@@ -27,7 +27,7 @@ set(sigma_maximum 6.0)
 set(number_of_sigma_steps 3)
 
 add_test(NAME SegmentBloodVesselsWithMultiScaleHessianBasedMeasureTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SegmentBloodVesselsWithMultiScaleHessianBasedMeasure
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
     ${output_image}
     ${sigma_minimum}

--- a/src/Nonunit/Review/SinglephaseChanAndVeseDenseFieldLevelSetSegmentation/CMakeLists.txt
+++ b/src/Nonunit/Review/SinglephaseChanAndVeseDenseFieldLevelSetSegmentation/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(SinglephaseChanAndVeseDenseFieldLevelSetSegmentation Code.cxx)
-target_link_libraries(SinglephaseChanAndVeseDenseFieldLevelSetSegmentation ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS SinglephaseChanAndVeseDenseFieldLevelSetSegmentation
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Nonunit/Review
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME SinglephaseChanAndVeseDenseFieldLevelSetSegmentationTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SinglephaseChanAndVeseDenseFieldLevelSetSegmentation)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Nonunit/Review/SinglephaseChanAndVeseSparseFieldLevelSetSegmentation/CMakeLists.txt
+++ b/src/Nonunit/Review/SinglephaseChanAndVeseSparseFieldLevelSetSegmentation/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(SinglephaseChanAndVeseSparseFieldLevelSetSegmentation Code.cxx)
-target_link_libraries(SinglephaseChanAndVeseSparseFieldLevelSetSegmentation ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS SinglephaseChanAndVeseSparseFieldLevelSetSegmentation
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Nonunit/Review
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME SinglephaseChanAndVeseSparseFieldLevelSetSegmentationTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SinglephaseChanAndVeseSparseFieldLevelSetSegmentation)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Numerics/Optimizers/AmoebaOptimizer/CMakeLists.txt
+++ b/src/Numerics/Optimizers/AmoebaOptimizer/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(AmoebaOptimizer Code.cxx ExampleCostFunction.h)
-target_link_libraries(AmoebaOptimizer ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx ExampleCostFunction.h)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS AmoebaOptimizer
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Optimizers
   COMPONENT Runtime
   )
@@ -23,5 +23,5 @@ install(FILES Code.cxx CMakeLists.txt
 enable_testing()
 
 add_test(NAME AmoebaOptimizerTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/AmoebaOptimizer
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   )

--- a/src/Numerics/Optimizers/ExhaustiveOptimizer/CMakeLists.txt
+++ b/src/Numerics/Optimizers/ExhaustiveOptimizer/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ExhaustiveOptimizer Code.cxx)
-target_link_libraries(ExhaustiveOptimizer ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ExhaustiveOptimizer
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Optimizers
   COMPONENT Runtime
   )
@@ -26,7 +26,7 @@ set(fixed_image ${CMAKE_CURRENT_BINARY_DIR}/orange.jpg)
 set(moving_image ${CMAKE_CURRENT_BINARY_DIR}/apple.jpg)
 
 add_test(NAME ExhaustiveOptimizerTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ExhaustiveOptimizer
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
 	${fixed_image}
 	${moving_image})
 	

--- a/src/Numerics/Optimizers/LevenbergMarquardtOptimization/CMakeLists.txt
+++ b/src/Numerics/Optimizers/LevenbergMarquardtOptimization/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(LevenbergMarquardtOptimization Code.cxx)
-target_link_libraries(LevenbergMarquardtOptimization ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS LevenbergMarquardtOptimization
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Optimizers
   COMPONENT Runtime
   )
@@ -26,7 +26,7 @@ set(output_image Output.png)
 set(test_options)
 
 add_test(NAME LevenbergMarquardtOptimizationTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/LevenbergMarquardtOptimization
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
     ${output_image}
     ${test_options}

--- a/src/Numerics/Statistics/2DGaussianMixtureModelExpectMax/CMakeLists.txt
+++ b/src/Numerics/Statistics/2DGaussianMixtureModelExpectMax/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(2DGaussianMixtureModelExpectMax Code.cxx)
-target_link_libraries(2DGaussianMixtureModelExpectMax ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS 2DGaussianMixtureModelExpectMax
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Statistics
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME 2DGaussianMixtureModelExpectMaxTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/2DGaussianMixtureModelExpectMax)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Numerics/Statistics/ComputeHistogramFromGrayscaleImage/CMakeLists.txt
+++ b/src/Numerics/Statistics/ComputeHistogramFromGrayscaleImage/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ComputeHistogramFromGrayscaleImage)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ComputeHistogramFromGrayscaleImage Code.cxx)
-target_link_libraries(ComputeHistogramFromGrayscaleImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ComputeHistogramFromGrayscaleImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Statistics
   COMPONENT Runtime
 )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ComputeHistogramFromGrayscaleImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ComputeHistogramFromGrayscaleImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/sf4.png
     16
   )

--- a/src/Numerics/Statistics/ComputeHistogramOfMaskedRegion/CMakeLists.txt
+++ b/src/Numerics/Statistics/ComputeHistogramOfMaskedRegion/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ComputeHistogramOfMaskedRegion Code.cxx)
-target_link_libraries(ComputeHistogramOfMaskedRegion ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ComputeHistogramOfMaskedRegion
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Statistics
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ComputeHistogramOfMaskedRegionTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ComputeHistogramOfMaskedRegion)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Numerics/Statistics/ComputeTextureFeatures/CMakeLists.txt
+++ b/src/Numerics/Statistics/ComputeTextureFeatures/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ComputeTextureFeatures Code.cxx)
-target_link_libraries(ComputeTextureFeatures ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ComputeTextureFeatures
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Statistics
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ComputeTextureFeaturesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ComputeTextureFeatures)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Numerics/Statistics/CreateGaussianDistribution/CMakeLists.txt
+++ b/src/Numerics/Statistics/CreateGaussianDistribution/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(CreateGaussianDistribution Code.cxx)
-target_link_libraries(CreateGaussianDistribution ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateGaussianDistribution
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Statistics
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CreateGaussianDistributionTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateGaussianDistribution)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Numerics/Statistics/CreateHistogramFromListOfMeasurements/CMakeLists.txt
+++ b/src/Numerics/Statistics/CreateHistogramFromListOfMeasurements/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(CreateHistogramFromListOfMeasurements Code.cxx)
-target_link_libraries(CreateHistogramFromListOfMeasurements ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateHistogramFromListOfMeasurements
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Statistics
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CreateHistogramFromListOfMeasurementsTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateHistogramFromListOfMeasurements)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Numerics/Statistics/CreateListOfSampleMeasurements/CMakeLists.txt
+++ b/src/Numerics/Statistics/CreateListOfSampleMeasurements/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(CreateListOfSampleMeasurements Code.cxx)
-target_link_libraries(CreateListOfSampleMeasurements ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateListOfSampleMeasurements
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Statistics
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CreateListOfSampleMeasurementsTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateListOfSampleMeasurements)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Numerics/Statistics/CreateListOfSamplesFromImageWithoutDuplication/CMakeLists.txt
+++ b/src/Numerics/Statistics/CreateListOfSamplesFromImageWithoutDuplication/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(CreateListOfSamplesFromImageWithoutDuplication Code.cxx)
-target_link_libraries(CreateListOfSamplesFromImageWithoutDuplication ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateListOfSamplesFromImageWithoutDuplication
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Statistics
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CreateListOfSamplesFromImageWithoutDuplicationTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateListOfSamplesFromImageWithoutDuplication)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Numerics/Statistics/CreateListOfSamplesWithIDs/CMakeLists.txt
+++ b/src/Numerics/Statistics/CreateListOfSamplesWithIDs/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(CreateListOfSamplesWithIDs Code.cxx)
-target_link_libraries(CreateListOfSamplesWithIDs ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CreateListOfSamplesWithIDs
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Statistics
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CreateListOfSamplesWithIDsTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CreateListOfSamplesWithIDs)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Numerics/Statistics/DistributeSamplingUsingGMM/CMakeLists.txt
+++ b/src/Numerics/Statistics/DistributeSamplingUsingGMM/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(DistributeSamplingUsingGMM Code.cxx)
-target_link_libraries(DistributeSamplingUsingGMM ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS DistributeSamplingUsingGMM
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Statistics
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME DistributeSamplingUsingGMMTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/DistributeSamplingUsingGMM)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Numerics/Statistics/DistributionOfPixelsUsingGMM/CMakeLists.txt
+++ b/src/Numerics/Statistics/DistributionOfPixelsUsingGMM/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(DistributionOfPixelsUsingGMM Code.cxx)
-target_link_libraries(DistributionOfPixelsUsingGMM ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS DistributionOfPixelsUsingGMM
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Statistics
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME DistributionOfPixelsUsingGMMTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/DistributionOfPixelsUsingGMM)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Numerics/Statistics/HistogramCreationAndBinAccess/CMakeLists.txt
+++ b/src/Numerics/Statistics/HistogramCreationAndBinAccess/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(HistogramCreationAndBinAccess Code.cxx)
-target_link_libraries(HistogramCreationAndBinAccess ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS HistogramCreationAndBinAccess
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Statistics
   COMPONENT Runtime
   )
@@ -25,7 +25,7 @@ enable_testing()
 set(HistogramCreationAndBinAccessTest_Regex "Frequency of the bin at index \\[0, 2\\] is 5 and the bin's instance identifier is 6")
 
 add_test(NAME HistogramCreationAndBinAccessTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/HistogramCreationAndBinAccess
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   )
 set_tests_properties(HistogramCreationAndBinAccessTest PROPERTIES
   PASS_REGULAR_EXPRESSION "${HistogramCreationAndBinAccessTest_Regex}")

--- a/src/Numerics/Statistics/SpatialSearch/CMakeLists.txt
+++ b/src/Numerics/Statistics/SpatialSearch/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(SpatialSearch Code.cxx)
-target_link_libraries(SpatialSearch ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS SpatialSearch
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Numerics/Statistics
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME SpatialSearchTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SpatialSearch)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Registration/Common/ComputeMeanSquareBetweenTwoImages/CMakeLists.txt
+++ b/src/Registration/Common/ComputeMeanSquareBetweenTwoImages/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ComputeMeanSquareBetweenTwoImages Code.cxx)
-target_link_libraries(ComputeMeanSquareBetweenTwoImages ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ComputeMeanSquareBetweenTwoImages
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Registration/Common
   COMPONENT Runtime
   )
@@ -22,7 +22,7 @@ install(FILES Code.cxx Code.py CMakeLists.txt
 
 enable_testing()
 add_test(NAME ComputeMeanSquareBetweenTwoImagesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ComputeMeanSquareBetweenTwoImages
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     Yinyang.png
     Gourds.png)
     

--- a/src/Registration/Common/GlobalRegistrationOfTwoImages/CMakeLists.txt
+++ b/src/Registration/Common/GlobalRegistrationOfTwoImages/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(GlobalRegistrationOfTwoImages Code.cxx)
-target_link_libraries(GlobalRegistrationOfTwoImages ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS GlobalRegistrationOfTwoImages
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Registration/Common
   COMPONENT Runtime
   )
@@ -23,7 +23,7 @@ install(FILES Code.cxx CMakeLists.txt
 enable_testing()
 
 add_test(NAME GlobalRegistrationOfTwoImagesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/GlobalRegistrationOfTwoImages)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 
 if( ITK_WRAP_PYTHON )
   add_test( NAME GlobalRegistrationOfTwoImagesTestPython

--- a/src/Registration/Common/MatchFeaturePoints/CMakeLists.txt
+++ b/src/Registration/Common/MatchFeaturePoints/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(MatchFeaturePoints Code.cxx)
-target_link_libraries(MatchFeaturePoints ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS MatchFeaturePoints
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Registration/Common
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME MatchFeaturePointsTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MatchFeaturePoints)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Registration/Common/MultiresolutionPyramidFromImage/CMakeLists.txt
+++ b/src/Registration/Common/MultiresolutionPyramidFromImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(MultiresolutionPyramidFromImage Code.cxx)
-target_link_libraries(MultiresolutionPyramidFromImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS MultiresolutionPyramidFromImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Registration/Common
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME MultiresolutionPyramidFromImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MultiresolutionPyramidFromImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Registration/Common/MutualInformation/CMakeLists.txt
+++ b/src/Registration/Common/MutualInformation/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(MutualInformation Code.cxx)
-target_link_libraries(MutualInformation ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS MutualInformation
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Registration/Common
   COMPONENT Runtime
   )
@@ -22,7 +22,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME MutualInformationTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MutualInformation
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   fixed.png
   moving.png
   output.png)

--- a/src/Registration/Common/Perform2DTranslationRegistrationWithMeanSquares/CMakeLists.txt
+++ b/src/Registration/Common/Perform2DTranslationRegistrationWithMeanSquares/CMakeLists.txt
@@ -11,10 +11,10 @@ project(Perform2DTranslationRegistrationWithMeanSquares)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(Perform2DTranslationRegistrationWithMeanSquares Code.cxx)
-target_link_libraries(Perform2DTranslationRegistrationWithMeanSquares ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS Perform2DTranslationRegistrationWithMeanSquares
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Registration/Common
   COMPONENT Runtime
   )
@@ -26,7 +26,7 @@ install(FILES Code.cxx CMakeLists.txt Code.py
 
 enable_testing()
 add_test(NAME Perform2DTranslationRegistrationWithMeanSquaresTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Perform2DTranslationRegistrationWithMeanSquares
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   ${input_image1}
   ${input_image2}
   ${output_image1}

--- a/src/Registration/Common/PerformMultiModalityRegistrationWithMutualInformation/CMakeLists.txt
+++ b/src/Registration/Common/PerformMultiModalityRegistrationWithMutualInformation/CMakeLists.txt
@@ -5,10 +5,10 @@ project(PerformMultiModalityRegistrationWithMutualInformation)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(PerformMultiModalityRegistrationWithMutualInformation Code.cxx)
-target_link_libraries(PerformMultiModalityRegistrationWithMutualInformation ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS PerformMultiModalityRegistrationWithMutualInformation
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Registration/Common
   COMPONENT Runtime
   )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME PerformMultiModalityRegistrationWithMutualInformationTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/PerformMultiModalityRegistrationWithMutualInformation
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
   BrainT1SliceBorder20.png
   BrainProtonDensitySliceShifted13x17y.png
   Output.png

--- a/src/Registration/Common/RegisterImageToAnotherUsingLandmarks/CMakeLists.txt
+++ b/src/Registration/Common/RegisterImageToAnotherUsingLandmarks/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(RegisterImageToAnotherUsingLandmarks Code.cxx)
-target_link_libraries(RegisterImageToAnotherUsingLandmarks ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS RegisterImageToAnotherUsingLandmarks
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Registration/Common
   COMPONENT Runtime
   )
@@ -21,7 +21,7 @@ install(FILES Code.cxx CMakeLists.txt Code.py
 
 enable_testing()
 add_test(NAME RegisterImageToAnotherUsingLandmarksTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/RegisterImageToAnotherUsingLandmarks)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 
 if(ITK_WRAP_PYTHON)
   add_test(NAME RegisterImageToAnotherUsingLandmarksTestPython

--- a/src/Registration/Common/WatchRegistration/CMakeLists.txt
+++ b/src/Registration/Common/WatchRegistration/CMakeLists.txt
@@ -19,8 +19,8 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
   include(${VTK_USE_FILE})
 endif()
 
-add_executable(WatchRegistration Code.cxx)
-target_link_libraries(WatchRegistration ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(
@@ -29,7 +29,7 @@ if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     )
 endif()
 
-install(TARGETS WatchRegistration
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Registration/Common
   COMPONENT Runtime
   )
@@ -42,5 +42,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME WatchRegistrationTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/WatchRegistration fixed.png moving.png)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME} fixed.png moving.png)
 

--- a/src/Registration/Metricsv4/PerformRegistrationOnVectorImages/CMakeLists.txt
+++ b/src/Registration/Metricsv4/PerformRegistrationOnVectorImages/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(PerformRegistrationOnVectorImages Code.cxx)
-target_link_libraries(PerformRegistrationOnVectorImages ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS PerformRegistrationOnVectorImages
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Registration/Metricsv4
   COMPONENT Runtime
   )
@@ -30,7 +30,7 @@ set(test_options
   )
 
 add_test(NAME PerformRegistrationOnVectorImagesTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/PerformRegistrationOnVectorImages
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${fixed_image}
     ${moving_image}
     ${output_image}

--- a/src/Registration/Metricsv4/RegisterTwoPointSets/CMakeLists.txt
+++ b/src/Registration/Metricsv4/RegisterTwoPointSets/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(RegisterTwoPointSets Code.cxx)
-target_link_libraries(RegisterTwoPointSets ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS RegisterTwoPointSets
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Registration/Common
   COMPONENT Runtime
   )
@@ -22,7 +22,7 @@ install(FILES Code.cxx Code.py CMakeLists.txt
 
 enable_testing()
 add_test(NAME RegisterTwoPointSetsTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/RegisterTwoPointSets)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
   
 if(ITK_WRAP_PYTHON)
   # TODO broken in itk v5.3rc03

--- a/src/Remote/WikiExamples/CustomUserMatrixToAlignImageWithDICOM/CMakeLists.txt
+++ b/src/Remote/WikiExamples/CustomUserMatrixToAlignImageWithDICOM/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(CustomUserMatrixToAlignImageWithDICOM Code.cxx)
-target_link_libraries(CustomUserMatrixToAlignImageWithDICOM ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS CustomUserMatrixToAlignImageWithDICOM
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Remote/WikiExamples
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME CustomUserMatrixToAlignImageWithDICOMTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/CustomUserMatrixToAlignImageWithDICOM)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Remote/WikiExamples/DisplayITKImage/CMakeLists.txt
+++ b/src/Remote/WikiExamples/DisplayITKImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(DisplayITKImage Code.cxx)
-target_link_libraries(DisplayITKImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS DisplayITKImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Remote/WikiExamples
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME DisplayITKImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/DisplayITKImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Segmentation/Classifiers/ClusterPixelsInGrayscaleImage/CMakeLists.txt
+++ b/src/Segmentation/Classifiers/ClusterPixelsInGrayscaleImage/CMakeLists.txt
@@ -20,8 +20,8 @@ if(VTK_VERSION VERSION_LESS "8.90.0")
   include(${VTK_USE_FILE})
 endif()
 
-add_executable(ClusterPixelsInGrayscaleImage Code.cxx)
-target_link_libraries(ClusterPixelsInGrayscaleImage ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
 if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   vtk_module_autoinit(
@@ -30,7 +30,7 @@ if(NOT VTK_VERSION VERSION_LESS "8.90.0")
   )
 endif()
 
-install(TARGETS ClusterPixelsInGrayscaleImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Segmentation/Classifiers
   COMPONENT Runtime
   )
@@ -43,4 +43,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ClusterPixelsInGrayscaleImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ClusterPixelsInGrayscaleImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Segmentation/Classifiers/KMeansClusterOfPixelsInImage/CMakeLists.txt
+++ b/src/Segmentation/Classifiers/KMeansClusterOfPixelsInImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(KMeansClusterOfPixelsInImage Code.cxx)
-target_link_libraries(KMeansClusterOfPixelsInImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS KMeansClusterOfPixelsInImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Segmentation/Classifiers
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME KMeansClusterOfPixelsInImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/KMeansClusterOfPixelsInImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Segmentation/Classifiers/KMeansClustering/CMakeLists.txt
+++ b/src/Segmentation/Classifiers/KMeansClustering/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(KMeansClustering Code.cxx)
-target_link_libraries(KMeansClustering ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS KMeansClustering
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Segmentation/Classifiers
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME KMeansClusteringTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/KMeansClustering)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Segmentation/ConnectedComponents/AssignContiguousLabelsToConnectedRegions/CMakeLists.txt
+++ b/src/Segmentation/ConnectedComponents/AssignContiguousLabelsToConnectedRegions/CMakeLists.txt
@@ -17,8 +17,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(AssignContiguousLabelsToConnectedRegions Code.cxx)
-  target_link_libraries(AssignContiguousLabelsToConnectedRegions ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -27,11 +27,11 @@ if(ENABLE_QUICKVIEW)
     )
   endif()
 else()
-  add_executable(AssignContiguousLabelsToConnectedRegions Code.cxx)
-  target_link_libraries(AssignContiguousLabelsToConnectedRegions ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS AssignContiguousLabelsToConnectedRegions
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Segmentation/ConnectedComponents
   COMPONENT Runtime
   )
@@ -44,4 +44,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME AssignContiguousLabelsToConnectedRegionsTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/AssignContiguousLabelsToConnectedRegions)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Segmentation/ConnectedComponents/ExtraLargestConnectComponentFromBinaryImage/CMakeLists.txt
+++ b/src/Segmentation/ConnectedComponents/ExtraLargestConnectComponentFromBinaryImage/CMakeLists.txt
@@ -17,8 +17,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(ExtraLargestConnectComponentFromBinaryImage Code.cxx)
-  target_link_libraries(ExtraLargestConnectComponentFromBinaryImage ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -27,11 +27,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(ExtraLargestConnectComponentFromBinaryImage Code.cxx)
-  target_link_libraries(ExtraLargestConnectComponentFromBinaryImage ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS ExtraLargestConnectComponentFromBinaryImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Segmentation/ConnectedComponents
   COMPONENT Runtime
   )
@@ -44,5 +44,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ExtraLargestConnectComponentFromBinaryImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ExtraLargestConnectComponentFromBinaryImage
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     Yinyang.png)

--- a/src/Segmentation/ConnectedComponents/LabelConnectComponentsInBinaryImage/CMakeLists.txt
+++ b/src/Segmentation/ConnectedComponents/LabelConnectComponentsInBinaryImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(LabelConnectComponentsInBinaryImage Code.cxx)
-target_link_libraries(LabelConnectComponentsInBinaryImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS LabelConnectComponentsInBinaryImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Segmentation/ConnectedComponents
   COMPONENT Runtime
   )
@@ -22,4 +22,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME LabelConnectComponentsInBinaryImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/LabelConnectComponentsInBinaryImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Segmentation/ConnectedComponents/LabelConnectComponentsInGrayscaleImage/CMakeLists.txt
+++ b/src/Segmentation/ConnectedComponents/LabelConnectComponentsInGrayscaleImage/CMakeLists.txt
@@ -17,8 +17,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(LabelConnectComponentsInGrayscaleImage Code.cxx)
-  target_link_libraries(LabelConnectComponentsInGrayscaleImage ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -27,11 +27,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(LabelConnectComponentsInGrayscaleImage Code.cxx)
-  target_link_libraries(LabelConnectComponentsInGrayscaleImage ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS LabelConnectComponentsInGrayscaleImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Segmentation/ConnectedComponents
   COMPONENT Runtime
   )
@@ -44,4 +44,4 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME LabelConnectComponentsInGrayscaleImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/LabelConnectComponentsInGrayscaleImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})

--- a/src/Segmentation/KLMRegionGrowing/BasicRegionGrowing/CMakeLists.txt
+++ b/src/Segmentation/KLMRegionGrowing/BasicRegionGrowing/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(BasicRegionGrowing Code.cxx)
-target_link_libraries(BasicRegionGrowing ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS BasicRegionGrowing
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Segmentation/KLMRegionGrowing
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME BasicRegionGrowingTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/BasicRegionGrowing)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Segmentation/LabelVoting/IterativeHoleFilling/CMakeLists.txt
+++ b/src/Segmentation/LabelVoting/IterativeHoleFilling/CMakeLists.txt
@@ -5,10 +5,10 @@ project(IterativeHoleFilling)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(IterativeHoleFilling Code.cxx)
-target_link_libraries(IterativeHoleFilling ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS IterativeHoleFilling
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Segmentation/LabelVoting
   COMPONENT Runtime
   )
@@ -21,7 +21,7 @@ install(FILES Code.cxx CMakeLists.txt
 enable_testing()
 
 add_test(NAME IterativeHoleFillingTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/IterativeHoleFilling
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/BinaryThresholdImageFilter.png
     Output.png
     3 1 5

--- a/src/Segmentation/LevelSets/SegmentWithGeodesicActiveContourLevelSet/CMakeLists.txt
+++ b/src/Segmentation/LevelSets/SegmentWithGeodesicActiveContourLevelSet/CMakeLists.txt
@@ -5,10 +5,10 @@ project(SegmentWithGeodesicActiveContourLevelSet)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(SegmentWithGeodesicActiveContourLevelSet Code.cxx)
-target_link_libraries(SegmentWithGeodesicActiveContourLevelSet ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS SegmentWithGeodesicActiveContourLevelSet
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Segmentation/LevelSets
   COMPONENT Runtime
   )
@@ -21,28 +21,28 @@ install(FILES Code.cxx CMakeLists.txt
 enable_testing()
 
 add_test(NAME GeodesicActiveContourLeftVentricleTest
-    COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SegmentWithGeodesicActiveContourLevelSet
+    COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/BrainProtonDensitySlice.png
     Output1.png
     81 114 5.0 1.0 -0.5 3.0 2.0 800
   )
 
 add_test(NAME GeodesicActiveContourRightVentricleTest
-    COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SegmentWithGeodesicActiveContourLevelSet
+    COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/BrainProtonDensitySlice.png
     Output2.png
     99 114 5.0 1.0 -0.5 3.0 2.0 800
   )
 
 add_test(NAME GeodesicActiveContourWhiteMatterTest
-    COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SegmentWithGeodesicActiveContourLevelSet
+    COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/BrainProtonDensitySlice.png
     Output3.png
     56 92 5.0 1.0 -0.3 2.0 10.0 800
   )
 
 add_test(NAME GeodesicActiveContourGrayMatterTest
-    COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SegmentWithGeodesicActiveContourLevelSet
+    COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/BrainProtonDensitySlice.png
     Output4.png
     40 90 5.0 .5 -0.3 2.0 10.0 800

--- a/src/Segmentation/RegionGrowing/ConnectedComponentsInImage/CMakeLists.txt
+++ b/src/Segmentation/RegionGrowing/ConnectedComponentsInImage/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(ConnectedComponentsInImage Code.cxx)
-target_link_libraries(ConnectedComponentsInImage ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ConnectedComponentsInImage
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Segmentation/RegionGrowing
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ConnectedComponentsInImageTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ConnectedComponentsInImage)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Segmentation/RegionGrowing/SegmentPixelsWithSimilarStats/CMakeLists.txt
+++ b/src/Segmentation/RegionGrowing/SegmentPixelsWithSimilarStats/CMakeLists.txt
@@ -16,8 +16,8 @@ if(ENABLE_QUICKVIEW)
     include(${VTK_USE_FILE})
   endif()
 
-  add_executable(SegmentPixelsWithSimilarStats Code.cxx)
-  target_link_libraries(SegmentPixelsWithSimilarStats ${ITK_LIBRARIES} ${VTK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES} ${VTK_LIBRARIES})
 
   if(NOT VTK_VERSION VERSION_LESS "8.90.0")
     vtk_module_autoinit(
@@ -26,11 +26,11 @@ if(ENABLE_QUICKVIEW)
       )
   endif()
 else()
-  add_executable(SegmentPixelsWithSimilarStats Code.cxx)
-  target_link_libraries(SegmentPixelsWithSimilarStats ${ITK_LIBRARIES})
+  add_executable(${PROJECT_NAME} Code.cxx)
+  target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 endif()
 
-install(TARGETS SegmentPixelsWithSimilarStats
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Segmentation/RegionGrowing
   COMPONENT Runtime
   )
@@ -46,7 +46,7 @@ enable_testing()
 set(input_image ${CMAKE_CURRENT_BINARY_DIR}/Yinyang.png)
 
 add_test(NAME SegmentPixelsWithSimilarStatsTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SegmentPixelsWithSimilarStats
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
     100
     50

--- a/src/Segmentation/Voronoi/VoronoiDiagram/CMakeLists.txt
+++ b/src/Segmentation/Voronoi/VoronoiDiagram/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(VoronoiDiagram Code.cxx)
-target_link_libraries(VoronoiDiagram ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS VoronoiDiagram
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Segmentation/Voronoi
   COMPONENT Runtime
   )
@@ -22,5 +22,5 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME VoronoiDiagramTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/VoronoiDiagram)
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME})
 

--- a/src/Segmentation/Watersheds/MorphologicalWatershedSegmentation/CMakeLists.txt
+++ b/src/Segmentation/Watersheds/MorphologicalWatershedSegmentation/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(MorphologicalWatershedSegmentation Code.cxx)
-target_link_libraries(MorphologicalWatershedSegmentation ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS MorphologicalWatershedSegmentation
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Segmentation/Watersheds
   COMPONENT Runtime
   )
@@ -22,7 +22,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME MorphologicalWatershedSegmentationTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/MorphologicalWatershedSegmentation
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     input.png
     20
     3)

--- a/src/Segmentation/Watersheds/SegmentWithWatershedImageFilter/CMakeLists.txt
+++ b/src/Segmentation/Watersheds/SegmentWithWatershedImageFilter/CMakeLists.txt
@@ -6,10 +6,10 @@ find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
 
-add_executable(SegmentWithWatershedImageFilter Code.cxx)
-target_link_libraries(SegmentWithWatershedImageFilter ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS SegmentWithWatershedImageFilter
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Segmentation/Watersheds
   COMPONENT Runtime
   )
@@ -34,35 +34,35 @@ set(level04 0.75)
 set(level05 0.9)
 
 add_test(NAME SegmentWithWatershedImageFilterTest01
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SegmentWithWatershedImageFilter
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
     SegmentWithWatershedImageFilterTest01.png
     ${threshold01}
     ${level01}
   )
 add_test(NAME SegmentWithWatershedImageFilterTest02
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SegmentWithWatershedImageFilter
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
     SegmentWithWatershedImageFilterTest02.png
     ${threshold02}
     ${level02}
   )
 add_test(NAME SegmentWithWatershedImageFilterTest03
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SegmentWithWatershedImageFilter
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
     SegmentWithWatershedImageFilterTest03.png
     ${threshold03}
     ${level03}
   )
 add_test(NAME SegmentWithWatershedImageFilterTest04
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SegmentWithWatershedImageFilter
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
     SegmentWithWatershedImageFilterTest04.png
     ${threshold04}
     ${level04}
   )
 add_test(NAME SegmentWithWatershedImageFilterTest05
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/SegmentWithWatershedImageFilter
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${input_image}
     SegmentWithWatershedImageFilterTest05.png
     ${threshold05}

--- a/src/Video/BridgeOpenCV/ConvertAnITKGrayScaleImageToCVMat/CMakeLists.txt
+++ b/src/Video/BridgeOpenCV/ConvertAnITKGrayScaleImageToCVMat/CMakeLists.txt
@@ -5,10 +5,10 @@ project(ConvertAnITKGrayScaleImageToCVMat)
 find_package(ITK REQUIRED)
 include(${ITK_USE_FILE})
 
-add_executable(ConvertAnITKGrayScaleImageToCVMat Code.cxx)
-target_link_libraries(ConvertAnITKGrayScaleImageToCVMat ${ITK_LIBRARIES})
+add_executable(${PROJECT_NAME} Code.cxx)
+target_link_libraries(${PROJECT_NAME} ${ITK_LIBRARIES})
 
-install(TARGETS ConvertAnITKGrayScaleImageToCVMat
+install(TARGETS ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Video/BridgeOpenCV
   COMPONENT Runtime
   )
@@ -20,7 +20,7 @@ install(FILES Code.cxx CMakeLists.txt
 
 enable_testing()
 add_test(NAME ConvertAnITKGrayScaleImageToCVMatTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ConvertAnITKGrayScaleImageToCVMat
+  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
     ${CMAKE_CURRENT_BINARY_DIR}/Yinyang.png
     ${CMAKE_CURRENT_BINARY_DIR}/Output.png
 )


### PR DESCRIPTION
Replaced `add_executable\(\S+` with `add_executable\(\${PROJECT_NAME}`,
replaced `install\(TARGETS \S+` with `install\(TARGETS \${PROJECT_NAME}`,
and `target_link_libraries\(\S+` with `target_link_libraries\${PROJECT_NAME}`,
using Notepad++ v8.3.3, Find in Files (Regular expression, Filters:
`CMake*.txt`).

This makes the convention of using the project name as target name explicit.