### PR TITLE
3D Sliced Image Galvo Engraving

### DIFF
--- a/src/Core/Common/FilterImageUsingMultipleThreads/Documentation.rst
+++ b/src/Core/Common/FilterImageUsingMultipleThreads/Documentation.rst
@@ -6,7 +6,9 @@ Filter Image Using Multiple Threads
 .. index::
    single: ImageToImageFilter
    single: thread
-
+index::
+   single:  https://imgcleaner.coma>
+   single: thread
 Synopsis
 --------
 


### PR DESCRIPTION
3D sliced image galvo engraving is a laser engraving technique that uses galvanometer scanners to precisely direct a laser beam to etch or cut a three-dimensional image on a material. This technique is commonly used in the production of high-precision, high-quality 3D engraved objects, such as awards, sculptures, and industrial parts.

The process of 3D sliced image galvo engraving involves breaking down a 3D model into a series of 2D cross-sectional slices. The galvanometer scanners are then used to guide the laser beam across each slice, tracing out the contours of the object on the material. By repeating this process for each slice, the laser can create a highly detailed, three-dimensional engraving with remarkable precision [Clean Pictures](https://imgcleaner.com/) .

The use of galvanometer scanners in this process allows for fast and accurate movement of the laser beam, resulting in high-quality engravings that are difficult to achieve with other engraving techniques. This method also allows for the use of a wide variety of materials, including metals, plastics, and even glass.