### PR TITLE
ENH: Bump `upload-artifact` actions version to v4

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -364,7 +364,7 @@ jobs:
           ctest -j 2 -VV -S dashboard.cmake
 
       - name: Publish Documentation html as GitHub Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Documentation
           path: |


### PR DESCRIPTION
Bump `upload-artifact` actions version to v4.

Fixes:
```
Artifact actions v3 will be closing down by January 30, 2025.
You are receiving this email because you have GitHub Actions
workflows using v3 of actions/upload-artifact or
actions/download-artifact. After this date using v3 of these
actions will result in a workflow failure.
```

received via email on Jan 7, 2025 from GitHub.