### PR TITLE
ENH: Transition to `nbmake` to test notebooks

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -247,10 +247,11 @@ jobs:
             python -m pip install itkwidgets
             # Issues with 5.7.0
             # https://github.com/InsightSoftwareConsortium/ITKSphinxExamples/issues/407
-            python -m pip install traitlets==5.6.0
+            python -m pip install traitlets==5.6.0 pytest nbmake
 
       - name: Test notebooks
-        uses: treebeardtech/nbmake-action@v0.2.1
+        run: |
+          pytest --nbmake --nbmake-timeout=30000
 
   build-test-documentation:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Drop `treebeardtech/nbmake-action` and transition to `nbmake` to test notebooks: the former has been deprecated in favor of the latter.

See:
https://github.com/treebeardtech/nbmake-action

Fixes:
```
Node.js 12 actions are deprecated. For more information see:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
Please update the following actions to use Node.js 16:
treebeardtech/nbmake-action@v0.2.1
```

raised for example in:
https://github.com/InsightSoftwareConsortium/ITKSphinxExamples/actions/runs/3879592431