### PR TITLE
STYLE: Capitalize first letter for `Histogram` class name in index

### DIFF
--- a/src/Numerics/Statistics/CreateHistogramFromListOfMeasurements/Documentation.rst
+++ b/src/Numerics/Statistics/CreateHistogramFromListOfMeasurements/Documentation.rst
@@ -5,7 +5,7 @@ Create Histogram From List of Measurements
 
 .. index::
    single: SampleToHistogramFilter
-   single: histogram
+   single: Histogram
 
 Synopsis
 --------


### PR DESCRIPTION
Capitalize first letter for `Histogram` class name in index: avoids
creating a `histogram` entry linked to the same class name, and adds a
new link in the `Histogram` index entry.