### PR TITLE
COMP: Replace itkTypeMacro calls with `itkOverrideGetNameOfClassMacro`

### DIFF
--- a/src/Developer/ImageFilter.h
+++ b/src/Developer/ImageFilter.h
@@ -20,7 +20,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(ImageFilter);
 
 protected:
   ImageFilter() = default;

--- a/src/Developer/ImageFilterMultipleInputsDifferentType.h
+++ b/src/Developer/ImageFilterMultipleInputsDifferentType.h
@@ -21,7 +21,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ImageFilterMultipleInputsDifferentType, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(ImageFilterMultipleInputsDifferentType);
 
   /** The image to be inpainted in regions where the mask is white.*/
   void

--- a/src/Developer/ImageFilterMultipleOutputs.h
+++ b/src/Developer/ImageFilterMultipleOutputs.h
@@ -20,7 +20,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ImageFilterMultipleOutputs, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(ImageFilterMultipleOutputs);
 
   TImage *
   GetOutput1();

--- a/src/Developer/ImageFilterMultipleOutputsDifferentType.h
+++ b/src/Developer/ImageFilterMultipleOutputsDifferentType.h
@@ -23,7 +23,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ImageFilterMultipleOutputsDifferentType, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(ImageFilterMultipleOutputsDifferentType);
 
   TOutputImage1 *
   GetOutput1();

--- a/src/Developer/ImageFilterX.h
+++ b/src/Developer/ImageFilterX.h
@@ -21,7 +21,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(ImageFilter);
 
   itkSetMacro(Variable, double);
   itkGetMacro(Variable, double);

--- a/src/Developer/ImageFilterY.h
+++ b/src/Developer/ImageFilterY.h
@@ -23,7 +23,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(ImageFilter);
 
 
   /** Image dimension. */

--- a/src/Developer/ImageSource.h
+++ b/src/Developer/ImageSource.h
@@ -23,7 +23,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ImageSource, ProcessObject);
+  itkOverrideGetNameOfClassMacro(ImageSource);
 
 protected:
   ImageSource() = default;

--- a/src/Developer/MultiThreadedImageFilter.h
+++ b/src/Developer/MultiThreadedImageFilter.h
@@ -23,7 +23,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(ImageFilter);
 
 protected:
   MultiThreadedImageFilter() = default;

--- a/src/Developer/MyInPlaceImageFilter.h
+++ b/src/Developer/MyInPlaceImageFilter.h
@@ -20,7 +20,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(MyInPlaceImageFilter, InPlaceImageFilter);
+  itkOverrideGetNameOfClassMacro(MyInPlaceImageFilter);
 
 protected:
   MyInPlaceImageFilter() = default;

--- a/src/Developer/itkImageFilterMultipleInputs.h
+++ b/src/Developer/itkImageFilterMultipleInputs.h
@@ -20,7 +20,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ImageFilterMultipleInputs, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(ImageFilterMultipleInputs);
 
   /** The image to be inpainted in regions where the mask is white.*/
   void

--- a/src/Developer/itkOilPaintingImageFilter.h
+++ b/src/Developer/itkOilPaintingImageFilter.h
@@ -31,7 +31,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(OilPaintingImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(OilPaintingImageFilter);
 
   itkSetMacro(NumberOfBins, unsigned int);
   itkGetConstMacro(NumberOfBins, unsigned int);

--- a/src/Numerics/Optimizers/AmoebaOptimizer/ExampleCostFunction.h
+++ b/src/Numerics/Optimizers/AmoebaOptimizer/ExampleCostFunction.h
@@ -22,7 +22,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ExampleCostFunction2, SingleValuedCostfunction);
+  itkOverrideGetNameOfClassMacro(ExampleCostFunction2);
 
   unsigned int
   GetNumberOfParameters() const override

--- a/src/Numerics/Optimizers/LevenbergMarquardtOptimization/itkExampleCostFunction.h
+++ b/src/Numerics/Optimizers/LevenbergMarquardtOptimization/itkExampleCostFunction.h
@@ -21,7 +21,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ExampleCostFunction, MultipleValuedCostFunction);
+  itkOverrideGetNameOfClassMacro(ExampleCostFunction);
 
   // The equation we're fitting is y=C*e^(K*x)
   // The free parameters which we're trying to fit are C and K


### PR DESCRIPTION
Follow-up to pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4373 commit https://github.com/InsightSoftwareConsortium/ITK/commit/2c264ea2ef62e916c6ef947599ce659cc8fce5fe "STYLE: Replace itkTypeMacro calls with `itkOverrideGetNameOfClassMacro`"

----

Assumes a very recent version of ITK (_after_ v5.4rc02), including commit https://github.com/InsightSoftwareConsortium/ITK/commit/94e7339da49a0cd3df6751f9e8a6e9ba91905dbd (merged to the ITK master branch on December 27, 2023)
