### PR TITLE
ENH: Switch Github Actions Linux environment

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -130,9 +130,9 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        os: [ubuntu-18.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
             cmake-build-type: "MinSizeRel"
@@ -229,7 +229,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        os: [ubuntu-18.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
 
     steps:
       - uses: actions/checkout@v1
@@ -254,9 +254,9 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
             cmake-build-type: "Release"


### PR DESCRIPTION
Switch Github Actions Linux environment version to `ubuntu-20.04`.

`ubuntu-18.04` is being deprecated and support will end by 12/1/2022:
https://github.com/actions/virtual-environments/issues/6002

Related to recent warnings in the Azure Pipelines Linux environment
being used in the main ITK repository:
https://github.com/InsightSoftwareConsortium/ITK/pull/3554/commits/497c3a7b8e1397ca56a2675ce846dca657af8861