### PR TITLE
ENH: Bump ITK to 5.4 Release Candidate 3

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -3,7 +3,7 @@ name: Build, test, publish
 on: [push,pull_request]
 
 env:
-  itk-git-tag: "v5.4rc02"
+  itk-git-tag: "v5.4rc03"
 
 jobs:
   build-test-cxx:
@@ -242,7 +242,7 @@ jobs:
         run: |
             python -m pip install --upgrade pip
             python -m pip install ninja
-            python -m pip install itk>=5.4rc2
+            python -m pip install itk>=5.4rc3
             python -m pip install matplotlib
             python -m pip install itkwidgets
             # Issues with 5.7.0

--- a/Superbuild/External-ITK.cmake
+++ b/Superbuild/External-ITK.cmake
@@ -2,8 +2,8 @@
 # Get and build itk
 
 if(NOT ITK_TAG)
-  # ITK release 2023-10-10
-  set(ITK_TAG "v5.4rc02")
+  # ITK release 2024-04-09
+  set(ITK_TAG "v5.4rc03")
 endif()
 
 set(_vtk_args)

--- a/Superbuild/External-Python.cmake
+++ b/Superbuild/External-Python.cmake
@@ -17,6 +17,6 @@ ExternalProject_Add(ITKPython
   DOWNLOAD_COMMAND ""
   CONFIGURE_COMMAND ${PYTHON_EXECUTABLE} -m venv "${_itk_venv}"
   BUILD_COMMAND ${ITKPYTHON_EXECUTABLE} -m pip install --upgrade pip
-  INSTALL_COMMAND ${ITKPYTHON_EXECUTABLE} -m pip install --ignore-installed itk>=5.4rc2 sphinx==4.4.0 docutils<0.18 traitlets==5.6.0 six black nbsphinx ipywidgets sphinx-contributors ipykernel matplotlib itkwidgets[lab,notebook]>=1.0a21 pydata-sphinx-theme
+  INSTALL_COMMAND ${ITKPYTHON_EXECUTABLE} -m pip install --ignore-installed itk>=5.4rc3 sphinx==4.4.0 docutils<0.18 traitlets==5.6.0 six black nbsphinx ipywidgets sphinx-contributors ipykernel matplotlib itkwidgets[lab,notebook]>=1.0a21 pydata-sphinx-theme
   COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/ITKBlackConfig.cmake
   )


### PR DESCRIPTION
The superbuild, python package and CI tests now use ITK 5.3 RC 3.
