### PR TITLE
ENH: Update CMake to decouple archives from example builds

### DIFF
--- a/src/Bridge/CMakeLists.txt
+++ b/src/Bridge/CMakeLists.txt
@@ -1,5 +1,14 @@
+set(Bridge_MODULES
+  VtkGlue
+  NumPy
+)
+
 if(ENABLE_QUICKVIEW)
 add_subdirectory_if_module_enabled(VtkGlue)
 endif()
 
 add_subdirectory_if_module_enabled( NumPy )
+
+foreach(_module ${Bridge_MODULES})
+  add_module_archives(${_module})
+endforeach()

--- a/src/Core/CMakeLists.txt
+++ b/src/Core/CMakeLists.txt
@@ -1,8 +1,15 @@
-add_subdirectory_if_module_enabled(Common)
-add_subdirectory_if_module_enabled(QuadEdgeMesh)
-add_subdirectory_if_module_enabled(Mesh)
-add_subdirectory_if_module_enabled(TestKernel)
-add_subdirectory_if_module_enabled(Transform)
-add_subdirectory_if_module_enabled(ImageFunction)
-add_subdirectory_if_module_enabled(ImageAdaptors)
-add_subdirectory_if_module_enabled(SpatialObjects)
+set(Core_MODULES
+  Common
+  QuadEdgeMesh
+  Mesh
+  TestKernel
+  Transform
+  ImageFunction
+  ImageAdaptors
+  SpatialObjects
+)
+
+foreach(_module ${Core_MODULES})
+  add_subdirectory_if_module_enabled(${_module})
+  add_module_archives(${_module})
+endforeach()

--- a/src/Filtering/CMakeLists.txt
+++ b/src/Filtering/CMakeLists.txt
@@ -1,26 +1,39 @@
-add_subdirectory_if_module_enabled(BinaryMathematicalMorphology)
-add_subdirectory_if_module_enabled(ImageGrid)
-add_subdirectory_if_module_enabled(ImageFeature)
-add_subdirectory_if_module_enabled(FastMarching)
-add_subdirectory_if_module_enabled(Colormap)
-add_subdirectory_if_module_enabled(ImageIntensity)
-add_subdirectory_if_module_enabled(ImageFilterBase)
-add_subdirectory_if_module_enabled(Thresholding)
-add_subdirectory_if_module_enabled(QuadEdgeMeshFiltering)
-add_subdirectory_if_module_enabled(ImageCompare)
-add_subdirectory_if_module_enabled(MathematicalMorphology)
-add_subdirectory_if_module_enabled(Smoothing)
-# TODO: Need to re-enable ImageGraadient
-# add_subdirectory_if_module_enabled(ImageGradient)
-add_subdirectory_if_module_enabled(AnisotropicSmoothing)
-add_subdirectory_if_module_enabled(FFT)
-add_subdirectory_if_module_enabled(AntiAlias)
-add_subdirectory_if_module_enabled(LabelMap)
-add_subdirectory_if_module_enabled(ImageStatistics)
-add_subdirectory_if_module_enabled(ImageFusion)
-add_subdirectory_if_module_enabled(Convolution)
-add_subdirectory_if_module_enabled(DistanceMap)
-add_subdirectory_if_module_enabled(ImageCompose)
-add_subdirectory_if_module_enabled(ImageLabel)
-add_subdirectory_if_module_enabled(CurvatureFlow)
-add_subdirectory_if_module_enabled(Path)
+set(Filtering_MODULES
+  AnisotropicSmoothing
+  AntiAlias
+  BinaryMathematicalMorphology
+  Colormap
+  Convolution
+  CurvatureFlow
+  DistanceMap
+  FastMarching
+  FFT
+  ImageCompare
+  ImageCompose
+  ImageFeature
+  ImageFilterBase
+  ImageFusion
+  ImageGradient
+  ImageGrid
+  ImageIntensity
+  ImageLabel
+  ImageStatistics
+  LabelMap
+  MathematicalMorphology
+  Path
+  QuadEdgeMeshFiltering
+  Smoothing
+  Thresholding
+)
+
+set(Filtering_MODULES_IGNORED
+  # TODO: Fix ImageGradient examples and re-enable
+  ImageGradient
+)
+
+foreach(_module ${Filtering_MODULES})
+  if(NOT (${_module} IN_LIST Filtering_MODULES_IGNORED))
+    add_subdirectory_if_module_enabled(${_module})
+  endif()
+  add_module_archives(${_module})
+endforeach()

--- a/src/IO/CMakeLists.txt
+++ b/src/IO/CMakeLists.txt
@@ -1,6 +1,20 @@
+set(IO_MODULES
+  ImageBase
+  Mesh
+  TIFF
+  GDCM
+  TransformBase
+  TransformFactory
+)
+
+# Add subdirectories with corresponding ITK module names
 add_subdirectory_if_module_enabled(ImageBase ITKIOImageBase)
 add_subdirectory_if_module_enabled(Mesh ITKIOMesh)
 add_subdirectory_if_module_enabled(TIFF ITKIOTIFF)
 add_subdirectory_if_module_enabled(GDCM ITKGDCM)
 add_subdirectory_if_module_enabled(TransformBase)
 add_subdirectory_if_module_enabled(TransformFactory)
+
+foreach(_module ${IO_MODULES})
+  add_module_archives(${_module})
+endforeach()

--- a/src/Nonunit/CMakeLists.txt
+++ b/src/Nonunit/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory_if_module_enabled(Review)
+add_module_archives(Review)

--- a/src/Numerics/CMakeLists.txt
+++ b/src/Numerics/CMakeLists.txt
@@ -1,2 +1,9 @@
-add_subdirectory_if_module_enabled(Statistics)
-add_subdirectory_if_module_enabled(Optimizers)
+set(Numerics_MODULES
+  Optimizers
+  Statistics
+)
+
+foreach(_module ${Numerics_MODULES})
+  add_subdirectory_if_module_enabled(${_module})
+  add_module_archives(${_module})
+endforeach()

--- a/src/Registration/CMakeLists.txt
+++ b/src/Registration/CMakeLists.txt
@@ -1,2 +1,9 @@
-add_subdirectory_if_module_enabled(Common)
-add_subdirectory_if_module_enabled(Metricsv4)
+set(Numerics_MODULES
+  Common
+  Metricsv4
+)
+
+foreach(_module ${Numerics_MODULES})
+  add_subdirectory_if_module_enabled(${_module})
+  add_module_archives(${_module})
+endforeach()

--- a/src/Remote/CMakeLists.txt
+++ b/src/Remote/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(Remote) 
 add_subdirectory_if_module_enabled(WikiExamples)
+add_module_archives(WikiExamples)

--- a/src/Segmentation/CMakeLists.txt
+++ b/src/Segmentation/CMakeLists.txt
@@ -1,10 +1,21 @@
-add_subdirectory_if_module_enabled(LevelSets)
-add_subdirectory_if_module_enabled(LabelVoting)
-add_subdirectory_if_module_enabled(Watersheds)
-add_subdirectory_if_module_enabled(Classifiers)
-add_subdirectory_if_module_enabled(Voronoi)
-add_subdirectory_if_module_enabled(ConnectedComponents)
-add_subdirectory_if_module_enabled(RegionGrowing)
-if(ENABLE_QUICKVIEW)
-add_subdirectory_if_module_enabled(KLMRegionGrowing)
-endif()
+set(Segmentation_MODULES
+  Classifiers
+  CMakeLists.txt
+  ConnectedComponents
+  index.rst
+  KLMRegionGrowing
+  LabelVoting
+  LevelSets
+  RegionGrowing
+  Voronoi
+  Watersheds
+)
+
+set(QUICKVIEW_MODULES KLMRegionGrowing)
+
+foreach(_module ${Segmentation_MODULES})
+  if(ENABLE_QUICKVIEW OR NOT (${_module} IN_LIST QUICKVIEW_MODULES))
+    add_subdirectory_if_module_enabled(${_module})
+  endif()
+  add_module_archives(${_module})
+endforeach()

--- a/src/Video/CMakeLists.txt
+++ b/src/Video/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory_if_module_enabled(BridgeOpenCV ITKVideoBridgeOpenCV)
+add_module_archives(BridgeOpenCV)


### PR DESCRIPTION
Addresses issue where archives were not build for examples without an `add_example()` call, resulting in broken download links on `examples.itk.org`.

New behavior packages example archives for all examples to accompany Sphinx documentation. Also cleans up `CMakeLists.txt` for several module groups.

Closes #373.