### PR TITLE
COMP: Remove duplicate image declaration and read

### DIFF
--- a/src/Filtering/Thresholding/DemonstrateThresholdAlgorithms/Code.cxx
+++ b/src/Filtering/Thresholding/DemonstrateThresholdAlgorithms/Code.cxx
@@ -74,8 +74,6 @@ main(int argc, char * argv[])
   using TriangleFilterType = itk::TriangleThresholdImageFilter<InputImageType, OutputImageType>;
   using YenFilterType = itk::YenThresholdImageFilter<InputImageType, OutputImageType>;
 
-  const auto input = itk::ReadImage<InputImageType>(argv[1]);
-
   QuickView viewer;
   viewer.AddImage(input.GetPointer(), true, itksys::SystemTools::GetFilenameName(argv[1]));
 


### PR DESCRIPTION
The error was:
```log
13>C:\Dev\ITKExamples\src\Filtering\Thresholding\DemonstrateThresholdAlgorithms\Code.cxx(77,14): error C2371: 'input': redefinition; different basic types
13>C:\Dev\ITKExamples\src\Filtering\Thresholding\DemonstrateThresholdAlgorithms\Code.cxx(57,14): message : see declaration of 'input'
13>C:\Dev\ITKExamples\src\Filtering\Thresholding\DemonstrateThresholdAlgorithms\Code.cxx(80,9): error C2672: 'QuickView::AddImage': no matching overloaded function found
13>C:\Dev\ITK-git\Modules\Bridge\VtkGlue\include\QuickView.h(128,3): message : could be 'void QuickView::AddImage(TImage *,bool,std::string)'
13>Done building project "DemonstrateThresholdAlgorithms.vcxproj" -- FAILED.
```