### PR TITLE
Replace `T var; var.Fill` with `auto var = T::Filled`, for both `Index` and `Size`

### DIFF
--- a/src/Core/Common/AddOffsetToIndex/Code.cxx
+++ b/src/Core/Common/AddOffsetToIndex/Code.cxx
@@ -26,8 +26,7 @@ main()
 {
   constexpr unsigned int Dimension = 2;
 
-  itk::Index<Dimension> index;
-  index.Fill(5);
+  auto index = itk::Index<Dimension>::Filled(5);
 
   itk::Offset<Dimension> offset;
   offset.Fill(1);

--- a/src/Core/Common/ApplyAFilterOnlyToASpecifiedRegionOfAnImage/Code.cxx
+++ b/src/Core/Common/ApplyAFilterOnlyToASpecifiedRegionOfAnImage/Code.cxx
@@ -28,15 +28,13 @@ main()
 
   using ImageType = itk::Image<PixelType, Dimension>;
 
-  ImageType::SizeType smallSize;
-  smallSize.Fill(10);
+  auto smallSize = ImageType::SizeType::Filled(10);
 
   ImageType::IndexType index{};
 
   ImageType::RegionType region(index, smallSize);
 
-  ImageType::SizeType bigSize;
-  bigSize.Fill(10000);
+  auto bigSize = ImageType::SizeType::Filled(10000);
 
   using RandomSourceType = itk::RandomImageSource<ImageType>;
   auto randomImageSource = RandomSourceType::New();

--- a/src/Core/Common/CreateABackwardDifferenceOperator/Code.cxx
+++ b/src/Core/Common/CreateABackwardDifferenceOperator/Code.cxx
@@ -30,8 +30,7 @@ main()
   // Create the operator for the X axis derivative
   backwardDifferenceOperator.SetDirection(0);
 
-  itk::Size<Dimension> radius;
-  radius.Fill(1);
+  auto radius = itk::Size<Dimension>::Filled(1);
 
   backwardDifferenceOperator.CreateToRadius(radius);
 

--- a/src/Core/Common/CreateAnImageRegion/Code.cxx
+++ b/src/Core/Common/CreateAnImageRegion/Code.cxx
@@ -26,8 +26,7 @@ main()
   using RegionType = itk::ImageRegion<Dimension>;
   auto size = RegionType::SizeType::Filled(3);
 
-  RegionType::IndexType index;
-  index.Fill(1);
+  auto index = RegionType::IndexType::Filled(1);
 
   RegionType region(index, size);
 

--- a/src/Core/Common/CreateAnImageRegion/Code.cxx
+++ b/src/Core/Common/CreateAnImageRegion/Code.cxx
@@ -24,8 +24,7 @@ main()
   constexpr unsigned int Dimension = 2;
 
   using RegionType = itk::ImageRegion<Dimension>;
-  RegionType::SizeType size;
-  size.Fill(3);
+  auto size = RegionType::SizeType::Filled(3);
 
   RegionType::IndexType index;
   index.Fill(1);

--- a/src/Core/Common/CreateAnotherInstanceOfAFilter/Code.cxx
+++ b/src/Core/Common/CreateAnotherInstanceOfAFilter/Code.cxx
@@ -26,8 +26,7 @@ CreateImage(typename TImage::Pointer image)
   using ImageType = TImage;
   typename ImageType::IndexType start{};
 
-  typename ImageType::SizeType size;
-  size.Fill(2);
+  auto size = ImageType::SizeType::Filled(2);
 
   typename ImageType::RegionType region(start, size);
 

--- a/src/Core/Common/CreateDerivativeKernel/Code.cxx
+++ b/src/Core/Common/CreateDerivativeKernel/Code.cxx
@@ -23,8 +23,7 @@ main()
   using DerivativeOperatorType = itk::DerivativeOperator<float, 2>;
   DerivativeOperatorType derivativeOperator;
   derivativeOperator.SetDirection(0); // Create the operator for the X axis derivative
-  itk::Size<2> radius;
-  radius.Fill(1);
+  auto radius = itk::Size<2>::Filled(1);
   derivativeOperator.CreateToRadius(radius);
 
   std::cout << "Size: " << derivativeOperator.GetSize() << std::endl;

--- a/src/Core/Common/CreateForwardDifferenceKernel/Code.cxx
+++ b/src/Core/Common/CreateForwardDifferenceKernel/Code.cxx
@@ -23,8 +23,7 @@ main()
   using ForwardDifferenceOperatorType = itk::ForwardDifferenceOperator<float, 2>;
   ForwardDifferenceOperatorType forwardDifferenceOperator;
   forwardDifferenceOperator.SetDirection(0); // Create the operator for the X axis derivative
-  itk::Size<2> radius;
-  radius.Fill(1);
+  auto radius = itk::Size<2>::Filled(1);
   forwardDifferenceOperator.CreateToRadius(radius);
 
   std::cout << "Size: " << forwardDifferenceOperator.GetSize() << std::endl;

--- a/src/Core/Common/CreateGaussianDerivativeKernel/Code.cxx
+++ b/src/Core/Common/CreateGaussianDerivativeKernel/Code.cxx
@@ -23,8 +23,7 @@ main()
   using GaussianDerivativeOperatorType = itk::GaussianDerivativeOperator<float, 2>;
   GaussianDerivativeOperatorType gaussianDerivativeOperator;
   gaussianDerivativeOperator.SetDirection(0); // Create the operator for the X axis derivative
-  itk::Size<2> radius;
-  radius.Fill(1);
+  auto radius = itk::Size<2>::Filled(1);
   gaussianDerivativeOperator.CreateToRadius(radius);
 
   std::cout << "Size: " << gaussianDerivativeOperator.GetSize() << std::endl;

--- a/src/Core/Common/CreateGaussianKernel/Code.cxx
+++ b/src/Core/Common/CreateGaussianKernel/Code.cxx
@@ -23,8 +23,7 @@ main()
   using GaussianOperatorType = itk::GaussianOperator<float, 2>;
   GaussianOperatorType gaussianOperator;
   gaussianOperator.SetDirection(0); // Create the operator for the X axis derivative
-  itk::Size<2> radius;
-  radius.Fill(1);
+  auto radius = itk::Size<2>::Filled(1);
   gaussianOperator.CreateToRadius(radius);
 
   std::cout << "Size: " << gaussianOperator.GetSize() << std::endl;

--- a/src/Core/Common/CreateLaplacianKernel/Code.cxx
+++ b/src/Core/Common/CreateLaplacianKernel/Code.cxx
@@ -22,8 +22,7 @@ main()
 {
   using LaplacianOperatorType = itk::LaplacianOperator<float, 2>;
   LaplacianOperatorType laplacianOperator;
-  itk::Size<2>          radius;
-  radius.Fill(1);
+  auto                  radius = itk::Size<2>::Filled(1);
   laplacianOperator.CreateToRadius(radius);
 
   std::cout << "Size: " << laplacianOperator.GetSize() << std::endl;

--- a/src/Core/Common/CreateSobelKernel/Code.cxx
+++ b/src/Core/Common/CreateSobelKernel/Code.cxx
@@ -23,8 +23,7 @@ main()
   using SobelOperatorType = itk::SobelOperator<float, 2>;
   SobelOperatorType sobelOperator;
   sobelOperator.SetDirection(0); // Create the operator for the X axis derivative
-  itk::Size<2> radius;
-  radius.Fill(1);
+  auto radius = itk::Size<2>::Filled(1);
   sobelOperator.CreateToRadius(radius);
 
   std::cout << sobelOperator << std::endl;

--- a/src/Core/Common/CreateVectorImage/Code.cxx
+++ b/src/Core/Common/CreateVectorImage/Code.cxx
@@ -25,8 +25,7 @@ main()
 
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(2);
+  auto size = ImageType::SizeType::Filled(2);
 
   ImageType::RegionType region(start, size);
 

--- a/src/Core/Common/CropImageBySpecifyingRegion/Code.cxx
+++ b/src/Core/Common/CropImageBySpecifyingRegion/Code.cxx
@@ -27,8 +27,7 @@ main()
 
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(10);
+  auto size = ImageType::SizeType::Filled(10);
 
   ImageType::RegionType region(start, size);
 
@@ -42,8 +41,7 @@ main()
   ImageType::IndexType desiredStart;
   desiredStart.Fill(3);
 
-  ImageType::SizeType desiredSize;
-  desiredSize.Fill(4);
+  auto desiredSize = ImageType::SizeType::Filled(4);
 
   ImageType::RegionType desiredRegion(desiredStart, desiredSize);
 

--- a/src/Core/Common/CropImageBySpecifyingRegion/Code.cxx
+++ b/src/Core/Common/CropImageBySpecifyingRegion/Code.cxx
@@ -38,8 +38,7 @@ main()
 
   std::cout << "Image largest region: " << image->GetLargestPossibleRegion() << std::endl;
 
-  ImageType::IndexType desiredStart;
-  desiredStart.Fill(3);
+  auto desiredStart = ImageType::IndexType::Filled(3);
 
   auto desiredSize = ImageType::SizeType::Filled(4);
 
@@ -60,8 +59,7 @@ main()
   output->DisconnectPipeline();
   output->FillBuffer(2);
 
-  itk::Index<2> index;
-  index.Fill(5);
+  auto index = itk::Index<2>::Filled(5);
 
   std::cout << "new largest region: " << output->GetLargestPossibleRegion() << std::endl;
   std::cout << "new: " << (int)output->GetPixel(index) << std::endl;

--- a/src/Core/Common/DemonstrateAllOperators/Code.cxx
+++ b/src/Core/Common/DemonstrateAllOperators/Code.cxx
@@ -53,8 +53,7 @@ main()
   operators.push_back(new AnnulusOperatorType);
   operators.push_back(new BackwardDifferenceOperatorType);
 
-  itk::Size<2> radius;
-  radius.Fill(1);
+  auto radius = itk::Size<2>::Filled(1);
 
   for (auto & operatorId : operators)
   {

--- a/src/Core/Common/DistanceBetweenIndices/Code.cxx
+++ b/src/Core/Common/DistanceBetweenIndices/Code.cxx
@@ -25,11 +25,9 @@
 int
 main()
 {
-  itk::Index<2> pixel1;
-  pixel1.Fill(2);
+  auto pixel1 = itk::Index<2>::Filled(2);
 
-  itk::Index<2> pixel2;
-  pixel2.Fill(4);
+  auto pixel2 = itk::Index<2>::Filled(4);
 
   itk::Point<double, 2> p1;
   p1[0] = pixel1[0];

--- a/src/Core/Common/IsPixelInsideRegion/Code.cxx
+++ b/src/Core/Common/IsPixelInsideRegion/Code.cxx
@@ -29,8 +29,7 @@ main()
   using SizeType = RegionType::SizeType;
   using IndexType = RegionType::IndexType;
 
-  SizeType size;
-  size.Fill(3);
+  auto size = SizeType::Filled(3);
 
   IndexType start{};
 

--- a/src/Core/Common/IterateImageStartingAtSeed/Code.cxx
+++ b/src/Core/Common/IterateImageStartingAtSeed/Code.cxx
@@ -61,8 +61,7 @@ CreateImage(ImageType::Pointer image)
 {
   itk::Index<2> start{};
 
-  itk::Size<2> size;
-  size.Fill(100);
+  auto size = itk::Size<2>::Filled(100);
 
   itk::ImageRegion<2> region(start, size);
   image->SetRegions(region);

--- a/src/Core/Common/IterateImageStartingAtSeed/Code.cxx
+++ b/src/Core/Common/IterateImageStartingAtSeed/Code.cxx
@@ -73,8 +73,7 @@ CreateImage(ImageType::Pointer image)
   // Make a line
   for (unsigned int i = 20; i < 50; ++i)
   {
-    itk::Index<2> pixelIndex;
-    pixelIndex.Fill(i);
+    auto pixelIndex = itk::Index<2>::Filled(i);
 
     image->SetPixel(pixelIndex, 255);
   }

--- a/src/Core/Common/IterateLineThroughImage/Code.cxx
+++ b/src/Core/Common/IterateLineThroughImage/Code.cxx
@@ -88,8 +88,7 @@ main(int argc, char * argv[])
 void
 CreateImage(ImageType::Pointer image)
 {
-  ImageType::SizeType regionSize;
-  regionSize.Fill(100);
+  auto regionSize = ImageType::SizeType::Filled(100);
 
   ImageType::IndexType regionIndex{};
 

--- a/src/Core/Common/IterateLineThroughImageWithoutWriteAccess/Code.cxx
+++ b/src/Core/Common/IterateLineThroughImageWithoutWriteAccess/Code.cxx
@@ -50,8 +50,7 @@ main()
 void
 CreateImage(ImageType::Pointer image)
 {
-  ImageType::SizeType regionSize;
-  regionSize.Fill(3);
+  auto regionSize = ImageType::SizeType::Filled(3);
 
   ImageType::IndexType regionIndex{};
 

--- a/src/Core/Common/IterateOverARegionWithAShapedNeighborhoodIterator/Code.cxx
+++ b/src/Core/Common/IterateOverARegionWithAShapedNeighborhoodIterator/Code.cxx
@@ -40,8 +40,7 @@ main()
 
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(10);
+  auto size = ImageType::SizeType::Filled(10);
 
   ImageType::RegionType region(start, size);
 

--- a/src/Core/Common/IterateOverARegionWithAShapedNeighborhoodIteratorManual/Code.cxx
+++ b/src/Core/Common/IterateOverARegionWithAShapedNeighborhoodIteratorManual/Code.cxx
@@ -39,8 +39,7 @@ main()
 
   using IteratorType = itk::ShapedNeighborhoodIterator<ImageType>;
 
-  itk::Size<2> radius;
-  radius.Fill(1);
+  auto         radius = itk::Size<2>::Filled(1);
   IteratorType iterator(radius, image, image->GetLargestPossibleRegion());
   std::cout << "By default there are " << iterator.GetActiveIndexListSize() << " active indices." << std::endl;
 
@@ -87,8 +86,7 @@ CreateImage(ImageType::Pointer image)
 {
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(10);
+  auto size = ImageType::SizeType::Filled(10);
 
   ImageType::RegionType region(start, size);
 

--- a/src/Core/Common/IterateOverSpecificRegion/Code.cxx
+++ b/src/Core/Common/IterateOverSpecificRegion/Code.cxx
@@ -29,8 +29,7 @@ int
 main()
 {
 
-  ImageType::SizeType exclusionRegionSize;
-  exclusionRegionSize.Fill(2);
+  auto exclusionRegionSize = ImageType::SizeType::Filled(2);
 
   ImageType::IndexType exclusionRegionIndex{};
 
@@ -58,8 +57,7 @@ main()
 void
 CreateImage(ImageType::Pointer image)
 {
-  ImageType::SizeType regionSize;
-  regionSize.Fill(3);
+  auto regionSize = ImageType::SizeType::Filled(3);
 
   ImageType::IndexType regionIndex{};
 

--- a/src/Core/Common/NeighborhoodIteratorOnVectorImage/Code.cxx
+++ b/src/Core/Common/NeighborhoodIteratorOnVectorImage/Code.cxx
@@ -28,8 +28,7 @@ main()
 
   itk::Index<2> start{};
 
-  itk::Size<2> size;
-  size.Fill(10);
+  auto size = itk::Size<2>::Filled(10);
 
   itk::ImageRegion<2> region(start, size);
 

--- a/src/Core/Common/ObserveAnEvent/Code.cxx
+++ b/src/Core/Common/ObserveAnEvent/Code.cxx
@@ -58,8 +58,7 @@ main()
   using SourceType = itk::GaussianImageSource<ImageType>;
   auto source = SourceType::New();
 
-  ImageType::SizeType size;
-  size.Fill(128);
+  auto size = ImageType::SizeType::Filled(128);
   source->SetSize(size);
 
   SourceType::ArrayType sigma;

--- a/src/Core/Common/RandomSelectPixelFromRegionWithoutReplacee/Code.cxx
+++ b/src/Core/Common/RandomSelectPixelFromRegionWithoutReplacee/Code.cxx
@@ -24,8 +24,7 @@ main()
   using ImageType = itk::Image<unsigned char, 2>;
   auto image = ImageType::New();
 
-  ImageType::SizeType regionSize;
-  regionSize.Fill(3);
+  auto regionSize = ImageType::SizeType::Filled(3);
 
   ImageType::IndexType regionIndex{};
 

--- a/src/Core/Common/StoreNonPixelDataInImage/Code.cxx
+++ b/src/Core/Common/StoreNonPixelDataInImage/Code.cxx
@@ -78,8 +78,7 @@ CreateImage(ImageType::Pointer image)
 {
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(10);
+  auto size = ImageType::SizeType::Filled(10);
 
   ImageType::RegionType region;
   region.SetSize(size);

--- a/src/Core/Common/StreamAPipeline/Code.cxx
+++ b/src/Core/Common/StreamAPipeline/Code.cxx
@@ -35,9 +35,8 @@ main(int argc, char * argv[])
   using ImageType = itk::Image<PixelType, Dimension>;
 
   using SourceType = itk::RandomImageSource<ImageType>;
-  auto                source = SourceType::New();
-  ImageType::SizeType size;
-  size.Fill(numberOfSplits);
+  auto source = SourceType::New();
+  auto size = ImageType::SizeType::Filled(numberOfSplits);
   source->SetSize(size);
 
   using MonitorFilterType = itk::PipelineMonitorImageFilter<ImageType>;

--- a/src/Core/Common/WatchAFilter/Code.cxx
+++ b/src/Core/Common/WatchAFilter/Code.cxx
@@ -31,8 +31,7 @@ CreateImage(typename TImage::Pointer image)
   typename ImageType::RegionType region;
   typename ImageType::IndexType  start{};
 
-  typename ImageType::SizeType size;
-  size.Fill(100);
+  auto size = ImageType::SizeType::Filled(100);
 
   region.SetSize(size);
   region.SetIndex(start);

--- a/src/Core/ImageAdaptors/AddConstantToPixelsWithoutDuplicatingImage/Code.cxx
+++ b/src/Core/ImageAdaptors/AddConstantToPixelsWithoutDuplicatingImage/Code.cxx
@@ -64,8 +64,7 @@ CreateImage(ImageType::Pointer image)
 {
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(10);
+  auto size = ImageType::SizeType::Filled(10);
 
   ImageType::RegionType region;
   region.SetSize(size);

--- a/src/Core/ImageAdaptors/ExtractChannelOfImageWithMultipleComponents/Code.cxx
+++ b/src/Core/ImageAdaptors/ExtractChannelOfImageWithMultipleComponents/Code.cxx
@@ -51,8 +51,7 @@ CreateImage(VectorImageType::Pointer image)
 {
   VectorImageType::IndexType start{};
 
-  VectorImageType::SizeType size;
-  size.Fill(2);
+  auto size = VectorImageType::SizeType::Filled(2);
 
   VectorImageType::RegionType region;
   region.SetSize(size);

--- a/src/Core/ImageAdaptors/PresentImageAfterOperation/Code.cxx
+++ b/src/Core/ImageAdaptors/PresentImageAfterOperation/Code.cxx
@@ -80,8 +80,7 @@ CreateImage(VectorImageType::Pointer image)
 {
   VectorImageType::IndexType start{};
 
-  VectorImageType::SizeType size;
-  size.Fill(2);
+  auto size = VectorImageType::SizeType::Filled(2);
 
   VectorImageType::RegionType region;
   region.SetSize(size);

--- a/src/Core/ImageAdaptors/ProcessNthComponentOfVectorImage/Code.cxx
+++ b/src/Core/ImageAdaptors/ProcessNthComponentOfVectorImage/Code.cxx
@@ -51,8 +51,7 @@ CreateImage(VectorImageType::Pointer image)
 {
   VectorImageType::IndexType start{};
 
-  VectorImageType::SizeType size;
-  size.Fill(2);
+  auto size = VectorImageType::SizeType::Filled(2);
 
   VectorImageType::RegionType region;
   region.SetSize(size);

--- a/src/Core/ImageAdaptors/ViewComponentVectorImageAsScaleImage/Code.cxx
+++ b/src/Core/ImageAdaptors/ViewComponentVectorImageAsScaleImage/Code.cxx
@@ -51,8 +51,7 @@ CreateImage(VectorImageType::Pointer image)
 {
   VectorImageType::IndexType start{};
 
-  VectorImageType::SizeType size;
-  size.Fill(2);
+  auto size = VectorImageType::SizeType::Filled(2);
 
   VectorImageType::RegionType region;
   region.SetSize(size);

--- a/src/Core/ImageFunction/ComputeMedianOfImageAtPixel/Code.cxx
+++ b/src/Core/ImageFunction/ComputeMedianOfImageAtPixel/Code.cxx
@@ -47,8 +47,7 @@ CreateImage(UnsignedCharImageType::Pointer image)
 {
   itk::Index<2> start{};
 
-  itk::Size<2> size;
-  size.Fill(100);
+  auto size = itk::Size<2>::Filled(100);
 
   itk::ImageRegion<2> region(start, size);
 

--- a/src/Core/ImageFunction/ComputeMedianOfImageAtPixel/Code.cxx
+++ b/src/Core/ImageFunction/ComputeMedianOfImageAtPixel/Code.cxx
@@ -35,8 +35,7 @@ main()
   auto medianImageFunction = MedianImageFunctionType::New();
   medianImageFunction->SetInputImage(image);
 
-  itk::Index<2> index;
-  index.Fill(10);
+  auto index = itk::Index<2>::Filled(10);
   std::cout << "Median at " << index << " is " << static_cast<int>(medianImageFunction->EvaluateAtIndex(index))
             << std::endl;
   return EXIT_SUCCESS;

--- a/src/Core/ImageFunction/MultiplyKernelWithAnImageAtLocation/Code.cxx
+++ b/src/Core/ImageFunction/MultiplyKernelWithAnImageAtLocation/Code.cxx
@@ -76,8 +76,7 @@ CreateImage(UnsignedCharImageType::Pointer image)
   // Create an image with 2 connected components
   UnsignedCharImageType::IndexType start{};
 
-  UnsignedCharImageType::SizeType size;
-  size.Fill(100);
+  auto size = UnsignedCharImageType::SizeType::Filled(100);
 
   UnsignedCharImageType::RegionType region(start, size);
 

--- a/src/Core/ImageFunction/MultiplyKernelWithAnImageAtLocation/Code.cxx
+++ b/src/Core/ImageFunction/MultiplyKernelWithAnImageAtLocation/Code.cxx
@@ -44,24 +44,21 @@ main()
   neighborhoodOperatorImageFunction->SetInputImage(image);
 
   {
-    itk::Index<2> index;
-    index.Fill(20);
+    auto index = itk::Index<2>::Filled(20);
 
     float output = neighborhoodOperatorImageFunction->EvaluateAtIndex(index);
     std::cout << "Sum on border: " << output << std::endl;
   }
 
   {
-    itk::Index<2> index;
-    index.Fill(35);
+    auto index = itk::Index<2>::Filled(35);
 
     float output = neighborhoodOperatorImageFunction->EvaluateAtIndex(index);
     std::cout << "Sum in center: " << output << std::endl;
   }
 
   {
-    itk::Index<2> index;
-    index.Fill(7);
+    auto index = itk::Index<2>::Filled(7);
 
     float output = neighborhoodOperatorImageFunction->EvaluateAtIndex(index);
     std::cout << "Sum outside: " << output << std::endl;

--- a/src/Core/SpatialObjects/ContourSpatialObject/Code.cxx
+++ b/src/Core/SpatialObjects/ContourSpatialObject/Code.cxx
@@ -55,9 +55,8 @@ main(int /*argc*/, char * /*argv*/[])
   auto contour = ContourType::New();
   contour->SetControlPoints(points);
 
-  auto         imageFilter = SpatialObjectToImageFilterType::New();
-  itk::Size<2> size;
-  size.Fill(50);
+  auto imageFilter = SpatialObjectToImageFilterType::New();
+  auto size = itk::Size<2>::Filled(50);
   imageFilter->SetInsideValue(255); // white
   imageFilter->SetSize(size);
   imageFilter->SetInput(contour);

--- a/src/Core/SpatialObjects/CreateALineSpatialObject/Code.cxx
+++ b/src/Core/SpatialObjects/CreateALineSpatialObject/Code.cxx
@@ -51,9 +51,8 @@ main(int itkNotUsed(argc), char * itkNotUsed(argv)[])
   auto line = LineType::New();
   line->SetPoints(points);
 
-  auto         imageFilter = SpatialObjectToImageFilterType::New();
-  itk::Size<2> size;
-  size.Fill(50);
+  auto imageFilter = SpatialObjectToImageFilterType::New();
+  auto size = itk::Size<2>::Filled(50);
   imageFilter->SetInsideValue(255); // white
   imageFilter->SetSize(size);
   imageFilter->SetInput(line);

--- a/src/Core/TestKernel/GenerateRandomImage/Code.cxx
+++ b/src/Core/TestKernel/GenerateRandomImage/Code.cxx
@@ -36,8 +36,7 @@ main(int argc, char * argv[])
 
   using ImageType = itk::Image<PixelType, Dimension>;
 
-  ImageType::SizeType size;
-  size.Fill(10);
+  auto size = ImageType::SizeType::Filled(10);
 
   using RandomImageSourceType = itk::RandomImageSource<ImageType>;
 

--- a/src/Core/Transform/TranslateAVectorImage/Code.cxx
+++ b/src/Core/Transform/TranslateAVectorImage/Code.cxx
@@ -31,8 +31,7 @@ main()
   auto          image = VectorImageType::New();
   itk::Index<2> start{};
 
-  itk::Size<2> size;
-  size.Fill(10);
+  auto size = itk::Size<2>::Filled(10);
 
   itk::ImageRegion<2> region(start, size);
   image->SetRegions(region);

--- a/src/Developer/ImageFilterMultipleOutputsDifferentType.hxx
+++ b/src/Developer/ImageFilterMultipleOutputsDifferentType.hxx
@@ -26,8 +26,7 @@ ImageFilterMultipleOutputsDifferentType<TInputImage, TOutputImage1, TOutputImage
 {
   itk::Index<2> start{};
 
-  itk::Size<2> size;
-  size.Fill(20);
+  auto size = itk::Size<2>::Filled(20);
 
   itk::ImageRegion<2> region(start, size);
 

--- a/src/Filtering/BinaryMathematicalMorphology/ThinImage/Code.cxx
+++ b/src/Filtering/BinaryMathematicalMorphology/ThinImage/Code.cxx
@@ -64,8 +64,7 @@ CreateImage(ImageType::Pointer image)
   // Create an image
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(100);
+  auto size = ImageType::SizeType::Filled(100);
 
   ImageType::RegionType region(start, size);
 

--- a/src/Filtering/Convolution/ColorNormalizedCorrelation/Code.cxx
+++ b/src/Filtering/Convolution/ColorNormalizedCorrelation/Code.cxx
@@ -60,8 +60,7 @@ main(int argc, char * argv[])
 
   auto extractFilter = ExtractFilterType::New();
 
-  FloatImageType::IndexType start;
-  start.Fill(50);
+  auto start = FloatImageType::IndexType::Filled(50);
 
   auto patchSize = FloatImageType::SizeType::Filled(51);
 

--- a/src/Filtering/Convolution/ColorNormalizedCorrelation/Code.cxx
+++ b/src/Filtering/Convolution/ColorNormalizedCorrelation/Code.cxx
@@ -63,8 +63,7 @@ main(int argc, char * argv[])
   FloatImageType::IndexType start;
   start.Fill(50);
 
-  FloatImageType::SizeType patchSize;
-  patchSize.Fill(51);
+  auto patchSize = FloatImageType::SizeType::Filled(51);
 
   FloatImageType::RegionType desiredRegion(start, patchSize);
 

--- a/src/Filtering/Convolution/ConvolveImageWithKernel/Code.cxx
+++ b/src/Filtering/Convolution/ConvolveImageWithKernel/Code.cxx
@@ -79,8 +79,7 @@ CreateKernel(ImageType::Pointer kernel, unsigned int width)
 {
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(width);
+  auto size = ImageType::SizeType::Filled(width);
 
   ImageType::RegionType region;
   region.SetSize(size);

--- a/src/Filtering/Convolution/NormalizedCorrelation/Code.cxx
+++ b/src/Filtering/Convolution/NormalizedCorrelation/Code.cxx
@@ -52,8 +52,7 @@ main(int argc, char * argv[])
   FloatImageType::IndexType start;
   start.Fill(50);
 
-  FloatImageType::SizeType patchSize;
-  patchSize.Fill(51);
+  auto patchSize = FloatImageType::SizeType::Filled(51);
 
   FloatImageType::RegionType desiredRegion(start, patchSize);
 

--- a/src/Filtering/Convolution/NormalizedCorrelation/Code.cxx
+++ b/src/Filtering/Convolution/NormalizedCorrelation/Code.cxx
@@ -49,8 +49,7 @@ main(int argc, char * argv[])
 
   auto extractFilter = ExtractFilterType::New();
 
-  FloatImageType::IndexType start;
-  start.Fill(50);
+  auto start = FloatImageType::IndexType::Filled(50);
 
   auto patchSize = FloatImageType::SizeType::Filled(51);
 

--- a/src/Filtering/Convolution/NormalizedCorrelationOfMaskedImage/Code.cxx
+++ b/src/Filtering/Convolution/NormalizedCorrelationOfMaskedImage/Code.cxx
@@ -128,8 +128,7 @@ CreateMask(MaskType * const mask)
 {
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(51);
+  auto size = ImageType::SizeType::Filled(51);
 
   ImageType::RegionType region(start, size);
 
@@ -162,8 +161,7 @@ CreateImage(ImageType * const image)
 {
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(51);
+  auto size = ImageType::SizeType::Filled(51);
 
   ImageType::RegionType region(start, size);
 
@@ -177,8 +175,7 @@ CreateImageOfSquare(ImageType * const image, const itk::Index<2> & cornerOfSquar
 {
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(51);
+  auto size = ImageType::SizeType::Filled(51);
 
   ImageType::RegionType region(start, size);
 

--- a/src/Filtering/Convolution/NormalizedCorrelationUsingFFT/Code.cxx
+++ b/src/Filtering/Convolution/NormalizedCorrelationUsingFFT/Code.cxx
@@ -103,8 +103,7 @@ CreateImage(ImageType::Pointer image, const itk::Index<2> & cornerOfSquare)
 {
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(51);
+  auto size = ImageType::SizeType::Filled(51);
 
   ImageType::RegionType region(start, size);
 

--- a/src/Filtering/Convolution/NormalizedCorrelationUsingFFTWithMaskImages/Code.cxx
+++ b/src/Filtering/Convolution/NormalizedCorrelationUsingFFTWithMaskImages/Code.cxx
@@ -110,8 +110,7 @@ CreateImage(ImageType::Pointer image, const itk::Index<2> & cornerOfSquare)
 {
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(51);
+  auto size = ImageType::SizeType::Filled(51);
 
   ImageType::RegionType region(start, size);
 
@@ -141,8 +140,7 @@ CreateMask(MaskType * const mask)
 {
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(51);
+  auto size = ImageType::SizeType::Filled(51);
 
   ImageType::RegionType region(start, size);
 

--- a/src/Filtering/DistanceMap/ApproxDistanceMapOfBinary/Code.cxx
+++ b/src/Filtering/DistanceMap/ApproxDistanceMapOfBinary/Code.cxx
@@ -75,8 +75,7 @@ CreateImage(UnsignedCharImageType::Pointer image)
   // Create an image
   itk::Index<2> start{};
 
-  itk::Size<2> size;
-  size.Fill(100);
+  auto size = itk::Size<2>::Filled(100);
 
   itk::ImageRegion<2> region(start, size);
   image->SetRegions(region);

--- a/src/Filtering/DistanceMap/ApproxDistanceMapOfBinary/Code.cxx
+++ b/src/Filtering/DistanceMap/ApproxDistanceMapOfBinary/Code.cxx
@@ -85,8 +85,7 @@ CreateImage(UnsignedCharImageType::Pointer image)
   // Create a line of white pixels
   for (unsigned int i = 40; i < 60; ++i)
   {
-    itk::Index<2> pixel;
-    pixel.Fill(i);
+    auto pixel = itk::Index<2>::Filled(i);
     image->SetPixel(pixel, 255);
   }
 }

--- a/src/Filtering/DistanceMap/MaurerDistanceMapOfBinary/Code.cxx
+++ b/src/Filtering/DistanceMap/MaurerDistanceMapOfBinary/Code.cxx
@@ -73,8 +73,7 @@ CreateImage(UnsignedCharImageType::Pointer image)
   // Create an image
   itk::Index<2> start{};
 
-  itk::Size<2> size;
-  size.Fill(100);
+  auto size = itk::Size<2>::Filled(100);
 
   itk::ImageRegion<2> region(start, size);
   image->SetRegions(region);

--- a/src/Filtering/DistanceMap/MaurerDistanceMapOfBinary/Code.cxx
+++ b/src/Filtering/DistanceMap/MaurerDistanceMapOfBinary/Code.cxx
@@ -83,8 +83,7 @@ CreateImage(UnsignedCharImageType::Pointer image)
   // Create a line of white pixels
   for (unsigned int i = 40; i < 60; ++i)
   {
-    itk::Index<2> pixel;
-    pixel.Fill(i);
+    auto pixel = itk::Index<2>::Filled(i);
     image->SetPixel(pixel, 255);
   }
 }

--- a/src/Filtering/DistanceMap/SignedDistanceMapOfBinary/Code.cxx
+++ b/src/Filtering/DistanceMap/SignedDistanceMapOfBinary/Code.cxx
@@ -73,8 +73,7 @@ CreateImage(UnsignedCharImageType::Pointer image)
   // Create an image
   itk::Index<2> start{};
 
-  itk::Size<2> size;
-  size.Fill(100);
+  auto size = itk::Size<2>::Filled(100);
 
   itk::ImageRegion<2> region(start, size);
   image->SetRegions(region);

--- a/src/Filtering/DistanceMap/SignedDistanceMapOfBinary/Code.cxx
+++ b/src/Filtering/DistanceMap/SignedDistanceMapOfBinary/Code.cxx
@@ -83,8 +83,7 @@ CreateImage(UnsignedCharImageType::Pointer image)
   // Create a line of white pixels
   for (unsigned int i = 40; i < 60; ++i)
   {
-    itk::Index<2> pixel;
-    pixel.Fill(i);
+    auto pixel = itk::Index<2>::Filled(i);
     image->SetPixel(pixel, 255);
   }
 }

--- a/src/Filtering/ImageCompare/AbsValueOfTwoImages/Code.cxx
+++ b/src/Filtering/ImageCompare/AbsValueOfTwoImages/Code.cxx
@@ -53,8 +53,7 @@ CreateImage1(UnsignedCharImageType::Pointer image)
 {
   UnsignedCharImageType::IndexType start{};
 
-  UnsignedCharImageType::SizeType size;
-  size.Fill(10);
+  auto size = UnsignedCharImageType::SizeType::Filled(10);
 
   UnsignedCharImageType::RegionType region;
   region.SetSize(size);
@@ -80,8 +79,7 @@ CreateImage2(UnsignedCharImageType::Pointer image)
   // Create an image with 2 connected components
   UnsignedCharImageType::IndexType start{};
 
-  UnsignedCharImageType::SizeType size;
-  size.Fill(10);
+  auto size = UnsignedCharImageType::SizeType::Filled(10);
 
   UnsignedCharImageType::RegionType region;
   region.SetSize(size);

--- a/src/Filtering/ImageCompare/CombineTwoImagesWithCheckerBoardPattern/Code.cxx
+++ b/src/Filtering/ImageCompare/CombineTwoImagesWithCheckerBoardPattern/Code.cxx
@@ -37,8 +37,7 @@ main(int argc, char * argv[])
 
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(100);
+  auto size = ImageType::SizeType::Filled(100);
 
   ImageType::RegionType region;
   region.SetSize(size);

--- a/src/Filtering/ImageCompare/SquaredDifferenceOfTwoImages/Code.cxx
+++ b/src/Filtering/ImageCompare/SquaredDifferenceOfTwoImages/Code.cxx
@@ -52,8 +52,7 @@ CreateImage1(UnsignedCharImageType::Pointer image)
 {
   UnsignedCharImageType::IndexType start{};
 
-  UnsignedCharImageType::SizeType size;
-  size.Fill(10);
+  auto size = UnsignedCharImageType::SizeType::Filled(10);
 
   UnsignedCharImageType::RegionType region;
   region.SetSize(size);
@@ -79,8 +78,7 @@ CreateImage2(UnsignedCharImageType::Pointer image)
   // Create an image with 2 connected components
   UnsignedCharImageType::IndexType start{};
 
-  UnsignedCharImageType::SizeType size;
-  size.Fill(10);
+  auto size = UnsignedCharImageType::SizeType::Filled(10);
 
   UnsignedCharImageType::RegionType region;
   region.SetSize(size);

--- a/src/Filtering/ImageCompose/ComposeVectorFromThreeScalarImages/Code.cxx
+++ b/src/Filtering/ImageCompose/ComposeVectorFromThreeScalarImages/Code.cxx
@@ -53,8 +53,7 @@ CreateImage(ScalarImageType::Pointer image)
 {
   ScalarImageType::IndexType start{};
 
-  ScalarImageType::SizeType size;
-  size.Fill(2);
+  auto size = ScalarImageType::SizeType::Filled(2);
 
   ScalarImageType::RegionType region;
   region.SetSize(size);

--- a/src/Filtering/ImageCompose/CreateVectorImageFromScalarImages/Code.cxx
+++ b/src/Filtering/ImageCompose/CreateVectorImageFromScalarImages/Code.cxx
@@ -57,8 +57,7 @@ CreateImage(ScalarImageType::Pointer image)
 {
   ScalarImageType::IndexType start{};
 
-  ScalarImageType::SizeType size;
-  size.Fill(100);
+  auto size = ScalarImageType::SizeType::Filled(100);
 
   ScalarImageType::RegionType region(start, size);
 

--- a/src/Filtering/ImageCompose/JoinImages/Code.cxx
+++ b/src/Filtering/ImageCompose/JoinImages/Code.cxx
@@ -57,8 +57,7 @@ CreateImage(ImageType::Pointer image, unsigned char value)
   // Create an image
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(100);
+  auto size = ImageType::SizeType::Filled(100);
 
   ImageType::RegionType region(start, size);
 

--- a/src/Filtering/ImageFeature/ApplyAFilterOnlyToASpecifiedImageRegion/Code.cxx
+++ b/src/Filtering/ImageFeature/ApplyAFilterOnlyToASpecifiedImageRegion/Code.cxx
@@ -24,15 +24,13 @@ main()
 {
   using ImageType = itk::Image<float, 2>;
 
-  itk::Size<2> smallSize;
-  smallSize.Fill(10);
+  auto smallSize = itk::Size<2>::Filled(10);
 
   itk::Index<2> index{};
 
   itk::ImageRegion<2> region(index, smallSize);
 
-  itk::Size<2> bigSize;
-  bigSize.Fill(10000);
+  auto bigSize = itk::Size<2>::Filled(10000);
 
   itk::RandomImageSource<ImageType>::Pointer randomImageSource = itk::RandomImageSource<ImageType>::New();
   randomImageSource->SetNumberOfWorkUnits(1); // to produce non-random results

--- a/src/Filtering/ImageFeature/ExtractContoursFromImage/Code.cxx
+++ b/src/Filtering/ImageFeature/ExtractContoursFromImage/Code.cxx
@@ -61,8 +61,7 @@ void CreateImage(UnsignedCharImageType::Pointer image)
   // Create a line pixels
   for(unsigned int i = 40; i < 60; ++i)
     {
-    itk::Index<2> pixel;
-    pixel.Fill(i);
+    auto pixel = itk::Index<2>::Filled(i);
     image->SetPixel(pixel, 255);
     }
 

--- a/src/Filtering/ImageFeature/ExtractContoursFromImage/Code.cxx
+++ b/src/Filtering/ImageFeature/ExtractContoursFromImage/Code.cxx
@@ -50,8 +50,7 @@ void CreateImage(UnsignedCharImageType::Pointer image)
   // Create an image
   itk::Index<2> start{};
 
-  itk::Size<2> size;
-  size.Fill(100);
+  auto size = itk::Size<2>::Filled(100);
 
   itk::ImageRegion<2> region(start,size);
 

--- a/src/Filtering/ImageFeature/FindZeroCrossingsInSignedImage/Code.cxx
+++ b/src/Filtering/ImageFeature/FindZeroCrossingsInSignedImage/Code.cxx
@@ -69,8 +69,7 @@ CreateImage(ImageType::Pointer image)
 {
   itk::Index<2> start{};
 
-  itk::Size<2> size;
-  size.Fill(100);
+  auto size = itk::Size<2>::Filled(100);
 
   itk::ImageRegion<2> region(start, size);
 

--- a/src/Filtering/ImageFilterBase/ApplyKernelToEveryPixel/Code.cxx
+++ b/src/Filtering/ImageFilterBase/ApplyKernelToEveryPixel/Code.cxx
@@ -37,9 +37,8 @@ main()
 
   using SobelOperatorType = itk::SobelOperator<float, 2>;
   SobelOperatorType sobelOperator;
-  itk::Size<2>      radius;
-  radius.Fill(1);                // a radius of 1x1 creates a 3x3 operator
-  sobelOperator.SetDirection(0); // Create the operator for the X axis derivative
+  auto              radius = itk::Size<2>::Filled(1); // a radius of 1x1 creates a 3x3 operator
+  sobelOperator.SetDirection(0);                      // Create the operator for the X axis derivative
   sobelOperator.CreateToRadius(radius);
 
   using NeighborhoodOperatorImageFilterType = itk::NeighborhoodOperatorImageFilter<FloatImageType, FloatImageType>;
@@ -58,8 +57,7 @@ CreateImage(FloatImageType::Pointer image)
 {
   FloatImageType::IndexType start{};
 
-  FloatImageType::SizeType size;
-  size.Fill(100);
+  auto size = FloatImageType::SizeType::Filled(100);
 
   FloatImageType::RegionType region(start, size);
 

--- a/src/Filtering/ImageFilterBase/ApplyKernelToEveryPixelInNonZeroImage/Code.cxx
+++ b/src/Filtering/ImageFilterBase/ApplyKernelToEveryPixelInNonZeroImage/Code.cxx
@@ -44,9 +44,8 @@ main()
 
   using SobelOperatorType = itk::SobelOperator<float, 2>;
   SobelOperatorType sobelOperator;
-  itk::Size<2>      radius;
-  radius.Fill(1);                // a radius of 1x1 creates a 3x3 operator
-  sobelOperator.SetDirection(0); // Create the operator for the X axis derivative
+  auto              radius = itk::Size<2>::Filled(1); // a radius of 1x1 creates a 3x3 operator
+  sobelOperator.SetDirection(0);                      // Create the operator for the X axis derivative
   sobelOperator.CreateToRadius(radius);
 
   // Visualize mask image
@@ -112,8 +111,7 @@ CreateImage(UnsignedCharImageType::Pointer image)
 {
   itk::Index<2> start{};
 
-  itk::Size<2> size;
-  size.Fill(100);
+  auto size = itk::Size<2>::Filled(100);
 
   itk::ImageRegion<2> region(start, size);
 

--- a/src/Filtering/ImageFilterBase/ComputeLocalNoise/Code.cxx
+++ b/src/Filtering/ImageFilterBase/ComputeLocalNoise/Code.cxx
@@ -70,8 +70,7 @@ CreateImage(ImageType::Pointer image)
   }
 
   // Create a rogue white pixel
-  ImageType::IndexType pixel;
-  pixel.Fill(20);
+  auto pixel = ImageType::IndexType::Filled(20);
   image->SetPixel(pixel, 255);
 
   itk::WriteImage(image, "input.mhd");

--- a/src/Filtering/ImageFilterBase/ComputeLocalNoise/Code.cxx
+++ b/src/Filtering/ImageFilterBase/ComputeLocalNoise/Code.cxx
@@ -47,8 +47,7 @@ CreateImage(ImageType::Pointer image)
   // Create an image that is mostly constant but has some different kinds of objects.
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(100);
+  auto size = ImageType::SizeType::Filled(100);
 
   ImageType::RegionType region(start, size);
 

--- a/src/Filtering/ImageFilterBase/CustomOperationToCorrespondingPixelsInTwoImages/Code.cxx
+++ b/src/Filtering/ImageFilterBase/CustomOperationToCorrespondingPixelsInTwoImages/Code.cxx
@@ -94,8 +94,7 @@ CreateImage(ImageType::Pointer image)
 {
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(10);
+  auto size = ImageType::SizeType::Filled(10);
 
   ImageType::RegionType region(start, size);
   image->SetRegions(region);

--- a/src/Filtering/ImageFilterBase/PredefinedOperationToCorrespondingPixelsInTwoImages/Code.cxx
+++ b/src/Filtering/ImageFilterBase/PredefinedOperationToCorrespondingPixelsInTwoImages/Code.cxx
@@ -60,8 +60,7 @@ CreateImage(ImageType::Pointer image)
 {
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(10);
+  auto size = ImageType::SizeType::Filled(10);
 
   ImageType::RegionType region(start, size);
   image->SetRegions(region);

--- a/src/Filtering/ImageFusion/ColorBoundariesOfRegions/Code.cxx
+++ b/src/Filtering/ImageFusion/ColorBoundariesOfRegions/Code.cxx
@@ -65,8 +65,7 @@ CreateImage(ImageType::Pointer image)
   // Create a black image with a white square
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(100);
+  auto size = ImageType::SizeType::Filled(100);
 
   ImageType::RegionType region;
   region.SetSize(size);

--- a/src/Filtering/ImageFusion/ColorLabeledRegions/Code.cxx
+++ b/src/Filtering/ImageFusion/ColorLabeledRegions/Code.cxx
@@ -60,8 +60,7 @@ CreateImage(ImageType::Pointer image)
   // Create a black image with a white square
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(100);
+  auto size = ImageType::SizeType::Filled(100);
 
   ImageType::RegionType region;
   region.SetSize(size);

--- a/src/Filtering/ImageFusion/OverlayLabelMapOnImage/Code.cxx
+++ b/src/Filtering/ImageFusion/OverlayLabelMapOnImage/Code.cxx
@@ -65,8 +65,7 @@ CreateImage(ImageType::Pointer image)
   // Create a black image with a white square
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(100);
+  auto size = ImageType::SizeType::Filled(100);
 
   ImageType::RegionType region;
   region.SetSize(size);

--- a/src/Filtering/ImageGrid/FitSplineIntoPointSet/Code.cxx
+++ b/src/Filtering/ImageGrid/FitSplineIntoPointSet/Code.cxx
@@ -91,9 +91,8 @@ main()
   // The output will consist of a 1-D image where each voxel contains the
   // (x,y,z) locations of the points
   using OutputImageType = itk::Image<unsigned char, 2>;
-  auto                      outputImage = OutputImageType::New();
-  OutputImageType::SizeType size;
-  size.Fill(200);
+  auto outputImage = OutputImageType::New();
+  auto size = OutputImageType::SizeType::Filled(200);
 
   OutputImageType::IndexType start{};
 

--- a/src/Filtering/ImageGrid/PadAnImageWithAConstant/Code.cxx
+++ b/src/Filtering/ImageGrid/PadAnImageWithAConstant/Code.cxx
@@ -41,11 +41,9 @@ main(int argc, char * argv[])
 
   const auto input = itk::ReadImage<ImageType>(argv[1]);
 
-  ImageType::SizeType lowerExtendRegion;
-  lowerExtendRegion.Fill(std::stoi(argv[3]));
+  auto lowerExtendRegion = ImageType::SizeType::Filled(std::stoi(argv[3]));
 
-  ImageType::SizeType upperExtendRegion;
-  upperExtendRegion.Fill(std::stoi(argv[4]));
+  auto upperExtendRegion = ImageType::SizeType::Filled(std::stoi(argv[4]));
 
   using FilterType = itk::ConstantPadImageFilter<ImageType, ImageType>;
   auto filter = FilterType::New();

--- a/src/Filtering/ImageGrid/RunImageFilterOnRegionOfImage/Code.cxx
+++ b/src/Filtering/ImageGrid/RunImageFilterOnRegionOfImage/Code.cxx
@@ -50,9 +50,8 @@ main(int argc, char * argv[])
   const auto input = itk::ReadImage<ImageType>(inputFileName);
 
   // Create and setup a median filter
-  auto                      medianFilter = FilterType::New();
-  FilterType::InputSizeType radius;
-  radius.Fill(2);
+  auto medianFilter = FilterType::New();
+  auto radius = FilterType::InputSizeType::Filled(2);
   if (argc > 2)
   {
     radius.Fill(atoi(argv[2]));

--- a/src/Filtering/ImageGrid/ShrinkImage/Code.cxx
+++ b/src/Filtering/ImageGrid/ShrinkImage/Code.cxx
@@ -52,8 +52,7 @@ CreateImage(ImageType::Pointer image)
   // Create an image with 2 connected components
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(100);
+  auto size = ImageType::SizeType::Filled(100);
 
   ImageType::RegionType region(start, size);
   image->SetRegions(region);

--- a/src/Filtering/ImageIntensity/AddConstantToEveryPixel/Code.cxx
+++ b/src/Filtering/ImageIntensity/AddConstantToEveryPixel/Code.cxx
@@ -45,8 +45,7 @@ CreateImage(ImageType::Pointer image)
 {
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(100);
+  auto size = ImageType::SizeType::Filled(100);
 
   ImageType::RegionType region;
   region.SetSize(size);

--- a/src/Filtering/ImageIntensity/ApplyAtanImageFilter/Code.cxx
+++ b/src/Filtering/ImageIntensity/ApplyAtanImageFilter/Code.cxx
@@ -38,8 +38,7 @@ main(int argc, char * argv[])
 
   using InputImageType = itk::Image<InputPixelType, Dimension>;
 
-  InputImageType::SizeType size;
-  size.Fill(100);
+  auto size = InputImageType::SizeType::Filled(100);
 
   using RandomImageSourceType = itk::RandomImageSource<InputImageType>;
 

--- a/src/Filtering/ImageIntensity/BinaryANDTwoImages/Code.cxx
+++ b/src/Filtering/ImageIntensity/BinaryANDTwoImages/Code.cxx
@@ -57,8 +57,7 @@ CreateImage1(ImageType::Pointer image)
 {
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(100);
+  auto size = ImageType::SizeType::Filled(100);
 
   ImageType::RegionType region;
   region.SetSize(size);
@@ -89,8 +88,7 @@ CreateImage2(ImageType::Pointer image)
 {
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(100);
+  auto size = ImageType::SizeType::Filled(100);
 
   ImageType::RegionType region;
   region.SetSize(size);

--- a/src/Filtering/ImageIntensity/BinaryORTwoImages/Code.cxx
+++ b/src/Filtering/ImageIntensity/BinaryORTwoImages/Code.cxx
@@ -56,8 +56,7 @@ CreateImage1(ImageType::Pointer image)
 {
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(100);
+  auto size = ImageType::SizeType::Filled(100);
 
   ImageType::RegionType region;
   region.SetSize(size);
@@ -88,8 +87,7 @@ CreateImage2(ImageType::Pointer image)
 {
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(100);
+  auto size = ImageType::SizeType::Filled(100);
 
   ImageType::RegionType region;
   region.SetSize(size);

--- a/src/Filtering/ImageIntensity/BinaryXORTwoImages/Code.cxx
+++ b/src/Filtering/ImageIntensity/BinaryXORTwoImages/Code.cxx
@@ -52,8 +52,7 @@ CreateImage1(ImageType::Pointer image)
 {
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(100);
+  auto size = ImageType::SizeType::Filled(100);
 
   ImageType::RegionType region;
   region.SetSize(size);
@@ -84,8 +83,7 @@ CreateImage2(ImageType::Pointer image)
 {
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(100);
+  auto size = ImageType::SizeType::Filled(100);
 
   ImageType::RegionType region;
   region.SetSize(size);

--- a/src/Filtering/ImageIntensity/CompareTwoImagesAndSetOutputPixelToMax/Code.cxx
+++ b/src/Filtering/ImageIntensity/CompareTwoImagesAndSetOutputPixelToMax/Code.cxx
@@ -50,8 +50,7 @@ CreateImage1(ImageType * image)
 {
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(100);
+  auto size = ImageType::SizeType::Filled(100);
 
   ImageType::RegionType region;
   region.SetSize(size);
@@ -82,8 +81,7 @@ CreateImage2(ImageType * image)
 {
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(100);
+  auto size = ImageType::SizeType::Filled(100);
 
   ImageType::RegionType region;
   region.SetSize(size);

--- a/src/Filtering/ImageIntensity/CompareTwoImagesAndSetOutputPixelToMin/Code.cxx
+++ b/src/Filtering/ImageIntensity/CompareTwoImagesAndSetOutputPixelToMin/Code.cxx
@@ -50,8 +50,7 @@ CreateImage1(ImageType * image)
 {
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(100);
+  auto size = ImageType::SizeType::Filled(100);
 
   ImageType::RegionType region;
   region.SetSize(size);
@@ -82,8 +81,7 @@ CreateImage2(ImageType * image)
 {
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(100);
+  auto size = ImageType::SizeType::Filled(100);
 
   ImageType::RegionType region;
   region.SetSize(size);

--- a/src/Filtering/ImageIntensity/ComputeEdgePotential/Code.cxx
+++ b/src/Filtering/ImageIntensity/ComputeEdgePotential/Code.cxx
@@ -71,8 +71,7 @@ CreateImage(UnsignedCharImageType::Pointer image)
 
   UnsignedCharImageType::IndexType start{};
 
-  UnsignedCharImageType::SizeType size;
-  size.Fill(200);
+  auto size = UnsignedCharImageType::SizeType::Filled(200);
 
   UnsignedCharImageType::RegionType region(start, size);
   image->SetRegions(region);

--- a/src/Filtering/ImageIntensity/ExtractComponentOfVectorImage/Code.cxx
+++ b/src/Filtering/ImageIntensity/ExtractComponentOfVectorImage/Code.cxx
@@ -50,8 +50,7 @@ CreateImage(VectorImageType::Pointer image)
 {
   VectorImageType::IndexType start{};
 
-  VectorImageType::SizeType size;
-  size.Fill(2);
+  auto size = VectorImageType::SizeType::Filled(2);
 
   VectorImageType::RegionType region(start, size);
 

--- a/src/Filtering/ImageIntensity/IntensityWindowing/Code.cxx
+++ b/src/Filtering/ImageIntensity/IntensityWindowing/Code.cxx
@@ -51,8 +51,7 @@ CreateImage(ImageType::Pointer image)
 {
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(100);
+  auto size = ImageType::SizeType::Filled(100);
 
   ImageType::RegionType region(start, size);
 

--- a/src/Filtering/ImageIntensity/InverseOfMaskToImage/Code.cxx
+++ b/src/Filtering/ImageIntensity/InverseOfMaskToImage/Code.cxx
@@ -80,8 +80,7 @@ CreateImage(ImageType::Pointer image)
 {
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(100);
+  auto size = ImageType::SizeType::Filled(100);
 
   ImageType::RegionType region(start, size);
 

--- a/src/Filtering/ImageIntensity/ScalePixelSumToConstant/Code.cxx
+++ b/src/Filtering/ImageIntensity/ScalePixelSumToConstant/Code.cxx
@@ -59,8 +59,7 @@ CreateImage(ImageType::Pointer image)
 
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(3);
+  auto size = ImageType::SizeType::Filled(3);
 
   ImageType::RegionType region(start, size);
 

--- a/src/Filtering/ImageIntensity/SquareEveryPixel/Code.cxx
+++ b/src/Filtering/ImageIntensity/SquareEveryPixel/Code.cxx
@@ -44,8 +44,7 @@ CreateImage(ImageType::Pointer image)
 {
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(100);
+  auto size = ImageType::SizeType::Filled(100);
 
   ImageType::RegionType region;
   region.SetSize(size);

--- a/src/Filtering/ImageIntensity/SubtractConstantFromEveryPixel/Code.cxx
+++ b/src/Filtering/ImageIntensity/SubtractConstantFromEveryPixel/Code.cxx
@@ -45,8 +45,7 @@ CreateImage(ImageType::Pointer image)
 {
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(100);
+  auto size = ImageType::SizeType::Filled(100);
 
   ImageType::RegionType region;
   region.SetSize(size);

--- a/src/Filtering/ImageLabel/ExtractInnerAndOuterBoundariesOfBlobsInBinaryImage/Code.cxx
+++ b/src/Filtering/ImageLabel/ExtractInnerAndOuterBoundariesOfBlobsInBinaryImage/Code.cxx
@@ -73,8 +73,7 @@ CreateImage(ImageType::Pointer image)
 {
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(20);
+  auto size = ImageType::SizeType::Filled(20);
 
   ImageType::RegionType region(start, size);
 

--- a/src/Filtering/ImageStatistics/AdaptiveHistogramEqualizationImageFilter/Code.cxx
+++ b/src/Filtering/ImageStatistics/AdaptiveHistogramEqualizationImageFilter/Code.cxx
@@ -47,9 +47,8 @@ main(int argc, char * argv[])
   float beta = std::stod(argv[4]);
   adaptiveHistogramEqualizationImageFilter->SetBeta(beta);
 
-  int                                                         radiusSize = std::stoi(argv[5]);
-  AdaptiveHistogramEqualizationImageFilterType::ImageSizeType radius;
-  radius.Fill(radiusSize);
+  int  radiusSize = std::stoi(argv[5]);
+  auto radius = AdaptiveHistogramEqualizationImageFilterType::ImageSizeType::Filled(radiusSize);
   adaptiveHistogramEqualizationImageFilter->SetRadius(radius);
 
   adaptiveHistogramEqualizationImageFilter->SetInput(input);

--- a/src/Filtering/ImageStatistics/StatisticalPropertiesOfRegions/Code.cxx
+++ b/src/Filtering/ImageStatistics/StatisticalPropertiesOfRegions/Code.cxx
@@ -85,8 +85,7 @@ CreateImage(ImageType::Pointer image)
   // Create a black image with a white square
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(20);
+  auto size = ImageType::SizeType::Filled(20);
 
   ImageType::RegionType region;
   region.SetSize(size);

--- a/src/Filtering/LabelMap/ConvertLabelMapToImage/Code.cxx
+++ b/src/Filtering/LabelMap/ConvertLabelMapToImage/Code.cxx
@@ -51,8 +51,7 @@ CreateImage(ImageType::Pointer image)
   // Create a black image with a white square
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(20);
+  auto size = ImageType::SizeType::Filled(20);
 
   ImageType::RegionType region;
   region.SetSize(size);

--- a/src/Filtering/LabelMap/InvertImageUsingBinaryNot/Code.cxx
+++ b/src/Filtering/LabelMap/InvertImageUsingBinaryNot/Code.cxx
@@ -51,8 +51,7 @@ CreateImage(ImageType::Pointer image)
 {
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(100);
+  auto size = ImageType::SizeType::Filled(100);
 
   ImageType::RegionType region;
   region.SetSize(size);

--- a/src/Filtering/LabelMap/KeepRegionsAboveLevel/Code.cxx
+++ b/src/Filtering/LabelMap/KeepRegionsAboveLevel/Code.cxx
@@ -77,8 +77,7 @@ CreateImage(ImageType::Pointer image)
   // Create a black image with three white squares
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(200);
+  auto size = ImageType::SizeType::Filled(200);
 
   ImageType::RegionType region;
   region.SetSize(size);

--- a/src/Filtering/LabelMap/KeepRegionsThatMeetSpecific/Code.cxx
+++ b/src/Filtering/LabelMap/KeepRegionsThatMeetSpecific/Code.cxx
@@ -79,8 +79,7 @@ CreateImage(ImageType::Pointer image)
   // Create a black image with three white squares
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(200);
+  auto size = ImageType::SizeType::Filled(200);
 
   ImageType::RegionType region;
   region.SetSize(size);

--- a/src/Filtering/LabelMap/LabelBinaryRegionsAndGetProperties/Code.cxx
+++ b/src/Filtering/LabelMap/LabelBinaryRegionsAndGetProperties/Code.cxx
@@ -62,8 +62,7 @@ CreateImage(ImageType::Pointer image)
   // Create a black image with a white square
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(20);
+  auto size = ImageType::SizeType::Filled(20);
 
   ImageType::RegionType region;
   region.SetSize(size);

--- a/src/Filtering/LabelMap/LabelBinaryRegionsInImage/Code.cxx
+++ b/src/Filtering/LabelMap/LabelBinaryRegionsInImage/Code.cxx
@@ -62,8 +62,7 @@ CreateImage(ImageType::Pointer image)
   // Create a black image with a white square
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(20);
+  auto size = ImageType::SizeType::Filled(20);
 
   ImageType::RegionType region;
   region.SetSize(size);

--- a/src/Filtering/LabelMap/MaskOneImageGivenLabelMap/Code.cxx
+++ b/src/Filtering/LabelMap/MaskOneImageGivenLabelMap/Code.cxx
@@ -92,8 +92,7 @@ main(int argc, char * argv[])
   // The crop border defaults to 0, and the image is not cropped by default.
   filter->SetCrop(crop);
 
-  FilterType::SizeType border;
-  border.Fill(borderSize);
+  auto border = FilterType::SizeType::Filled(borderSize);
 
   filter->SetCropBorder(border);
 

--- a/src/Filtering/LabelMap/RemoveLabelsFromLabelMap/Code.cxx
+++ b/src/Filtering/LabelMap/RemoveLabelsFromLabelMap/Code.cxx
@@ -79,8 +79,7 @@ CreateImage(ImageType::Pointer image)
   // Create a black image with a white square
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(20);
+  auto size = ImageType::SizeType::Filled(20);
 
   ImageType::RegionType region(start, size);
   image->SetRegions(region);

--- a/src/Filtering/Path/ExtractContoursFromImage/Code.cxx
+++ b/src/Filtering/Path/ExtractContoursFromImage/Code.cxx
@@ -72,8 +72,7 @@ CreateImage(UnsignedCharImageType::Pointer image)
   // Create an image
   itk::Index<2> start{};
 
-  itk::Size<2> size;
-  size.Fill(100);
+  auto size = itk::Size<2>::Filled(100);
 
   itk::ImageRegion<2> region(start, size);
   image->SetRegions(region);

--- a/src/Filtering/Path/ExtractContoursFromImage/Code.cxx
+++ b/src/Filtering/Path/ExtractContoursFromImage/Code.cxx
@@ -82,8 +82,7 @@ CreateImage(UnsignedCharImageType::Pointer image)
   // Create a line of white pixels
   for (unsigned int i = 40; i < 60; ++i)
   {
-    itk::Index<2> pixel;
-    pixel.Fill(i);
+    auto pixel = itk::Index<2>::Filled(i);
     image->SetPixel(pixel, 255);
   }
 

--- a/src/Filtering/Smoothing/MeanFilteringOfAnImage/Code.cxx
+++ b/src/Filtering/Smoothing/MeanFilteringOfAnImage/Code.cxx
@@ -45,8 +45,7 @@ main(int argc, char * argv[])
   using FilterType = itk::MeanImageFilter<ImageType, ImageType>;
   auto meanFilter = FilterType::New();
 
-  FilterType::InputSizeType radius;
-  radius.Fill(radiusValue);
+  auto radius = FilterType::InputSizeType::Filled(radiusValue);
 
   meanFilter->SetRadius(radius);
   meanFilter->SetInput(input);

--- a/src/Filtering/Smoothing/MedianFilteringOfAnImage/Code.cxx
+++ b/src/Filtering/Smoothing/MedianFilteringOfAnImage/Code.cxx
@@ -45,8 +45,7 @@ main(int argc, char * argv[])
   using FilterType = itk::MedianImageFilter<ImageType, ImageType>;
   auto medianFilter = FilterType::New();
 
-  FilterType::InputSizeType radius;
-  radius.Fill(radiusValue);
+  auto radius = FilterType::InputSizeType::Filled(radiusValue);
 
   medianFilter->SetRadius(radius);
   medianFilter->SetInput(input);

--- a/src/Filtering/Smoothing/MedianFilteringOfAnRGBImage/Code.cxx
+++ b/src/Filtering/Smoothing/MedianFilteringOfAnRGBImage/Code.cxx
@@ -76,8 +76,7 @@ main(int argc, char * argv[])
   using FilterType = itk::MedianImageFilter<MyImageType, MyImageType>;
   auto medianFilter = FilterType::New();
 
-  FilterType::InputSizeType radius;
-  radius.Fill(std::stoi(argv[3]));
+  auto radius = FilterType::InputSizeType::Filled(std::stoi(argv[3]));
 
   medianFilter->SetRadius(radius);
   medianFilter->SetInput(input);

--- a/src/Filtering/Thresholding/SeparateGroundUsingOtsu/Code.cxx
+++ b/src/Filtering/Thresholding/SeparateGroundUsingOtsu/Code.cxx
@@ -77,8 +77,7 @@ CreateImage(ImageType::Pointer image)
   // Create an image
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(100);
+  auto size = ImageType::SizeType::Filled(100);
 
   ImageType::RegionType region;
   region.SetSize(size);

--- a/src/Nonunit/Review/GeometricPropertiesOfRegion/Code.cxx
+++ b/src/Nonunit/Review/GeometricPropertiesOfRegion/Code.cxx
@@ -146,8 +146,7 @@ CreateIntensityImage(ImageType::Pointer image)
   // Create a random image.
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(20);
+  auto size = ImageType::SizeType::Filled(20);
 
   ImageType::RegionType region;
   region.SetSize(size);
@@ -173,8 +172,7 @@ CreateLabelImage(ImageType::Pointer image)
   // Create a black image with labeled squares.
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(20);
+  auto size = ImageType::SizeType::Filled(20);
 
   ImageType::RegionType region;
   region.SetSize(size);

--- a/src/Numerics/Statistics/ComputeTextureFeatures/Code.cxx
+++ b/src/Numerics/Statistics/ComputeTextureFeatures/Code.cxx
@@ -48,8 +48,7 @@ CreateImage(ImageType::Pointer image)
 {
   itk::Index<2> index{};
 
-  itk::Size<2> size;
-  size.Fill(100);
+  auto size = itk::Size<2>::Filled(100);
 
   itk::ImageRegion<2> region(index, size);
   image->SetRegions(region);

--- a/src/Registration/Common/MatchFeaturePoints/Code.cxx
+++ b/src/Registration/Common/MatchFeaturePoints/Code.cxx
@@ -81,9 +81,8 @@ void
 CreateImage(ImageType::Pointer image, const unsigned int x)
 {
   // Allocate empty image
-  itk::Index<2> start{};
-  itk::Size<2>  size;
-  size.Fill(100);
+  itk::Index<2>         start{};
+  auto                  size = itk::Size<2>::Filled(100);
   ImageType::RegionType region(start, size);
   image->SetRegions(region);
   image->Allocate();

--- a/src/Registration/Common/MultiresolutionPyramidFromImage/Code.cxx
+++ b/src/Registration/Common/MultiresolutionPyramidFromImage/Code.cxx
@@ -71,8 +71,7 @@ CreateImage(UnsignedCharImageType::Pointer image)
 
   UnsignedCharImageType::IndexType start{};
 
-  UnsignedCharImageType::SizeType size;
-  size.Fill(200);
+  auto size = UnsignedCharImageType::SizeType::Filled(200);
 
   UnsignedCharImageType::RegionType region(start, size);
   image->SetRegions(region);

--- a/src/Registration/Common/RegisterImageToAnotherUsingLandmarks/Code.cxx
+++ b/src/Registration/Common/RegisterImageToAnotherUsingLandmarks/Code.cxx
@@ -112,8 +112,7 @@ CreateFixedImage(ImageType::Pointer image)
   // Create a black image with a white square
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(100);
+  auto size = ImageType::SizeType::Filled(100);
 
   ImageType::RegionType region;
   region.SetSize(size);
@@ -145,8 +144,7 @@ CreateMovingImage(ImageType::Pointer image)
   // Create a black image with a white square
   ImageType::IndexType start{};
 
-  ImageType::SizeType size;
-  size.Fill(100);
+  auto size = ImageType::SizeType::Filled(100);
 
   ImageType::RegionType region;
   region.SetSize(size);

--- a/src/Segmentation/LabelVoting/IterativeHoleFilling/Code.cxx
+++ b/src/Segmentation/LabelVoting/IterativeHoleFilling/Code.cxx
@@ -47,8 +47,7 @@ main(int argc, char * argv[])
   const auto input = itk::ReadImage<ImageType>(inputFileName);
 
   using FilterType = itk::VotingBinaryIterativeHoleFillingImageFilter<ImageType>;
-  FilterType::InputSizeType radius;
-  radius.Fill(r);
+  auto radius = FilterType::InputSizeType::Filled(r);
 
   auto filter = FilterType::New();
   filter->SetInput(input);

--- a/src/Segmentation/Voronoi/VoronoiDiagram/Code.cxx
+++ b/src/Segmentation/Voronoi/VoronoiDiagram/Code.cxx
@@ -123,8 +123,7 @@ main()
 
     ImageType::IndexType start{};
 
-    ImageType::SizeType size;
-    size.Fill(100);
+    auto size = ImageType::SizeType::Filled(100);
 
     ImageType::RegionType region(start, size);
 

--- a/src/Segmentation/Watersheds/MorphologicalWatershedSegmentation/Code.cxx
+++ b/src/Segmentation/Watersheds/MorphologicalWatershedSegmentation/Code.cxx
@@ -96,8 +96,7 @@ CreateImage(UnsignedCharImageType::Pointer image)
 
   itk::Index<2> start{};
 
-  itk::Size<2> size;
-  size.Fill(200);
+  auto size = itk::Size<2>::Filled(200);
 
   itk::ImageRegion<2> region(start, size);
   image->SetRegions(region);


### PR DESCRIPTION
- Follow-up to ITK pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4906