### PR TITLE
COMP: Fix traitlets version to 5.6.0

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -245,6 +245,9 @@ jobs:
             python -m pip install itk>=5.3.0
             python -m pip install matplotlib
             python -m pip install itkwidgets
+            # Issues with 5.7.0
+            # https://github.com/InsightSoftwareConsortium/ITKSphinxExamples/issues/407
+            python -m pip install traitlets==5.6.0
 
       - name: Test notebooks
         uses: treebeardtech/nbmake-action@v0.2.1

--- a/Superbuild/External-Python.cmake
+++ b/Superbuild/External-Python.cmake
@@ -17,6 +17,6 @@ ExternalProject_Add(ITKPython
   DOWNLOAD_COMMAND ""
   CONFIGURE_COMMAND ${PYTHON_EXECUTABLE} -m venv "${_itk_venv}"
   BUILD_COMMAND ${ITKPYTHON_EXECUTABLE} -m pip install --upgrade pip
-  INSTALL_COMMAND ${ITKPYTHON_EXECUTABLE} -m pip install --ignore-installed itk>=5.3.0 sphinx==4.4.0 docutils<0.18 six black nbsphinx ipywidgets sphinx-contributors ipykernel matplotlib itkwidgets[lab,notebook]>=1.0a21 pydata-sphinx-theme
+  INSTALL_COMMAND ${ITKPYTHON_EXECUTABLE} -m pip install --ignore-installed itk>=5.3.0 sphinx==4.4.0 docutils<0.18 traitlets==5.6.0 six black nbsphinx ipywidgets sphinx-contributors ipykernel matplotlib itkwidgets[lab,notebook]>=1.0a21 pydata-sphinx-theme
   COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/ITKBlackConfig.cmake
   )


### PR DESCRIPTION
To address #407, notebook CI error:

```
TraitError: label_image_weights shape expected to have 1 components, but got () components
```

Co-authored-by: Tom Birdsong <tom.birdsong@kitware.com>