### PR TITLE
COMP: Link ITK::ITKVtkGlueModule in examples that include QuickView.h

### DIFF
--- a/src/Core/Common/DisplayImage/CMakeLists.txt
+++ b/src/Core/Common/DisplayImage/CMakeLists.txt
@@ -24,6 +24,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKImageIO
       ITK::ITKCommonModule
       ITK::ITKImageIntensityModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Core/Common/IterateLineThroughImage/CMakeLists.txt
+++ b/src/Core/Common/IterateLineThroughImage/CMakeLists.txt
@@ -23,6 +23,7 @@ if(ENABLE_QUICKVIEW)
     PRIVATE
       ITK::ITKImageIO
       ITK::ITKCommonModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Core/Common/IterateRegionWithAccessToIndexWithWriteAccess/CMakeLists.txt
+++ b/src/Core/Common/IterateRegionWithAccessToIndexWithWriteAccess/CMakeLists.txt
@@ -24,6 +24,7 @@ if(ENABLE_QUICKVIEW)
     PRIVATE
       ITK::ITKImageIO
       ITK::ITKCommonModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Core/Common/IterateRegionWithAccessToIndexWithoutWriteAccess/CMakeLists.txt
+++ b/src/Core/Common/IterateRegionWithAccessToIndexWithoutWriteAccess/CMakeLists.txt
@@ -23,6 +23,7 @@ if(ENABLE_QUICKVIEW)
     PRIVATE
       ITK::ITKImageIO
       ITK::ITKCommonModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Core/Common/MultiThreadOilPainting/CMakeLists.txt
+++ b/src/Core/Common/MultiThreadOilPainting/CMakeLists.txt
@@ -23,6 +23,7 @@ if(ENABLE_QUICKVIEW)
     PRIVATE
       ITK::ITKImageIO
       ITK::ITKCommonModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Core/SpatialObjects/ContourSpatialObject/CMakeLists.txt
+++ b/src/Core/SpatialObjects/ContourSpatialObject/CMakeLists.txt
@@ -23,6 +23,7 @@ if(ENABLE_QUICKVIEW)
     PRIVATE
       ITK::ITKImageIO
       ITK::ITKSpatialObjectsModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Core/Transform/GlobalRegistrationTwoImagesBSpline/CMakeLists.txt
+++ b/src/Core/Transform/GlobalRegistrationTwoImagesBSpline/CMakeLists.txt
@@ -29,6 +29,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKRegistrationCommonModule
       ITK::ITKSpatialObjectsModule
       ITK::ITKTransformModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/AnisotropicSmoothing/SmoothImageWhilePreservingEdges/CMakeLists.txt
+++ b/src/Filtering/AnisotropicSmoothing/SmoothImageWhilePreservingEdges/CMakeLists.txt
@@ -26,6 +26,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKCommonModule
       ITK::ITKImageAdaptorsModule
       ITK::ITKImageFilterBaseModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/AnisotropicSmoothing/SmoothImageWhilePreservingEdges2/CMakeLists.txt
+++ b/src/Filtering/AnisotropicSmoothing/SmoothImageWhilePreservingEdges2/CMakeLists.txt
@@ -26,6 +26,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKCommonModule
       ITK::ITKImageAdaptorsModule
       ITK::ITKImageFilterBaseModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/BinaryMathematicalMorphology/ClosingBinaryImage/CMakeLists.txt
+++ b/src/Filtering/BinaryMathematicalMorphology/ClosingBinaryImage/CMakeLists.txt
@@ -26,6 +26,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKCommonModule
       ITK::ITKImageIntensityModule
       ITK::ITKMathematicalMorphologyModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/BinaryMathematicalMorphology/OpeningBinaryImage/CMakeLists.txt
+++ b/src/Filtering/BinaryMathematicalMorphology/OpeningBinaryImage/CMakeLists.txt
@@ -26,6 +26,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKCommonModule
       ITK::ITKImageIntensityModule
       ITK::ITKMathematicalMorphologyModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/BinaryMathematicalMorphology/PruneBinaryImage/CMakeLists.txt
+++ b/src/Filtering/BinaryMathematicalMorphology/PruneBinaryImage/CMakeLists.txt
@@ -25,6 +25,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKBinaryMathematicalMorphologyModule
       ITK::ITKCommonModule
       ITK::ITKMathematicalMorphologyModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/Convolution/ColorNormalizedCorrelation/CMakeLists.txt
+++ b/src/Filtering/Convolution/ColorNormalizedCorrelation/CMakeLists.txt
@@ -11,6 +11,7 @@ target_link_libraries(
   PRIVATE
     ITK::ITKImageIO
     ITK::ITKCommonModule
+    ITK::ITKVtkGlueModule
     ITK::ITKConvolutionModule
     ITK::ITKImageGridModule
     ITK::ITKImageIntensityModule

--- a/src/Filtering/Convolution/ConvolveImageWithKernel/CMakeLists.txt
+++ b/src/Filtering/Convolution/ConvolveImageWithKernel/CMakeLists.txt
@@ -25,6 +25,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKImageIO
       ITK::ITKCommonModule
       ITK::ITKConvolutionModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/Convolution/NormalizedCorrelation/CMakeLists.txt
+++ b/src/Filtering/Convolution/NormalizedCorrelation/CMakeLists.txt
@@ -11,6 +11,7 @@ target_link_libraries(
   PRIVATE
     ITK::ITKImageIO
     ITK::ITKCommonModule
+    ITK::ITKVtkGlueModule
     ITK::ITKConvolutionModule
     ITK::ITKImageGridModule
     ITK::ITKImageIntensityModule

--- a/src/Filtering/CurvatureFlow/BinaryMinMaxCurvatureFlow/CMakeLists.txt
+++ b/src/Filtering/CurvatureFlow/BinaryMinMaxCurvatureFlow/CMakeLists.txt
@@ -25,6 +25,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKCommonModule
       ITK::ITKCurvatureFlowModule
       ITK::ITKImageIntensityModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/CurvatureFlow/SmoothImageUsingCurvatureFlow/CMakeLists.txt
+++ b/src/Filtering/CurvatureFlow/SmoothImageUsingCurvatureFlow/CMakeLists.txt
@@ -26,6 +26,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKCurvatureFlowModule
       ITK::ITKImageFilterBaseModule
       ITK::ITKImageIntensityModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/CurvatureFlow/SmoothImageUsingMinMaxCurvatureFlow/CMakeLists.txt
+++ b/src/Filtering/CurvatureFlow/SmoothImageUsingMinMaxCurvatureFlow/CMakeLists.txt
@@ -26,6 +26,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKCurvatureFlowModule
       ITK::ITKImageFilterBaseModule
       ITK::ITKImageIntensityModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/CurvatureFlow/SmoothRGBImageUsingCurvatureFlow/CMakeLists.txt
+++ b/src/Filtering/CurvatureFlow/SmoothRGBImageUsingCurvatureFlow/CMakeLists.txt
@@ -26,6 +26,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKCurvatureFlowModule
       ITK::ITKImageAdaptorsModule
       ITK::ITKImageComposeModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/CurvatureFlow/SmoothRGBImageUsingMinMaxCurvatureFlow/CMakeLists.txt
+++ b/src/Filtering/CurvatureFlow/SmoothRGBImageUsingMinMaxCurvatureFlow/CMakeLists.txt
@@ -26,6 +26,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKCurvatureFlowModule
       ITK::ITKImageAdaptorsModule
       ITK::ITKImageComposeModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/DistanceMap/ApproxDistanceMapOfBinary/CMakeLists.txt
+++ b/src/Filtering/DistanceMap/ApproxDistanceMapOfBinary/CMakeLists.txt
@@ -24,6 +24,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKImageIO
       ITK::ITKCommonModule
       ITK::ITKDistanceMapModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/DistanceMap/MaurerDistanceMapOfBinary/CMakeLists.txt
+++ b/src/Filtering/DistanceMap/MaurerDistanceMapOfBinary/CMakeLists.txt
@@ -25,6 +25,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKImageIO
       ITK::ITKCommonModule
       ITK::ITKDistanceMapModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/DistanceMap/MeanDistanceBetweenAllPointsOnTwoCurves/CMakeLists.txt
+++ b/src/Filtering/DistanceMap/MeanDistanceBetweenAllPointsOnTwoCurves/CMakeLists.txt
@@ -23,6 +23,7 @@ if(ENABLE_QUICKVIEW)
     PRIVATE
       ITK::ITKCommonModule
       ITK::ITKDistanceMapModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/DistanceMap/SignedDistanceMapOfBinary/CMakeLists.txt
+++ b/src/Filtering/DistanceMap/SignedDistanceMapOfBinary/CMakeLists.txt
@@ -25,6 +25,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKImageIO
       ITK::ITKCommonModule
       ITK::ITKDistanceMapModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/ImageFeature/ApplyAFilterToASpecifiedRegionOfAnImage/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/ApplyAFilterToASpecifiedRegionOfAnImage/CMakeLists.txt
@@ -25,6 +25,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKImageIO
       ITK::ITKCommonModule
       ITK::ITKImageFeatureModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/ImageFeature/BilateralFilterAnImage/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/BilateralFilterAnImage/CMakeLists.txt
@@ -26,6 +26,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKCommonModule
       ITK::ITKImageFeatureModule
       ITK::ITKImageIntensityModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/ImageFeature/FindZeroCrossingsInSignedImage/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/FindZeroCrossingsInSignedImage/CMakeLists.txt
@@ -24,6 +24,7 @@ if(ENABLE_QUICKVIEW)
     PRIVATE
       ITK::ITKImageIO
       ITK::ITKImageFeatureModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/ImageFeature/SharpenImage/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/SharpenImage/CMakeLists.txt
@@ -11,6 +11,7 @@ target_link_libraries(
   PRIVATE
     ITK::ITKImageIO
     ITK::ITKCommonModule
+    ITK::ITKVtkGlueModule
     ITK::ITKImageFeatureModule
     ITK::ITKImageIntensityModule
 )

--- a/src/Filtering/ImageFeature/ZeroCrossingBasedEdgeDecor/CMakeLists.txt
+++ b/src/Filtering/ImageFeature/ZeroCrossingBasedEdgeDecor/CMakeLists.txt
@@ -25,6 +25,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKImageIO
       ITK::ITKCommonModule
       ITK::ITKImageFeatureModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/ImageGrid/CropImageBySpecifyingRegion2/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/CropImageBySpecifyingRegion2/CMakeLists.txt
@@ -25,6 +25,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKImageIO
       ITK::ITKCommonModule
       ITK::ITKImageGridModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/ImageGrid/RunImageFilterOnRegionOfImage/CMakeLists.txt
+++ b/src/Filtering/ImageGrid/RunImageFilterOnRegionOfImage/CMakeLists.txt
@@ -27,6 +27,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKImageGridModule
       ITK::ITKImageIntensityModule
       ITK::ITKSmoothingModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/ImageIntensity/AbsValueOfImage/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/AbsValueOfImage/CMakeLists.txt
@@ -25,6 +25,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKImageIO
       ITK::ITKCommonModule
       ITK::ITKImageIntensityModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/ImageIntensity/InvertImage/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/InvertImage/CMakeLists.txt
@@ -25,6 +25,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKImageIO
       ITK::ITKCommonModule
       ITK::ITKImageIntensityModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/ImageIntensity/MaskImage/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/MaskImage/CMakeLists.txt
@@ -25,6 +25,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKImageIO
       ITK::ITKCommonModule
       ITK::ITKImageIntensityModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/ImageIntensity/NormalizeImage/CMakeLists.txt
+++ b/src/Filtering/ImageIntensity/NormalizeImage/CMakeLists.txt
@@ -26,6 +26,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKCommonModule
       ITK::ITKImageIntensityModule
       ITK::ITKImageStatisticsModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/ImageLabel/ExtractBoundariesOfConnectedRegionsInBinaryImage/CMakeLists.txt
+++ b/src/Filtering/ImageLabel/ExtractBoundariesOfConnectedRegionsInBinaryImage/CMakeLists.txt
@@ -23,6 +23,7 @@ if(ENABLE_QUICKVIEW)
     PRIVATE
       ITK::ITKCommonModule
       ITK::ITKImageLabelModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/ImageLabel/ExtractInnerAndOuterBoundariesOfBlobsInBinaryImage/CMakeLists.txt
+++ b/src/Filtering/ImageLabel/ExtractInnerAndOuterBoundariesOfBlobsInBinaryImage/CMakeLists.txt
@@ -24,6 +24,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKCommonModule
       ITK::ITKImageIntensityModule
       ITK::ITKImageLabelModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/ImageLabel/LabelContoursOfConnectComponent/CMakeLists.txt
+++ b/src/Filtering/ImageLabel/LabelContoursOfConnectComponent/CMakeLists.txt
@@ -27,6 +27,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKCommonModule
       ITK::ITKConnectedComponentsModule
       ITK::ITKImageLabelModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/MathematicalMorphology/ErodeBinaryImageUsingFlatStruct/CMakeLists.txt
+++ b/src/Filtering/MathematicalMorphology/ErodeBinaryImageUsingFlatStruct/CMakeLists.txt
@@ -25,6 +25,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKImageIO
       ITK::ITKBinaryMathematicalMorphologyModule
       ITK::ITKMathematicalMorphologyModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/Smoothing/FindHigherDerivativesOfImage/CMakeLists.txt
+++ b/src/Filtering/Smoothing/FindHigherDerivativesOfImage/CMakeLists.txt
@@ -26,6 +26,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKCommonModule
       ITK::ITKImageIntensityModule
       ITK::ITKSmoothingModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/Smoothing/SmoothImageWithDiscreteGaussianFilter/CMakeLists.txt
+++ b/src/Filtering/Smoothing/SmoothImageWithDiscreteGaussianFilter/CMakeLists.txt
@@ -25,6 +25,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKImageIO
       ITK::ITKCommonModule
       ITK::ITKSmoothingModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/Thresholding/DemonstrateThresholdAlgorithms/CMakeLists.txt
+++ b/src/Filtering/Thresholding/DemonstrateThresholdAlgorithms/CMakeLists.txt
@@ -24,6 +24,7 @@ if(ENABLE_QUICKVIEW)
     PRIVATE
       ITK::ITKImageIO
       ITK::ITKThresholdingModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Filtering/Thresholding/SeparateGroundUsingOtsu/CMakeLists.txt
+++ b/src/Filtering/Thresholding/SeparateGroundUsingOtsu/CMakeLists.txt
@@ -25,6 +25,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKImageIO
       ITK::ITKCommonModule
       ITK::ITKThresholdingModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Nonunit/Review/GeometricPropertiesOfRegion/CMakeLists.txt
+++ b/src/Nonunit/Review/GeometricPropertiesOfRegion/CMakeLists.txt
@@ -27,6 +27,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKImageFusionModule
       ITK::ITKLabelMapModule
       ITK::ITKImageStatisticsModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Segmentation/ConnectedComponents/AssignContiguousLabelsToConnectedRegions/CMakeLists.txt
+++ b/src/Segmentation/ConnectedComponents/AssignContiguousLabelsToConnectedRegions/CMakeLists.txt
@@ -24,6 +24,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKColormapModule
       ITK::ITKCommonModule
       ITK::ITKConnectedComponentsModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Segmentation/ConnectedComponents/ExtraLargestConnectComponentFromBinaryImage/CMakeLists.txt
+++ b/src/Segmentation/ConnectedComponents/ExtraLargestConnectComponentFromBinaryImage/CMakeLists.txt
@@ -27,6 +27,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKConnectedComponentsModule
       ITK::ITKImageIntensityModule
       ITK::ITKLabelMapModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Segmentation/ConnectedComponents/LabelConnectComponentsInBinaryImage/CMakeLists.txt
+++ b/src/Segmentation/ConnectedComponents/LabelConnectComponentsInBinaryImage/CMakeLists.txt
@@ -10,6 +10,7 @@ target_link_libraries(
   ${PROJECT_NAME}
   PRIVATE
     ITK::ITKImageIO
+    ITK::ITKVtkGlueModule
     ITK::ITKConnectedComponentsModule
     ITK::ITKImageFusionModule
     ITK::ITKThresholdingModule

--- a/src/Segmentation/ConnectedComponents/LabelConnectComponentsInGrayscaleImage/CMakeLists.txt
+++ b/src/Segmentation/ConnectedComponents/LabelConnectComponentsInGrayscaleImage/CMakeLists.txt
@@ -27,6 +27,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKConnectedComponentsModule
       ITK::ITKImageFusionModule
       ITK::ITKImageStatisticsModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 

--- a/src/Segmentation/RegionGrowing/SegmentPixelsWithSimilarStats/CMakeLists.txt
+++ b/src/Segmentation/RegionGrowing/SegmentPixelsWithSimilarStats/CMakeLists.txt
@@ -25,6 +25,7 @@ if(ENABLE_QUICKVIEW)
       ITK::ITKImageIO
       ITK::ITKCommonModule
       ITK::ITKRegionGrowingModule
+      ITK::ITKVtkGlueModule
       ${VTK_LIBRARIES}
   )
 


### PR DESCRIPTION
Forty-nine of the fifty examples that `#include "QuickView.h"` never linked `ITK::ITKVtkGlueModule`, the module that provides that header, so the build fails with `fatal error: 'QuickView.h' file not found` whenever VTK is present. One line added per example; no other changes.

<details>
<summary>Why this is not visible in a normal build</summary>

`src/CMakeLists.txt` sets `ENABLE_QUICKVIEW` and `add_definitions(-DENABLE_QUICKVIEW)` only when VTK is found. Every affected `Code.cxx` guards the include:

```cpp
#ifdef ENABLE_QUICKVIEW
#  include "QuickView.h"
#endif
```

Without VTK the include is compiled out and the missing link is harmless. With VTK the include fires, but because the target never links `ITK::ITKVtkGlueModule`, that module's include directory is absent from the compile line:

```
Code.cxx:23:12: fatal error: 'QuickView.h' file not found
   23 | #include "QuickView.h"
      |          ^~~~~~~~~~~~~
```

`Bridge/VtkGlue/VTKImageToITKImage` was the single example already linking the module, and supplied the spelling used throughout this change.

</details>

<details>
<summary>Shape of the change</summary>

Pure insertions — 49 files, one identical line each, nothing removed:

- 45 examples have a guarded `if(ENABLE_QUICKVIEW)` link block; the entry is added beside `${VTK_LIBRARIES}`.
- 4 examples link unconditionally; the entry is added to that single block.

`pre-commit run --all-files` passes, `gersemi` included, so the additions match the project's CMake formatting.

</details>

<details>
<summary>How it was found and verified</summary>

Surfaced by a downstream build testbed that builds ITKSphinxExamples against a locally built ITK with VTK available, so `ENABLE_QUICKVIEW` is on. Before the change the build stopped in `src/Core/Common/IterateLineThroughImage` and two sibling examples; after it, the suite configures and builds through to its test phase.

Verified against ITK `main` with `Module_ITKVtkGlue=ON`.

</details>

<!--
provenance: claude-code session 2026-09-07, itk_forest_build_testbed
detection: src/**/Code.cxx containing QuickView.h, whose CMakeLists.txt lacked ITKVtkGlue
reference_example: src/Bridge/VtkGlue/VTKImageToITKImage/CMakeLists.txt
variants: 45 guarded (6-space indent, beside ${VTK_LIBRARIES}); 4 unconditional (4-space indent)
related: ITK module-dependency gaps found in the same sweep (BoneMorphometry,
         TextureFeatures missing ITKIOImageBase; IOMeshMZ3 ITKZLIB PRIVATE_DEPENDS
         vs public header) -- separate repo, not part of this PR
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5zzoU6yyUwdLEvjM2s6iS
