### PR TITLE
ENH: Bump `macOS` version to 10.13 in GHA build, test, publish

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-12]
+        os: [ubuntu-22.04, windows-2022, macos-13]
         include:
           - os: ubuntu-22.04
             c-compiler: "gcc"
@@ -21,7 +21,7 @@ jobs:
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
             cmake-build-type: "Release"
-          - os: macos-12
+          - os: macos-13
             c-compiler: "clang"
             cxx-compiler: "clang++"
             cmake-build-type: "MinSizeRel"


### PR DESCRIPTION
Bump `macOS` version to 10.13 in GHA build, test, publish workflow file.

Fixes:
```
GitHub Actions has encountered an internal error when running your job.
The macOS-12 environment is deprecated, consider switching to macOS-13, macOS-14 (macos-latest) or macOS-15.
For more details, see https://github.com/actions/runner-images/issues/10721
```

raised for example in:
https://github.com/InsightSoftwareConsortium/ITKSphinxExamples/actions/runs/11671260757/job/32497243193