### PR TITLE
STYLE: Make pre-commit run --all-files converge

### DIFF
--- a/src/External/CMakeLists.txt
+++ b/src/External/CMakeLists.txt
@@ -1,1 +1,2 @@
-
+# No examples in this category yet; this file exists because
+# src/CMakeLists.txt calls add_subdirectory(External).

--- a/src/Filtering/AnisotropicSmoothing/ComputeCurvatureAnisotropicDiffusion/CMakeLists.txt
+++ b/src/Filtering/AnisotropicSmoothing/ComputeCurvatureAnisotropicDiffusion/CMakeLists.txt
@@ -2,7 +2,12 @@ cmake_minimum_required(VERSION 3.22.1)
 
 set(input_image ${CMAKE_CURRENT_BINARY_DIR}/BrainProtonDensitySlice.png)
 set(output_image Output.png)
-set(test_options 5 0.125 3.0)
+set(
+  test_options
+  5
+  0.125
+  3.0
+)
 
 project(ComputeCurvatureAnisotropicDiffusion)
 
@@ -10,37 +15,45 @@ find_package(ITK REQUIRED)
 itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(
+  ${PROJECT_NAME}
   PRIVATE
     ITK::ITKImageIO
     ITK::ITKAnisotropicSmoothingModule
     ITK::ITKImageIntensityModule
 )
 
-install(TARGETS ${PROJECT_NAME}
+install(
+  TARGETS
+    ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/AnisotropicSmoothing
   COMPONENT Runtime
-  )
+)
 
-install(FILES Code.cxx CMakeLists.txt Code.py
-  DESTINATION share/ITKSphinxExamples/Code/Filtering/AnisotropicSmoothing/ComputeCurvatureAnisotropicDiffusion
+install(
+  FILES
+    Code.cxx
+    CMakeLists.txt
+    Code.py
+  DESTINATION
+    share/ITKSphinxExamples/Code/Filtering/AnisotropicSmoothing/ComputeCurvatureAnisotropicDiffusion
   COMPONENT Code
 )
 
 enable_testing()
-add_test(NAME ComputeCurvatureAnisotropicDiffusionTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
-  ${input_image}
-  ${output_image}
-  ${test_options}
+add_test(
+  NAME ComputeCurvatureAnisotropicDiffusionTest
+  COMMAND
+    ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME} ${input_image}
+    ${output_image} ${test_options}
 )
 
 if(ITK_WRAP_PYTHON)
   string(REPLACE . "Python." output_image "${output_image}")
-  add_test(NAME ComputeCurvatureAnisotropicDiffusionTestPython
-    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/Code.py
-      ${input_image}
-      ${output_image}
-      ${test_options}
-    )
+  add_test(
+    NAME ComputeCurvatureAnisotropicDiffusionTestPython
+    COMMAND
+      ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/Code.py ${input_image}
+      ${output_image} ${test_options}
+  )
 endif()

--- a/src/GPU/CMakeLists.txt
+++ b/src/GPU/CMakeLists.txt
@@ -1,1 +1,2 @@
-
+# No examples in this category yet; this file exists because
+# src/CMakeLists.txt calls add_subdirectory(GPU).


### PR DESCRIPTION
`pre-commit run --all-files` has never converged on this repo: two hooks disagree about `src/External/CMakeLists.txt` and `src/GPU/CMakeLists.txt`, each of which contains only a newline. Giving both files a comment explaining why they exist resolves it, and unblocks the `gersemi` hook that has been unreachable since it was added.

<details>
<summary>The deadlock</summary>

Both directories hold an `index.rst` but no examples yet, so their `CMakeLists.txt` is empty. `src/CMakeLists.txt` still calls `add_subdirectory(External)` and `add_subdirectory(GPU)`, so the files cannot be deleted — CMake requires them.

On a degenerate zero-content file the two hooks want opposite things:

| Hook | Wants |
|---|---|
| `gersemi` | at least a newline (1 byte) |
| `end-of-file-fixer` | no trailing blank line (0 bytes) |

Each run flips the file back, so `--all-files` reports a failure forever. Any real content breaks the tie, and a comment is the useful kind of content.

Verified locally: run 1 applies the changes, runs 2 and 3 are fully clean.

</details>

<details>
<summary>Second commit: why one file was drifted, and why the style matches ITK</summary>

`gersemi` was onboarded in `1f457f72` (2026-06-16). `ComputeCurvatureAnisotropicDiffusion/CMakeLists.txt` last changed in `f5f72685` (2026-06-12) — four days earlier, so it predates the hook.

It stayed drifted because this config sets `fail_fast: true` and `end-of-file-fixer` runs *before* `gersemi`. The deadlock above failed EOF on every run, so **`gersemi` has never executed repo-wide since the day it was added**. Fixing the empty files is what makes the formatter reachable; this reformat is the backlog that falls out.

The reformat is not a new or local style. This repo and ITK `main` pin the same `gersemi` **0.19.3** with the same `.gersemi.config` (indent 2, `line_length` 80, `list_expansion: favour-expansion`). Checked against ITK's own config directly:

```
$ gersemi --config <ITK-main>/.gersemi.config --check \
    src/Filtering/AnisotropicSmoothing/ComputeCurvatureAnisotropicDiffusion/CMakeLists.txt
# no-op
```

Same result for the two commented `CMakeLists.txt`. ITK's config additionally sets `definitions: ["CMake/stubs"]`, which teaches gersemi about ITK-specific commands; this file uses only `set`, `target_link_libraries`, `install` and `add_test`, which is why the check is a no-op regardless.

</details>

Split out of #476 (ITK 6.0 `LevelSetNode` container fix), which was blocked behind this gate.

<!--
provenance: claude-code session 2026-09-02
hook_pins_vs_itk_main: gersemi 0.19.3 =, pre-commit-hooks v5.0.0 =,
  clang-format v19.1.7 =, pyupgrade v3.21.2 = (args py310 vs py311),
  black 25.12.0 here vs 24.2.0 in ITK (this repo is ahead)
root_cause: fail_fast:true + end-of-file-fixer ordered before gersemi
-->
