### PR TITLE
COMP: Keep GeodesicActiveContour example working on ITK 5.4 and 6.0

### DIFF
--- a/src/External/CMakeLists.txt
+++ b/src/External/CMakeLists.txt
@@ -1,1 +1,2 @@
-
+# No examples in this category yet; this file exists because
+# src/CMakeLists.txt calls add_subdirectory(External).

--- a/src/Filtering/AnisotropicSmoothing/ComputeCurvatureAnisotropicDiffusion/CMakeLists.txt
+++ b/src/Filtering/AnisotropicSmoothing/ComputeCurvatureAnisotropicDiffusion/CMakeLists.txt
@@ -2,7 +2,12 @@ cmake_minimum_required(VERSION 3.22.1)
 
 set(input_image ${CMAKE_CURRENT_BINARY_DIR}/BrainProtonDensitySlice.png)
 set(output_image Output.png)
-set(test_options 5 0.125 3.0)
+set(
+  test_options
+  5
+  0.125
+  3.0
+)
 
 project(ComputeCurvatureAnisotropicDiffusion)
 
@@ -10,37 +15,45 @@ find_package(ITK REQUIRED)
 itk_generate_factory_registration()
 
 add_executable(${PROJECT_NAME} Code.cxx)
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(
+  ${PROJECT_NAME}
   PRIVATE
     ITK::ITKImageIO
     ITK::ITKAnisotropicSmoothingModule
     ITK::ITKImageIntensityModule
 )
 
-install(TARGETS ${PROJECT_NAME}
+install(
+  TARGETS
+    ${PROJECT_NAME}
   DESTINATION bin/ITKSphinxExamples/Filtering/AnisotropicSmoothing
   COMPONENT Runtime
-  )
+)
 
-install(FILES Code.cxx CMakeLists.txt Code.py
-  DESTINATION share/ITKSphinxExamples/Code/Filtering/AnisotropicSmoothing/ComputeCurvatureAnisotropicDiffusion
+install(
+  FILES
+    Code.cxx
+    CMakeLists.txt
+    Code.py
+  DESTINATION
+    share/ITKSphinxExamples/Code/Filtering/AnisotropicSmoothing/ComputeCurvatureAnisotropicDiffusion
   COMPONENT Code
 )
 
 enable_testing()
-add_test(NAME ComputeCurvatureAnisotropicDiffusionTest
-  COMMAND ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}
-  ${input_image}
-  ${output_image}
-  ${test_options}
+add_test(
+  NAME ComputeCurvatureAnisotropicDiffusionTest
+  COMMAND
+    ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME} ${input_image}
+    ${output_image} ${test_options}
 )
 
 if(ITK_WRAP_PYTHON)
   string(REPLACE . "Python." output_image "${output_image}")
-  add_test(NAME ComputeCurvatureAnisotropicDiffusionTestPython
-    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/Code.py
-      ${input_image}
-      ${output_image}
-      ${test_options}
-    )
+  add_test(
+    NAME ComputeCurvatureAnisotropicDiffusionTestPython
+    COMMAND
+      ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/Code.py ${input_image}
+      ${output_image} ${test_options}
+  )
 endif()

--- a/src/GPU/CMakeLists.txt
+++ b/src/GPU/CMakeLists.txt
@@ -1,1 +1,2 @@
-
+# No examples in this category yet; this file exists because
+# src/CMakeLists.txt calls add_subdirectory(GPU).

--- a/src/Segmentation/LevelSets/SegmentWithGeodesicActiveContourLevelSet/Code.py
+++ b/src/Segmentation/LevelSets/SegmentWithGeodesicActiveContourLevelSet/Code.py
@@ -99,11 +99,17 @@ seedPosition = itk.Index[Dimension]()
 seedPosition[0] = args.seed_x
 seedPosition[1] = args.seed_y
 
-node = itk.LevelSetNode[InputPixelType, Dimension]()
+NodeType = itk.LevelSetNode[InputPixelType, Dimension]
+
+node = NodeType()
 node.SetValue(seedValue)
 node.SetIndex(seedPosition)
 
-seeds = itk.VectorContainer[itk.UI, itk.LevelSetNode[InputPixelType, Dimension]].New()
+try:
+    NodeContainer = itk.VectorContainer[itk.IT, NodeType]  # ITK >= 6.0
+except TypeError:
+    NodeContainer = itk.VectorContainer[itk.UI, NodeType]  # ITK <= 5.4
+seeds = NodeContainer.New()
 seeds.Initialize()
 seeds.InsertElement(0, node)
 


### PR DESCRIPTION
`SegmentWithGeodesicActiveContourLevelSet/Code.py` hard-codes `itk.VectorContainer[itk.UI, LevelSetNode]`, which ITK 6.0 no longer wraps after InsightSoftwareConsortium/ITK#6803. Selecting the index type at runtime keeps the example working on both 5.4 and 6.0.

> Stacked on #475 — that PR fixes an unrelated `pre-commit` deadlock that blocks `--all-files` on `main`. Review only the second commit here; this becomes a one-commit PR once #475 merges.

<details>
<summary>Why a single spelling cannot cover both</summary>

ITK#6803 changes `LevelSetTypeDefault::NodeContainer` from `VectorContainer<unsigned int, NodeType>` to the one-argument `VectorContainer<NodeType>`, whose index type is `SizeValueType`, and updates `ITKFastMarchingBase.wrap` accordingly.

The wrapping registry is keyed by the mangled name emitted by that one `itk_wrap_template` call, so the two spellings are strictly disjoint across the version boundary — there is no release where both resolve:

| ITK | `itk.VectorContainer[itk.UI, LevelSetNode]` | `itk.VectorContainer[itk.IT, LevelSetNode]` |
|---|---|---|
| 5.4.x | resolves | `TemplateTypeError` |
| 6.0 | `TemplateTypeError` | resolves |

Confirmed empirically against ITK 5.4.6, and `ITKFastMarchingBase.wrap` is byte-identical at `v5.4.7`, `release-5.4` and `main`-before-#6803. `itk.TemplateTypeError` subclasses `TypeError`, which is what the guard catches.

</details>

<details>
<summary>Test</summary>

Ran the example end to end against ITK 5.4.6 on `BrainProtonDensitySlice.png` (the `except` branch, which ITK's own CI cannot reach): exit 0, 171 iterations, RMS change 0.0198, output written.

`NodeType` is also hoisted so the template is spelled once rather than twice.

</details>

<!--
provenance: claude-code session 2026-09-02
upstream_pr: InsightSoftwareConsortium/ITK#6803
file: src/Segmentation/LevelSets/SegmentWithGeodesicActiveContourLevelSet/Code.py:102-111
stacked_on: InsightSoftwareConsortium/ITKSphinxExamples#475
forest_note: SphinxExamples sits in DEFERRED_TARGETS in itk_forest_build_testbed
  bin/run-matrix.sh, so this break was never scored; the matrix is also
  artifact-scored, which would not catch a runtime TemplateTypeError anyway.
post_merge_action: rebase onto main once #475 lands, drop the stacking note
-->
