### PR TITLE
BUG: Replace distutils.version with a standard-library comparison

### DIFF
--- a/src/Bridge/VtkGlue/ConvertAnRGBitkImageTovtkImageData/Code.py
+++ b/src/Bridge/VtkGlue/ConvertAnRGBitkImageTovtkImageData/Code.py
@@ -18,9 +18,7 @@ import sys
 import itk
 import argparse
 
-from distutils.version import StrictVersion
-
-if StrictVersion(itk.Version.GetITKVersion()) < StrictVersion("5.2.0"):
+if tuple(int(v) for v in itk.Version.GetITKVersion().split(".")) < (5, 2, 0):
     print("ITK 5.2.0 is required.")
     sys.exit(1)
 

--- a/src/Bridge/VtkGlue/ConvertAnitkImageTovtkImageData/Code.py
+++ b/src/Bridge/VtkGlue/ConvertAnitkImageTovtkImageData/Code.py
@@ -18,9 +18,7 @@ import sys
 import itk
 import argparse
 
-from distutils.version import StrictVersion
-
-if StrictVersion(itk.Version.GetITKVersion()) < StrictVersion("5.2.0"):
+if tuple(int(v) for v in itk.Version.GetITKVersion().split(".")) < (5, 2, 0):
     print("ITK 5.2.0 is required.")
     sys.exit(1)
 

--- a/src/Core/Common/AddOffsetToIndex/Code.py
+++ b/src/Core/Common/AddOffsetToIndex/Code.py
@@ -17,9 +17,7 @@
 import sys
 import itk
 
-from distutils.version import StrictVersion as VS
-
-if VS(itk.Version.GetITKVersion()) < VS("4.9.0"):
+if tuple(int(v) for v in itk.Version.GetITKVersion().split(".")) < (4, 9, 0):
     print("ITK 4.9.0 is required.")
     sys.exit(1)
 

--- a/src/Core/Common/StreamAPipeline/Code.py
+++ b/src/Core/Common/StreamAPipeline/Code.py
@@ -18,9 +18,7 @@ import sys
 import itk
 import argparse
 
-from distutils.version import StrictVersion as VS
-
-if VS(itk.Version.GetITKVersion()) < VS("4.10.0"):
+if tuple(int(v) for v in itk.Version.GetITKVersion().split(".")) < (4, 10, 0):
     print("ITK 4.10.0 is required.")
     sys.exit(1)
 

--- a/src/Filtering/Colormap/CreateACustomColormap/Code.py
+++ b/src/Filtering/Colormap/CreateACustomColormap/Code.py
@@ -18,9 +18,7 @@ import sys
 import itk
 import argparse
 
-from distutils.version import StrictVersion as VS
-
-if VS(itk.Version.GetITKVersion()) < VS("4.8.0"):
+if tuple(int(v) for v in itk.Version.GetITKVersion().split(".")) < (4, 8, 0):
     print("ITK 4.8.0 is required (see example documentation).")
     sys.exit(1)
 

--- a/src/Filtering/ImageFeature/SegmentBloodVessels/Code.py
+++ b/src/Filtering/ImageFeature/SegmentBloodVessels/Code.py
@@ -16,10 +16,10 @@
 
 import argparse
 
+import sys
 import itk
-from distutils.version import StrictVersion as VS
 
-if VS(itk.Version.GetITKVersion()) < VS("5.0.0"):
+if tuple(int(v) for v in itk.Version.GetITKVersion().split(".")) < (5, 0, 0):
     print("ITK 5.0.0 or newer is required.")
     sys.exit(1)
 

--- a/src/Filtering/ImageGradient/ApplyGradientRecursiveGaussian/Code.py
+++ b/src/Filtering/ImageGradient/ApplyGradientRecursiveGaussian/Code.py
@@ -18,9 +18,7 @@ import sys
 import itk
 import argparse
 
-from distutils.version import StrictVersion as VS
-
-if VS(itk.Version.GetITKVersion()) < VS("4.7.0"):
+if tuple(int(v) for v in itk.Version.GetITKVersion().split(".")) < (4, 7, 0):
     print("ITK 4.7.0 is required (see example documentation).")
     sys.exit(1)
 

--- a/src/Filtering/ImageGradient/ApplyGradientRecursiveGaussianWithVectorInput/Code.py
+++ b/src/Filtering/ImageGradient/ApplyGradientRecursiveGaussianWithVectorInput/Code.py
@@ -18,9 +18,7 @@ import sys
 import itk
 import argparse
 
-from distutils.version import StrictVersion as VS
-
-if VS(itk.Version.GetITKVersion()) < VS("4.8.0"):
+if tuple(int(v) for v in itk.Version.GetITKVersion().split(".")) < (4, 8, 0):
     print("ITK 4.8.0 is required (see example documentation).")
     sys.exit(1)
 

--- a/src/Nonunit/Review/SegmentBloodVesselsWithMultiScaleHessianBasedMeasure/Code.py
+++ b/src/Nonunit/Review/SegmentBloodVesselsWithMultiScaleHessianBasedMeasure/Code.py
@@ -16,10 +16,10 @@
 
 import argparse
 
+import sys
 import itk
-from distutils.version import StrictVersion as VS
 
-if VS(itk.Version.GetITKVersion()) < VS("5.0.0"):
+if tuple(int(v) for v in itk.Version.GetITKVersion().split(".")) < (5, 0, 0):
     print("ITK 5.0.0 or newer is required.")
     sys.exit(1)
 

--- a/src/Registration/Common/Perform2DTranslationRegistrationWithMeanSquares/Code.py
+++ b/src/Registration/Common/Perform2DTranslationRegistrationWithMeanSquares/Code.py
@@ -18,9 +18,7 @@ import sys
 import itk
 import argparse
 
-from distutils.version import StrictVersion as VS
-
-if VS(itk.Version.GetITKVersion()) < VS("4.9.0"):
+if tuple(int(v) for v in itk.Version.GetITKVersion().split(".")) < (4, 9, 0):
     print("ITK 4.9.0 is required.")
     sys.exit(1)
 


### PR DESCRIPTION
Python 3.12 removed `distutils`, which ten examples imported to check ITK's
version. Compare the dotted components as a tuple instead, dropping the
import entirely.

<details>
<summary>The failure</summary>

Every affected example guards its minimum ITK version like this:

```python
from distutils.version import StrictVersion as VS

if VS(itk.Version.GetITKVersion()) < VS("4.9.0"):
    print("ITK 4.9.0 is required.")
    sys.exit(1)
```

On Python 3.12 and newer the import raises before the example runs:

```
Traceback (most recent call last):
ModuleNotFoundError: No module named 'distutils'
```

The replacement keeps each example's own minimum and drops the import:

```python
if tuple(int(v) for v in itk.Version.GetITKVersion().split(".")) < (4, 9, 0):
```

</details>

<details>
<summary>Also fixed: a latent NameError in the same guard</summary>

`SegmentBloodVessels` and `SegmentBloodVesselsWithMultiScaleHessianBasedMeasure` call `sys.exit()` in that block without importing `sys`, so on an older ITK they would raise `NameError` instead of printing the message. Both now import it.

</details>

<details>
<summary>Verification</summary>

Built against ITK `main` with Python 3.14.6 and run through the project's own ctest Python suite:

| | before | after |
|---|---|---|
| Python tests failing | 10 | 2 |

All eight `distutils` casualties pass. The two remaining failures are unrelated to this change and were failing beforehand: `ConvolveImageWithKernelTestPython` needs `matplotlib`, which is absent from that environment, and `ComputeFFTInOneDimensionPhaseBaselineComparisonPython` fails a baseline image comparison (`ImageError 25.13`, 4 pixels).

`pre-commit run --all-files` passes, and no `distutils` reference remains in the repository.

</details>

<!--
provenance: claude-code session 2026-09-12, itk_forest_build_testbed
detection: src/**/Code.py importing distutils.version.StrictVersion (10 files)
minimums preserved: 4.7.0, 4.8.0 (x2), 4.9.0 (x2), 4.10.0, 5.0.0 (x2), 5.2.0 (x2)
extra fix: missing "import sys" in the two SegmentBloodVessels examples
verified: ctest -R Python, 169 tests, 10 failures -> 2 (both pre-existing, unrelated)
related: this is a standalone prerequisite; separate work requires ITK 6 and converts
         examples to find_package(ITK COMPONENTS ...) with ${ITK_INTERFACE_LIBRARIES}
-->
