### PR TITLE
COMP: Bump minimum CMake version to 3.16.3

### DIFF
--- a/Superbuild/CMakeLists.txt
+++ b/Superbuild/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.16.3)
 
 if(COMMAND CMAKE_POLICY)
   cmake_policy(SET CMP0003 NEW)

--- a/Utilities/CookieCutter/{{cookiecutter.example_name}}/CMakeLists.txt
+++ b/Utilities/CookieCutter/{{cookiecutter.example_name}}/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.16.3)
 
 project({{ cookiecutter.example_name }})
 

--- a/src/Core/Mesh/AccessDataInCells/CMakeLists.txt
+++ b/src/Core/Mesh/AccessDataInCells/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.16.3)
 
 project(AccessDataInCells)
 

--- a/src/Filtering/BinaryMathematicalMorphology/DilateABinaryImage/CMakeLists.txt
+++ b/src/Filtering/BinaryMathematicalMorphology/DilateABinaryImage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.16.3)
 project(DilateABinaryImage)
 
 


### PR DESCRIPTION
To be consistent with ITK 5.3.0.

Most of the other examples have already been updated.
